### PR TITLE
Review fixes: harden provider commerce guardrails

### DIFF
--- a/functions/src/providerContractConfig.js
+++ b/functions/src/providerContractConfig.js
@@ -18,6 +18,15 @@ function optional(value, maxLength = 200) {
   return text;
 }
 
+function validateTimestamp(value, field, { optional: allowEmpty = false } = {}) {
+  const text = allowEmpty ? optional(value, 64) : required(value, field, 64);
+  if (!text && allowEmpty) return "";
+  if (!Number.isFinite(Date.parse(text))) {
+    throw new TypeError(`${field} must be a valid timestamp`);
+  }
+  return text;
+}
+
 function normalizeProviderContract(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("provider contract must be an object");
@@ -45,8 +54,8 @@ function normalizeProviderContract(input) {
     throw new TypeError("attributable commercial model requires attributionField");
   }
 
-  const activeFrom = required(input.activeFrom, "activeFrom", 64);
-  const activeUntil = optional(input.activeUntil, 64);
+  const activeFrom = validateTimestamp(input.activeFrom, "activeFrom");
+  const activeUntil = validateTimestamp(input.activeUntil, "activeUntil", { optional: true });
   if (activeUntil && Date.parse(activeUntil) <= Date.parse(activeFrom)) {
     throw new TypeError("activeUntil must be after activeFrom");
   }
@@ -72,7 +81,6 @@ function isContractActive(contractInput, nowMs = Date.now()) {
   if (!contract.enabled) return false;
   const start = Date.parse(contract.activeFrom);
   const end = contract.activeUntil ? Date.parse(contract.activeUntil) : Number.POSITIVE_INFINITY;
-  if (!Number.isFinite(start)) return false;
   return nowMs >= start && nowMs < end;
 }
 

--- a/functions/src/providerDispatchEnvelope.js
+++ b/functions/src/providerDispatchEnvelope.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const crypto = require("node:crypto");
+const { buildProviderDispatchPayload } = require("./providerDispatch");
 
 const QUEUE_STATES = Object.freeze({
   READY: "READY",
@@ -9,6 +10,18 @@ const QUEUE_STATES = Object.freeze({
   RETRY_WAIT: "RETRY_WAIT",
   DEAD_LETTER: "DEAD_LETTER",
 });
+
+const ALLOWED_PROVIDER_PAYLOAD_KEYS = new Set([
+  "leadId",
+  "contactName",
+  "phone",
+  "contactEmail",
+  "requestedProvider",
+  "category",
+  "offerId",
+  "consentVersion",
+  "source",
+]);
 
 function required(value, field, maxLength = 200) {
   const text = typeof value === "string" ? value.trim() : "";
@@ -27,6 +40,32 @@ function dispatchId({ leadId, providerId, offerId, contractId }) {
   return crypto.createHash("sha256").update(material).digest("hex");
 }
 
+function normalizeMinimalProviderPayload(rawPayload, { leadId, offerId }) {
+  if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+    throw new TypeError("payload is required");
+  }
+
+  for (const key of Object.keys(rawPayload)) {
+    if (!ALLOWED_PROVIDER_PAYLOAD_KEYS.has(key)) {
+      throw new TypeError(`provider payload contains unsupported field: ${key}`);
+    }
+  }
+
+  const payload = buildProviderDispatchPayload(rawPayload);
+  if (!payload) throw new TypeError("provider payload is incomplete");
+  if (payload.leadId !== leadId) {
+    throw new TypeError("provider payload leadId does not match dispatch leadId");
+  }
+  if (payload.offerId !== offerId) {
+    throw new TypeError("provider payload offerId does not match dispatch offerId");
+  }
+  if (rawPayload.source && rawPayload.source !== payload.source) {
+    throw new TypeError("provider payload source is unsupported");
+  }
+
+  return payload;
+}
+
 function buildDispatchEnvelope(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("dispatch input must be an object");
@@ -36,17 +75,7 @@ function buildDispatchEnvelope(input) {
   const offerId = required(input.offerId, "offerId", 128);
   const contractId = required(input.contractId, "contractId", 128);
   const adapterKey = required(input.adapterKey, "adapterKey", 128);
-
-  const payload = input.payload && typeof input.payload === "object" && !Array.isArray(input.payload)
-    ? { ...input.payload }
-    : null;
-  if (!payload) throw new TypeError("payload is required");
-
-  for (const forbidden of ["uid", "gmail", "gmailContent", "currentMonthlyCost", "potentialMonthlySaving", "commissionAmount"]) {
-    if (Object.prototype.hasOwnProperty.call(payload, forbidden)) {
-      throw new TypeError(`provider payload contains forbidden field: ${forbidden}`);
-    }
-  }
+  const payload = normalizeMinimalProviderPayload(input.payload, { leadId, offerId });
 
   return {
     dispatchId: dispatchId({ leadId, providerId, offerId, contractId }),

--- a/functions/src/providerIntegrationFramework.js
+++ b/functions/src/providerIntegrationFramework.js
@@ -22,6 +22,14 @@ function requiredText(value, field, maxLength = 200) {
   return normalized;
 }
 
+function requiredTimestamp(value, field) {
+  const normalized = requiredText(value, field, 64);
+  if (!Number.isFinite(Date.parse(normalized))) {
+    throw new TypeError(`${field} must be a valid timestamp`);
+  }
+  return normalized;
+}
+
 function normalizeProviderConfig(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("provider config must be an object");
@@ -115,11 +123,11 @@ function normalizeLifecycleEvidence(input) {
 
   const providerReference = requiredText(input.providerReference, "providerReference", 200);
   const evidenceSource = requiredText(input.evidenceSource, "evidenceSource", 80);
-  const observedAt = requiredText(input.observedAt, "observedAt", 64);
+  const observedAt = requiredTimestamp(input.observedAt, "observedAt");
 
   const amount = input.amount == null ? null : Number(input.amount);
-  if (stage === "COMMISSION_CONFIRMED" && (!Number.isFinite(amount) || amount < 0)) {
-    throw new TypeError("commission confirmation requires a non-negative amount");
+  if (stage === "COMMISSION_CONFIRMED" && (!Number.isFinite(amount) || amount <= 0)) {
+    throw new TypeError("commission confirmation requires a positive amount");
   }
 
   return {

--- a/functions/src/providerReconciliation.js
+++ b/functions/src/providerReconciliation.js
@@ -20,6 +20,15 @@ function money(value, field) {
   return Math.round(amount * 100) / 100;
 }
 
+function normalizeEvidenceTimestamp(value) {
+  if (value == null || value === "") return "";
+  const normalized = String(value).trim().slice(0, 64);
+  if (!Number.isFinite(Date.parse(normalized))) {
+    throw new TypeError("evidenceObservedAt must be a valid timestamp");
+  }
+  return normalized;
+}
+
 function normalizeCommissionRecord(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("commission record must be an object");
@@ -40,9 +49,7 @@ function normalizeCommissionRecord(input) {
     evidenceSource: typeof input.evidenceSource === "string"
       ? input.evidenceSource.trim().slice(0, 80)
       : "",
-    evidenceObservedAt: typeof input.evidenceObservedAt === "string"
-      ? input.evidenceObservedAt.trim().slice(0, 64)
-      : "",
+    evidenceObservedAt: normalizeEvidenceTimestamp(input.evidenceObservedAt),
   };
 
   if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID, COMMISSION_STATES.REJECTED].includes(state)) {
@@ -50,8 +57,10 @@ function normalizeCommissionRecord(input) {
       throw new TypeError("resolved commission state requires provider evidence");
     }
   }
-  if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID].includes(state) && record.confirmedAmount == null) {
-    throw new TypeError("confirmed or paid commission requires confirmedAmount");
+  if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID].includes(state)) {
+    if (record.confirmedAmount == null || record.confirmedAmount <= 0) {
+      throw new TypeError("confirmed or paid commission requires a positive confirmedAmount");
+    }
   }
   return record;
 }

--- a/functions/test/providerContractConfig.test.js
+++ b/functions/test/providerContractConfig.test.js
@@ -44,6 +44,12 @@ test("non-direct commercial models require attribution field", () => {
   assert.throws(() => normalizeProviderContract(contract({ attributionField: "" })), /attributionField/);
 });
 
+test("contract active window requires valid timestamps in chronological order", () => {
+  assert.throws(() => normalizeProviderContract(contract({ activeFrom: "not-a-date" })), /activeFrom must be a valid timestamp/);
+  assert.throws(() => normalizeProviderContract(contract({ activeUntil: "not-a-date" })), /activeUntil must be a valid timestamp/);
+  assert.throws(() => normalizeProviderContract(contract({ activeUntil: "2026-07-31T23:59:59Z" })), /after activeFrom/);
+});
+
 test("contract activity is deterministic and independent of commission amount", () => {
   const midAugust = Date.parse("2026-08-15T12:00:00Z");
   assert.equal(isContractActive(contract(), midAugust), true);

--- a/functions/test/providerDispatchEnvelope.test.js
+++ b/functions/test/providerDispatchEnvelope.test.js
@@ -26,6 +26,7 @@ function input(overrides = {}) {
       requestedProvider: "Provider A",
       category: "אינטרנט",
       offerId: "offer-1",
+      consentVersion: "v1",
     },
     ...overrides,
   };
@@ -38,18 +39,46 @@ test("dispatch identity is deterministic for the same lead/provider/offer/contra
   assert.equal(first.length, 64);
 });
 
-test("dispatch envelope starts READY with zero attempts", () => {
+test("dispatch envelope starts READY with zero attempts and normalized minimal payload", () => {
   const envelope = buildDispatchEnvelope(input());
   assert.equal(envelope.state, QUEUE_STATES.READY);
   assert.equal(envelope.attempt, 0);
+  assert.deepEqual(envelope.payload, {
+    leadId: "lead-1",
+    contactName: "Test User",
+    phone: "0501234567",
+    contactEmail: "test@example.com",
+    requestedProvider: "Provider A",
+    category: "אינטרנט",
+    offerId: "offer-1",
+    consentVersion: "v1",
+    source: "CLICKANDSAVE_VERIFIED_OPPORTUNITY",
+  });
 });
 
-test("provider payload rejects internal financial and identity context", () => {
-  for (const forbidden of ["uid", "gmailContent", "currentMonthlyCost", "potentialMonthlySaving", "commissionAmount"]) {
+test("provider payload rejects every field outside the minimum-data allowlist", () => {
+  for (const forbidden of ["uid", "gmailContent", "currentMonthlyCost", "potentialMonthlySaving", "commissionAmount", "metadata"]) {
+    const value = forbidden === "metadata" ? { gmailContent: "private" } : "private";
     assert.throws(() => buildDispatchEnvelope(input({
-      payload: { ...input().payload, [forbidden]: "private" },
-    })), /forbidden field/);
+      payload: { ...input().payload, [forbidden]: value },
+    })), /unsupported field/);
   }
+});
+
+test("provider payload identifiers must match the dispatch envelope", () => {
+  assert.throws(() => buildDispatchEnvelope(input({
+    payload: { ...input().payload, leadId: "other-lead" },
+  })), /leadId does not match/);
+
+  assert.throws(() => buildDispatchEnvelope(input({
+    payload: { ...input().payload, offerId: "other-offer" },
+  })), /offerId does not match/);
+});
+
+test("provider payload cannot override the verified source marker", () => {
+  assert.throws(() => buildDispatchEnvelope(input({
+    payload: { ...input().payload, source: "MANUAL" },
+  })), /source is unsupported/);
 });
 
 test("attempt transitions READY to IN_FLIGHT and increments exactly once", () => {

--- a/functions/test/providerIntegrationFramework.test.js
+++ b/functions/test/providerIntegrationFramework.test.js
@@ -86,13 +86,30 @@ test("provider lifecycle advancement requires attributable external evidence", (
   assert.equal(evidence.evidenceSource, "PROVIDER_POSTBACK");
 });
 
-test("commission confirmation requires explicit amount evidence", () => {
+test("lifecycle evidence requires a valid observedAt timestamp", () => {
+  assert.throws(() => normalizeLifecycleEvidence({
+    stage: "ACTIVATED",
+    providerReference: "activation-789",
+    evidenceSource: "PROVIDER_POSTBACK",
+    observedAt: "not-a-timestamp",
+  }), /valid timestamp/);
+});
+
+test("commission confirmation requires explicit positive amount evidence", () => {
   assert.throws(() => normalizeLifecycleEvidence({
     stage: "COMMISSION_CONFIRMED",
     providerReference: "commission-1",
     evidenceSource: "PROVIDER_REPORT",
     observedAt: "2026-08-08T19:00:00Z",
-  }), /amount/);
+  }), /positive amount/);
+
+  assert.throws(() => normalizeLifecycleEvidence({
+    stage: "COMMISSION_CONFIRMED",
+    providerReference: "commission-1",
+    evidenceSource: "PROVIDER_REPORT",
+    observedAt: "2026-08-08T19:00:00Z",
+    amount: 0,
+  }), /positive amount/);
 
   const evidence = normalizeLifecycleEvidence({
     stage: "COMMISSION_CONFIRMED",

--- a/functions/test/providerReconciliation.test.js
+++ b/functions/test/providerReconciliation.test.js
@@ -27,7 +27,7 @@ test("expected commission does not require fabricated provider evidence", () => 
   assert.equal(record.confirmedAmount, null);
 });
 
-test("confirmed commission requires provider evidence and confirmed amount", () => {
+test("confirmed commission requires provider evidence and positive confirmed amount", () => {
   assert.throws(() => normalizeCommissionRecord(expected({
     state: COMMISSION_STATES.CONFIRMED,
   })), /evidence/);
@@ -36,7 +36,22 @@ test("confirmed commission requires provider evidence and confirmed amount", () 
     state: COMMISSION_STATES.CONFIRMED,
     evidenceSource: "PARTNER_REPORT",
     evidenceObservedAt: "2026-08-08T20:00:00Z",
-  })), /confirmedAmount/);
+  })), /positive confirmedAmount/);
+
+  assert.throws(() => normalizeCommissionRecord(expected({
+    state: COMMISSION_STATES.CONFIRMED,
+    confirmedAmount: 0,
+    evidenceSource: "PARTNER_REPORT",
+    evidenceObservedAt: "2026-08-08T20:00:00Z",
+  })), /positive confirmedAmount/);
+});
+
+test("resolved commission evidence requires a valid timestamp", () => {
+  assert.throws(() => normalizeCommissionRecord(expected({
+    state: COMMISSION_STATES.REJECTED,
+    evidenceSource: "PARTNER_REPORT",
+    evidenceObservedAt: "not-a-timestamp",
+  })), /valid timestamp/);
 });
 
 test("reconciliation upgrades expected commission only from explicit evidence", () => {


### PR DESCRIPTION
Coordinator review fixes for Stream C only.

This PR targets `agent/provider-commerce-integrations` and does not touch Stream A/Core directly.

Fixes:
- `COMMISSION_CONFIRMED` lifecycle evidence now requires a positive amount, matching Core semantics
- confirmed/paid reconciliation amounts must be positive
- lifecycle and reconciliation evidence timestamps must be parseable timestamps
- provider contract active windows validate timestamps before comparison
- provider dispatch envelope now reuses Core `buildProviderDispatchPayload()` and rejects every payload key outside the minimum-data allowlist
- dispatch payload lead/offer attribution must match the envelope
- verified source marker cannot be overridden
- regression tests cover zero commission rejection, invalid timestamps, nested/extra provider payload context, and attribution mismatch

No ranking, Gmail, Financial Context, Savings calculations or Android contracts are changed.