### PR TITLE
Parallel: add typed Push navigation contract

### DIFF
--- a/functions/src/pushContract.js
+++ b/functions/src/pushContract.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const ALLOWED_TYPES = new Set(["PUSH_TEST", "NEW_INVOICE", "SAVINGS_OPPORTUNITY"]);
+
+function requiredString(value, field, maxLength = 200) {
+  if (typeof value !== "string") throw new TypeError(`${field} must be a string`);
+  const normalized = value.trim();
+  if (!normalized) throw new TypeError(`${field} is required`);
+  if (normalized.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return normalized;
+}
+
+function normalizePushData(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("push data must be an object");
+  }
+  const type = requiredString(input.type, "type", 40);
+  if (!ALLOWED_TYPES.has(type)) throw new TypeError("push type is unsupported");
+
+  if (type === "PUSH_TEST") {
+    return { type, destination: "DASHBOARD" };
+  }
+
+  if (type === "NEW_INVOICE") {
+    return {
+      type,
+      destination: "INVOICES",
+      invoiceId: requiredString(input.invoiceId, "invoiceId", 200),
+      importedCount: String(Math.max(1, Math.floor(Number(input.importedCount || 1)))),
+    };
+  }
+
+  return {
+    type,
+    destination: "SAVINGS_OPPORTUNITY",
+    opportunityId: requiredString(input.opportunityId, "opportunityId", 160),
+    offerId: requiredString(input.offerId, "offerId", 160),
+  };
+}
+
+module.exports = { ALLOWED_TYPES, normalizePushData };

--- a/functions/test/pushContract.test.js
+++ b/functions/test/pushContract.test.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { normalizePushData } = require("../src/pushContract");
+
+test("test push always routes to dashboard", () => {
+  assert.deepEqual(normalizePushData({ type: "PUSH_TEST" }), {
+    type: "PUSH_TEST",
+    destination: "DASHBOARD",
+  });
+});
+
+test("new invoice push carries exact invoice id", () => {
+  assert.deepEqual(normalizePushData({
+    type: "NEW_INVOICE",
+    invoiceId: "invoice-1",
+    importedCount: 2,
+  }), {
+    type: "NEW_INVOICE",
+    destination: "INVOICES",
+    invoiceId: "invoice-1",
+    importedCount: "2",
+  });
+});
+
+test("savings push carries exact opportunity and offer", () => {
+  assert.deepEqual(normalizePushData({
+    type: "SAVINGS_OPPORTUNITY",
+    opportunityId: "opp-1",
+    offerId: "offer-1",
+  }), {
+    type: "SAVINGS_OPPORTUNITY",
+    destination: "SAVINGS_OPPORTUNITY",
+    opportunityId: "opp-1",
+    offerId: "offer-1",
+  });
+});
+
+test("unsupported push type is rejected", () => {
+  assert.throws(() => normalizePushData({ type: "MAGIC" }), /unsupported/);
+});


### PR DESCRIPTION
Archived without merge. Typed push/navigation work is now being implemented and tested on the queued post-E2E Stream A branch against the locked Core baseline. This old prototype targets the superseded foundation branch; commits remain available for reference.