### PR TITLE
Parallel: add monetization attribution domain

### DIFF
--- a/functions/src/monetizationDomain.js
+++ b/functions/src/monetizationDomain.js
@@ -1,0 +1,120 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+const ALLOWED_MODELS = new Set(["CPL", "CPA", "REVENUE_SHARE", "DIRECT"]);
+const ALLOWED_CLICK_STATUS = new Set(["CREATED", "REDIRECTED", "CONVERTED", "EXPIRED"]);
+const ALLOWED_CONVERSION_STATUS = new Set(["PENDING", "CONFIRMED", "REJECTED", "REVERSED"]);
+
+function requiredString(value, field, maxLength = 200) {
+  if (typeof value !== "string") throw new TypeError(`${field} must be a string`);
+  const normalized = value.trim();
+  if (!normalized) throw new TypeError(`${field} is required`);
+  if (normalized.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return normalized;
+}
+
+function nonNegativeMoney(value, field) {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount < 0) throw new TypeError(`${field} must be non-negative`);
+  return Math.round(amount * 100) / 100;
+}
+
+function createClickId({ uid, offerId, opportunityId, nonce }) {
+  const payload = [
+    requiredString(uid, "uid", 160),
+    requiredString(offerId, "offerId", 160),
+    requiredString(opportunityId, "opportunityId", 160),
+    requiredString(nonce, "nonce", 160),
+  ].join(":");
+  return crypto.createHash("sha256").update(payload).digest("hex");
+}
+
+function normalizePartnerOffer(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("offer must be an object");
+  }
+  const monetizationModel = requiredString(input.monetizationModel, "monetizationModel", 40);
+  if (!ALLOWED_MODELS.has(monetizationModel)) throw new TypeError("monetizationModel is unsupported");
+
+  const exactLandingUrl = requiredString(input.exactLandingUrl, "exactLandingUrl", 2048);
+  let url;
+  try {
+    url = new URL(exactLandingUrl);
+  } catch {
+    throw new TypeError("exactLandingUrl is invalid");
+  }
+  if (url.protocol !== "https:") throw new TypeError("exactLandingUrl must use https");
+
+  return {
+    offerId: requiredString(input.offerId, "offerId", 160),
+    partnerId: requiredString(input.partnerId, "partnerId", 160),
+    providerName: requiredString(input.providerName, "providerName", 160),
+    planName: requiredString(input.planName, "planName", 240),
+    category: requiredString(input.category, "category", 80),
+    exactLandingUrl: url.toString(),
+    monetizationModel,
+    commissionValue: nonNegativeMoney(input.commissionValue || 0, "commissionValue"),
+    commissionRate: Number(input.commissionRate || 0),
+    currency: requiredString(input.currency || "ILS", "currency", 8).toUpperCase(),
+    active: input.active === true,
+  };
+}
+
+function calculateCommission({ offer, conversionValue = 0 }) {
+  const normalized = normalizePartnerOffer(offer);
+  if (!normalized.active) return 0;
+
+  switch (normalized.monetizationModel) {
+    case "CPL":
+    case "CPA":
+    case "DIRECT":
+      return normalized.commissionValue;
+    case "REVENUE_SHARE": {
+      const rate = Number(normalized.commissionRate);
+      if (!Number.isFinite(rate) || rate < 0 || rate > 1) {
+        throw new TypeError("commissionRate must be between 0 and 1");
+      }
+      return Math.round(nonNegativeMoney(conversionValue, "conversionValue") * rate * 100) / 100;
+    }
+    default:
+      throw new TypeError("monetizationModel is unsupported");
+  }
+}
+
+function normalizeAttributionEvent(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("attribution event must be an object");
+  }
+  const type = requiredString(input.type, "type", 30);
+  if (type === "CLICK") {
+    const status = requiredString(input.status || "CREATED", "status", 30);
+    if (!ALLOWED_CLICK_STATUS.has(status)) throw new TypeError("click status is unsupported");
+  } else if (type === "CONVERSION") {
+    const status = requiredString(input.status || "PENDING", "status", 30);
+    if (!ALLOWED_CONVERSION_STATUS.has(status)) throw new TypeError("conversion status is unsupported");
+  } else {
+    throw new TypeError("attribution event type is unsupported");
+  }
+
+  return {
+    type,
+    clickId: requiredString(input.clickId, "clickId", 128),
+    offerId: requiredString(input.offerId, "offerId", 160),
+    partnerId: requiredString(input.partnerId, "partnerId", 160),
+    opportunityId: requiredString(input.opportunityId, "opportunityId", 160),
+    status: requiredString(input.status, "status", 30),
+    occurredAt: requiredString(input.occurredAt, "occurredAt", 64),
+    conversionValue: nonNegativeMoney(input.conversionValue || 0, "conversionValue"),
+  };
+}
+
+module.exports = {
+  ALLOWED_MODELS,
+  ALLOWED_CLICK_STATUS,
+  ALLOWED_CONVERSION_STATUS,
+  createClickId,
+  normalizePartnerOffer,
+  calculateCommission,
+  normalizeAttributionEvent,
+};

