### PR TITLE
Parallel: add Gmail initial-backfill and reconciliation policy

### DIFF
--- a/functions/src/gmailSyncPolicy.js
+++ b/functions/src/gmailSyncPolicy.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const INITIAL_LOOKBACK = "6m";
+const RECONCILIATION_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+function asMillis(value) {
+  if (value == null) return 0;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value.toMillis === "function") return Number(value.toMillis()) || 0;
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function initialBackfillRequired(connection = {}) {
+  return connection.initialBackfillCompleted !== true;
+}
+
+function reconciliationRequired(connection = {}, now = Date.now()) {
+  if (connection.watchEnabled !== true) return false;
+  if (connection.historyRecoveryRequired === true) return true;
+  const last = asMillis(connection.lastReconciliationAt || connection.lastIncrementalScanAt);
+  if (!last) return true;
+  return Number(now) - last >= RECONCILIATION_INTERVAL_MS;
+}
+
+function nextSyncAction(connection = {}, now = Date.now()) {
+  if (initialBackfillRequired(connection)) {
+    return { type: "INITIAL_BACKFILL", lookback: INITIAL_LOOKBACK };
+  }
+  if (reconciliationRequired(connection, now)) {
+    return { type: "RECONCILE", lookback: "incremental" };
+  }
+  return { type: "NONE", lookback: "" };
+}
+
+function markInitialBackfillCompleteFields() {
+  return {
+    initialBackfillCompleted: true,
+    initialBackfillLookback: INITIAL_LOOKBACK,
+  };
+}
+
+module.exports = {
+  INITIAL_LOOKBACK,
+  RECONCILIATION_INTERVAL_MS,
+  initialBackfillRequired,
+  reconciliationRequired,
+  nextSyncAction,
+  markInitialBackfillCompleteFields,
+};

--- a/functions/test/gmailSyncPolicy.test.js
+++ b/functions/test/gmailSyncPolicy.test.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  INITIAL_LOOKBACK,
+  RECONCILIATION_INTERVAL_MS,
+  initialBackfillRequired,
+  reconciliationRequired,
+  nextSyncAction,
+  markInitialBackfillCompleteFields,
+} = require("../src/gmailSyncPolicy");
+
+test("initial backfill is required exactly until completion is recorded", () => {
+  assert.equal(initialBackfillRequired({}), true);
+  assert.equal(initialBackfillRequired({ initialBackfillCompleted: false }), true);
+  assert.equal(initialBackfillRequired({ initialBackfillCompleted: true }), false);
+});
+
+test("initial sync action always uses six month lookback", () => {
+  assert.deepEqual(nextSyncAction({ initialBackfillCompleted: false }), {
+    type: "INITIAL_BACKFILL",
+    lookback: "6m",
+  });
+  assert.equal(INITIAL_LOOKBACK, "6m");
+});
+
+test("watch-enabled accounts reconcile after four hours", () => {
+  const now = Date.parse("2026-08-08T20:00:00Z");
+  const recent = new Date(now - RECONCILIATION_INTERVAL_MS + 1);
+  const stale = new Date(now - RECONCILIATION_INTERVAL_MS);
+  assert.equal(reconciliationRequired({ watchEnabled: true, lastReconciliationAt: recent }, now), false);
+  assert.equal(reconciliationRequired({ watchEnabled: true, lastReconciliationAt: stale }, now), true);
+});
+
+test("history recovery forces reconciliation immediately", () => {
+  assert.equal(reconciliationRequired({
+    watchEnabled: true,
+    historyRecoveryRequired: true,
+    lastReconciliationAt: new Date(),
+  }), true);
+});
+
+test("completed and fresh account needs no extra scan", () => {
+  const now = Date.now();
+  assert.deepEqual(nextSyncAction({
+    initialBackfillCompleted: true,
+    watchEnabled: true,
+    lastReconciliationAt: new Date(now),
+  }, now), { type: "NONE", lookback: "" });
+});
+
+test("completion marker records six-month backfill permanently", () => {
+  assert.deepEqual(markInitialBackfillCompleteFields(), {
+    initialBackfillCompleted: true,
+    initialBackfillLookback: "6m",
+  });
+});


### PR DESCRIPTION
Archived without merge. Gmail initial-backfill/watch/reconciliation policy is now implemented in the active Core and queued authoritative-sync work. This old prototype targets the superseded foundation baseline; branch/commits remain available for reference.