### PR TITLE
Parallel: add AI-native proactive decision contract

### DIFF
--- a/functions/src/aiNativeDecisionDomain.js
+++ b/functions/src/aiNativeDecisionDomain.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const ACTIONS = Object.freeze({
+  NONE: "NONE",
+  CONNECT_SOURCE: "CONNECT_SOURCE",
+  REVIEW_INVOICE: "REVIEW_INVOICE",
+  SHOW_VERIFIED_SAVINGS: "SHOW_VERIFIED_SAVINGS",
+  ALERT_PRICE_CHANGE: "ALERT_PRICE_CHANGE",
+});
+
+function number(value) {
+  const parsed = Number(value || 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function selectNextAction(input = {}) {
+  const connectedSources = Math.max(0, Math.floor(number(input.connectedSources)));
+  const unverifiedInvoices = Math.max(0, Math.floor(number(input.unverifiedInvoices)));
+  const verifiedSavingsMonthly = Math.max(0, number(input.verifiedSavingsMonthly));
+  const verifiedOpportunityCount = Math.max(0, Math.floor(number(input.verifiedOpportunityCount)));
+  const urgentPriceAlerts = Math.max(0, Math.floor(number(input.urgentPriceAlerts)));
+
+  if (verifiedOpportunityCount > 0 && verifiedSavingsMonthly > 0) {
+    return {
+      action: ACTIONS.SHOW_VERIFIED_SAVINGS,
+      priority: 100,
+      userMessage: `אפשר לחסוך ${Math.round(verifiedSavingsMonthly * 100) / 100} ₪ בחודש`,
+      reason: "verified_savings_available",
+    };
+  }
+
+  if (urgentPriceAlerts > 0) {
+    return {
+      action: ACTIONS.ALERT_PRICE_CHANGE,
+      priority: 90,
+      userMessage: "זיהינו שינוי במחיר שכדאי לבדוק",
+      reason: "urgent_price_change",
+    };
+  }
+
+  if (unverifiedInvoices > 0) {
+    return {
+      action: ACTIONS.REVIEW_INVOICE,
+      priority: 70,
+      userMessage: "יש חשבון חדש בבדיקה",
+      reason: "invoice_requires_verification",
+    };
+  }
+
+  if (connectedSources === 0) {
+    return {
+      action: ACTIONS.CONNECT_SOURCE,
+      priority: 50,
+      userMessage: "חבר מקור מידע כדי שנוכל להתחיל לחפש חיסכון",
+      reason: "no_financial_source_connected",
+    };
+  }
+
+  return {
+    action: ACTIONS.NONE,
+    priority: 0,
+    userMessage: "הכל מעודכן. נעדכן כשנמצא חיסכון חדש.",
+    reason: "nothing_actionable",
+  };
+}
+
+function shouldNotify(decision) {
+  if (!decision || typeof decision !== "object") return false;
+  return decision.action === ACTIONS.SHOW_VERIFIED_SAVINGS ||
+    decision.action === ACTIONS.ALERT_PRICE_CHANGE;
+}
+
+module.exports = { ACTIONS, selectNextAction, shouldNotify };

--- a/functions/test/aiNativeDecisionDomain.test.js
+++ b/functions/test/aiNativeDecisionDomain.test.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { ACTIONS, selectNextAction, shouldNotify } = require("../src/aiNativeDecisionDomain");
+
+test("verified savings outrank every other action", () => {
+  const decision = selectNextAction({
+    connectedSources: 1,
+    unverifiedInvoices: 3,
+    urgentPriceAlerts: 2,
+    verifiedOpportunityCount: 1,
+    verifiedSavingsMonthly: 180,
+  });
+  assert.equal(decision.action, ACTIONS.SHOW_VERIFIED_SAVINGS);
+  assert.equal(decision.priority, 100);
+  assert.match(decision.userMessage, /180/);
+  assert.equal(shouldNotify(decision), true);
+});
+
+test("urgent price change outranks invoice review", () => {
+  const decision = selectNextAction({
+    connectedSources: 1,
+    unverifiedInvoices: 3,
+    urgentPriceAlerts: 1,
+  });
+  assert.equal(decision.action, ACTIONS.ALERT_PRICE_CHANGE);
+  assert.equal(shouldNotify(decision), true);
+});
+
+test("unverified invoice becomes a quiet in-app review action", () => {
+  const decision = selectNextAction({ connectedSources: 1, unverifiedInvoices: 1 });
+  assert.equal(decision.action, ACTIONS.REVIEW_INVOICE);
+  assert.equal(shouldNotify(decision), false);
+});
+
+test("no connected source requests onboarding", () => {
+  const decision = selectNextAction({ connectedSources: 0 });
+  assert.equal(decision.action, ACTIONS.CONNECT_SOURCE);
+});
+
+test("healthy account generates no noisy action", () => {
+  const decision = selectNextAction({ connectedSources: 1 });
+  assert.equal(decision.action, ACTIONS.NONE);
+  assert.equal(shouldNotify(decision), false);
+});


### PR DESCRIPTION
Archived without merge. The proactive AI decision/orchestration layer belongs to queued Stream D only after the first validated staging E2E cycle. This prototype targets the old foundation baseline; branch/commits are preserved for later selective review.