--- a/functions/test/monetizationDomain.test.js
+++ b/functions/test/monetizationDomain.test.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  createClickId,
+  normalizePartnerOffer,
+  calculateCommission,
+  normalizeAttributionEvent,
+} = require("../src/monetizationDomain");
+
+function offer(overrides = {}) {
+  return {
+    offerId: "offer-1",
+    partnerId: "partner-1",
+    providerName: "Provider",
+    planName: "Plan A",
+    category: "אינטרנט",
+    exactLandingUrl: "https://provider.example/plan-a",
+    monetizationModel: "CPA",
+    commissionValue: 120,
+    commissionRate: 0,
+    currency: "ILS",
+    active: true,
+    ...overrides,
+  };
+}
+
+test("click ids are deterministic and bound to exact offer plus opportunity", () => {
+  const a = createClickId({ uid: "u1", offerId: "o1", opportunityId: "s1", nonce: "n1" });
+  const b = createClickId({ uid: "u1", offerId: "o1", opportunityId: "s1", nonce: "n1" });
+  const c = createClickId({ uid: "u1", offerId: "o2", opportunityId: "s1", nonce: "n1" });
+  assert.equal(a, b);
+  assert.notEqual(a, c);
+});
+
+test("partner offers require an exact HTTPS landing page", () => {
+  assert.equal(normalizePartnerOffer(offer()).exactLandingUrl, "https://provider.example/plan-a");
+  assert.throws(() => normalizePartnerOffer(offer({ exactLandingUrl: "http://provider.example/plan-a" })), /https/);
+});
+
+test("fixed CPA commission is deterministic", () => {
+  assert.equal(calculateCommission({ offer: offer(), conversionValue: 999 }), 120);
+});
+
+test("revenue share commission uses confirmed conversion value", () => {
+  assert.equal(calculateCommission({
+    offer: offer({ monetizationModel: "REVENUE_SHARE", commissionValue: 0, commissionRate: 0.15 }),
+    conversionValue: 1000,
+  }), 150);
+});
+
+test("inactive offers cannot accrue commission", () => {
+  assert.equal(calculateCommission({ offer: offer({ active: false }), conversionValue: 1000 }), 0);
+});
+
+test("attribution events preserve the click-to-offer-to-opportunity chain", () => {
+  const normalized = normalizeAttributionEvent({
+    type: "CONVERSION",
+    clickId: "click-1",
+    offerId: "offer-1",
+    partnerId: "partner-1",
+    opportunityId: "saving-1",
+    status: "CONFIRMED",
+    occurredAt: "2026-08-08T18:00:00Z",
+    conversionValue: 400,
+  });
+  assert.equal(normalized.clickId, "click-1");
+  assert.equal(normalized.status, "CONFIRMED");
+  assert.equal(normalized.conversionValue, 400);
+});


### PR DESCRIPTION
Archived without merge. This parallel monetization prototype targeted the old foundation branch and is superseded by the current AI-native commerce/attribution core and the isolated provider-commerce workstream. Branch and commits are preserved for selective reference after validated E2E.