### PR TITLE
Stream C v2: provider commerce integration and settlement safeguards

### DIFF
--- a/functions/src/providerAdapterHealthScore.js
+++ b/functions/src/providerAdapterHealthScore.js
@@ -1,0 +1,29 @@
+"use strict";
+
+function clamp01(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(1, Math.max(0, n));
+}
+
+function calculateAdapterHealthScore(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError("adapter health input must be an object");
+
+  const successRate = clamp01(input.successRate);
+  const ackWithinSlaRate = clamp01(input.ackWithinSlaRate);
+  const freshnessRate = clamp01(input.freshnessRate);
+  const deadLetterRate = clamp01(input.deadLetterRate);
+  const authFailureRate = clamp01(input.authFailureRate);
+
+  const raw = (successRate * 0.4) + (ackWithinSlaRate * 0.25) + (freshnessRate * 0.2) + ((1 - deadLetterRate) * 0.1) + ((1 - authFailureRate) * 0.05);
+  const score = Math.round(raw * 10000) / 100;
+
+  return {
+    score,
+    state: score >= 90 ? "HEALTHY" : score >= 75 ? "WARNING" : score >= 50 ? "DEGRADED" : "CRITICAL",
+  };
+}
+
+module.exports = {
+  calculateAdapterHealthScore,
+};

--- a/functions/src/providerAdapterRegistry.js
+++ b/functions/src/providerAdapterRegistry.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const CAPABILITIES = Object.freeze({
+  DISPATCH: "DISPATCH",
+  STATUS_LOOKUP: "STATUS_LOOKUP",
+  CONVERSION_IMPORT: "CONVERSION_IMPORT",
+  COMMISSION_RECONCILIATION: "COMMISSION_RECONCILIATION",
+});
+
+const SUPPORTED_CAPABILITIES = new Set(Object.values(CAPABILITIES));
+
+function requiredText(value, field, maxLength = 160) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function normalizeCapabilities(input) {
+  if (!Array.isArray(input)) throw new TypeError("capabilities must be an array");
+  const unique = [];
+  const seen = new Set();
+  for (const raw of input) {
+    const capability = requiredText(raw, "capability", 64).toUpperCase();
+    if (!SUPPORTED_CAPABILITIES.has(capability)) {
+      throw new TypeError(`unsupported adapter capability: ${capability}`);
+    }
+    if (!seen.has(capability)) {
+      seen.add(capability);
+      unique.push(capability);
+    }
+  }
+  return unique.sort();
+}
+
+function normalizeAdapterDescriptor(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("adapter descriptor must be an object");
+  }
+
+  const implemented = input.implemented === true;
+  const capabilities = normalizeCapabilities(input.capabilities || []);
+  if (!implemented && capabilities.length > 0) {
+    throw new TypeError("unimplemented adapter cannot declare capabilities");
+  }
+
+  return {
+    adapterKey: requiredText(input.adapterKey, "adapterKey", 128),
+    providerId: requiredText(input.providerId, "providerId", 128),
+    version: requiredText(input.version || "1", "version", 32),
+    implemented,
+    capabilities,
+  };
+}
+
+function createAdapterRegistry(descriptors) {
+  if (!Array.isArray(descriptors)) throw new TypeError("adapter descriptors must be an array");
+  const registry = new Map();
+  for (const descriptorInput of descriptors) {
+    const descriptor = normalizeAdapterDescriptor(descriptorInput);
+    if (registry.has(descriptor.adapterKey)) {
+      throw new TypeError(`duplicate adapterKey: ${descriptor.adapterKey}`);
+    }
+    registry.set(descriptor.adapterKey, Object.freeze(descriptor));
+  }
+  return registry;
+}
+
+function getAdapterDescriptor(registry, adapterKey) {
+  if (!(registry instanceof Map)) throw new TypeError("adapter registry must be a Map");
+  const key = requiredText(adapterKey, "adapterKey", 128);
+  return registry.get(key) || null;
+}
+
+function assertAdapterCapability(registry, adapterKey, capabilityInput) {
+  const descriptor = getAdapterDescriptor(registry, adapterKey);
+  if (!descriptor || descriptor.implemented !== true) {
+    throw new Error("provider adapter is not implemented");
+  }
+  const capability = requiredText(capabilityInput, "capability", 64).toUpperCase();
+  if (!SUPPORTED_CAPABILITIES.has(capability)) {
+    throw new TypeError(`unsupported adapter capability: ${capability}`);
+  }
+  if (!descriptor.capabilities.includes(capability)) {
+    throw new Error(`provider adapter does not support capability: ${capability}`);
+  }
+  return descriptor;
+}
+
+module.exports = {
+  CAPABILITIES,
+  normalizeCapabilities,
+  normalizeAdapterDescriptor,
+  createAdapterRegistry,
+  getAdapterDescriptor,
+  assertAdapterCapability,
+};

--- a/functions/src/providerCircuitBreaker.js
+++ b/functions/src/providerCircuitBreaker.js
@@ -1,0 +1,139 @@
+"use strict";
+
+const CIRCUIT_STATES = Object.freeze({
+  CLOSED: "CLOSED",
+  OPEN: "OPEN",
+  HALF_OPEN: "HALF_OPEN",
+});
+
+const DEFAULT_FAILURE_THRESHOLD = 5;
+const DEFAULT_RECOVERY_TIMEOUT_MS = 60_000;
+const MAX_RECOVERY_TIMEOUT_MS = 6 * 60 * 60 * 1000;
+
+function integer(value, field, { min = 0, max = Number.MAX_SAFE_INTEGER, fallback } = {}) {
+  const raw = value == null && fallback != null ? fallback : Number(value);
+  if (!Number.isInteger(raw) || raw < min || raw > max) {
+    throw new TypeError(`${field} must be an integer between ${min} and ${max}`);
+  }
+  return raw;
+}
+
+function normalizeCircuitState(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("circuit state must be an object");
+  }
+
+  const state = input.state || CIRCUIT_STATES.CLOSED;
+  if (!Object.values(CIRCUIT_STATES).includes(state)) {
+    throw new TypeError(`unsupported circuit state: ${state}`);
+  }
+
+  const failureThreshold = integer(input.failureThreshold, "failureThreshold", {
+    min: 1,
+    max: 100,
+    fallback: DEFAULT_FAILURE_THRESHOLD,
+  });
+  const recoveryTimeoutMs = integer(input.recoveryTimeoutMs, "recoveryTimeoutMs", {
+    min: 1_000,
+    max: MAX_RECOVERY_TIMEOUT_MS,
+    fallback: DEFAULT_RECOVERY_TIMEOUT_MS,
+  });
+  const consecutiveFailures = integer(input.consecutiveFailures, "consecutiveFailures", {
+    min: 0,
+    max: 1_000_000,
+    fallback: 0,
+  });
+  const openedAtMs = input.openedAtMs == null ? null : Number(input.openedAtMs);
+  if (openedAtMs != null && !Number.isFinite(openedAtMs)) {
+    throw new TypeError("openedAtMs must be a finite timestamp");
+  }
+
+  if (state === CIRCUIT_STATES.OPEN && openedAtMs == null) {
+    throw new TypeError("OPEN circuit requires openedAtMs");
+  }
+
+  return {
+    state,
+    failureThreshold,
+    recoveryTimeoutMs,
+    consecutiveFailures,
+    openedAtMs,
+    probeInFlight: input.probeInFlight === true,
+  };
+}
+
+function evaluateCircuit(input = {}, nowMs = Date.now()) {
+  const circuit = normalizeCircuitState(input);
+  const now = Number(nowMs);
+  if (!Number.isFinite(now)) throw new TypeError("nowMs must be finite");
+
+  if (circuit.state === CIRCUIT_STATES.CLOSED) {
+    return { state: CIRCUIT_STATES.CLOSED, allowRequest: true, delayMs: 0, probe: false };
+  }
+
+  if (circuit.state === CIRCUIT_STATES.OPEN) {
+    const elapsed = Math.max(0, now - circuit.openedAtMs);
+    if (elapsed < circuit.recoveryTimeoutMs) {
+      return {
+        state: CIRCUIT_STATES.OPEN,
+        allowRequest: false,
+        delayMs: circuit.recoveryTimeoutMs - elapsed,
+        probe: false,
+      };
+    }
+    return {
+      state: CIRCUIT_STATES.HALF_OPEN,
+      allowRequest: !circuit.probeInFlight,
+      delayMs: 0,
+      probe: !circuit.probeInFlight,
+    };
+  }
+
+  return {
+    state: CIRCUIT_STATES.HALF_OPEN,
+    allowRequest: !circuit.probeInFlight,
+    delayMs: 0,
+    probe: !circuit.probeInFlight,
+  };
+}
+
+function recordCircuitSuccess(input = {}) {
+  const circuit = normalizeCircuitState(input);
+  return {
+    ...circuit,
+    state: CIRCUIT_STATES.CLOSED,
+    consecutiveFailures: 0,
+    openedAtMs: null,
+    probeInFlight: false,
+  };
+}
+
+function recordCircuitFailure(input = {}, nowMs = Date.now()) {
+  const circuit = normalizeCircuitState(input);
+  const now = Number(nowMs);
+  if (!Number.isFinite(now)) throw new TypeError("nowMs must be finite");
+
+  const consecutiveFailures = circuit.consecutiveFailures + 1;
+  const mustOpen = circuit.state === CIRCUIT_STATES.HALF_OPEN ||
+    circuit.state === CIRCUIT_STATES.OPEN ||
+    consecutiveFailures >= circuit.failureThreshold;
+
+  return {
+    ...circuit,
+    state: mustOpen ? CIRCUIT_STATES.OPEN : CIRCUIT_STATES.CLOSED,
+    consecutiveFailures,
+    openedAtMs: mustOpen ? now : null,
+    probeInFlight: false,
+  };
+}
+
+module.exports = {
+  CIRCUIT_STATES,
+  DEFAULT_FAILURE_THRESHOLD,
+  DEFAULT_RECOVERY_TIMEOUT_MS,
+  MAX_RECOVERY_TIMEOUT_MS,
+  normalizeCircuitState,
+  evaluateCircuit,
+  recordCircuitSuccess,
+  recordCircuitFailure,
+};

--- a/functions/src/providerCommissionEvidenceAdapter.js
+++ b/functions/src/providerCommissionEvidenceAdapter.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const {
+  COMMISSION_STATES,
+  normalizeCommissionRecord,
+  reconcileCommission,
+} = require("./providerReconciliation");
+
+function requiredObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value;
+}
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function reconcileCommissionFromProviderEvidence(currentInput, evidenceInput, correlationInput) {
+  const current = normalizeCommissionRecord(currentInput);
+  const evidence = requiredObject(evidenceInput, "commission evidence");
+  const correlation = requiredObject(correlationInput, "evidence correlation");
+
+  if (correlation.matched !== true) {
+    throw new Error("commission evidence must be correlated to an acknowledged dispatch");
+  }
+
+  const kind = requiredText(evidence.kind, "evidence.kind", 40).toUpperCase();
+  if (kind !== "COMMISSION") {
+    throw new TypeError("only COMMISSION provider evidence can confirm commission");
+  }
+
+  const providerReference = requiredText(evidence.providerReference, "evidence.providerReference", 200);
+  if (providerReference !== current.providerReference || providerReference !== correlation.providerReference) {
+    throw new Error("commission evidence provider reference does not match reconciliation identity");
+  }
+
+  const evidenceEventId = requiredText(evidence.evidenceEventId, "evidence.evidenceEventId", 128);
+  if (evidenceEventId !== correlation.evidenceEventId) {
+    throw new Error("commission evidence event does not match correlation evidence event");
+  }
+
+  const amount = Number(evidence.amount);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new TypeError("commission provider evidence requires a positive amount");
+  }
+
+  const currency = requiredText(evidence.currency || "ILS", "evidence.currency", 8).toUpperCase();
+  if (currency !== current.currency) {
+    throw new Error("commission evidence currency does not match expected commission currency");
+  }
+
+  const source = requiredText(evidence.source, "evidence.source", 40).toUpperCase();
+  const observedAt = requiredText(evidence.observedAt, "evidence.observedAt", 64);
+  if (!Number.isFinite(Date.parse(observedAt))) {
+    throw new TypeError("evidence.observedAt must be a valid timestamp");
+  }
+
+  return reconcileCommission(current, {
+    state: COMMISSION_STATES.CONFIRMED,
+    confirmedAmount: Math.round(amount * 100) / 100,
+    evidenceSource: `PROVIDER_${source}`,
+    evidenceObservedAt: observedAt,
+  });
+}
+
+module.exports = {
+  reconcileCommissionFromProviderEvidence,
+};

--- a/functions/src/providerConsentIntentGate.js
+++ b/functions/src/providerConsentIntentGate.js
@@ -1,0 +1,35 @@
+"use strict";
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function verifyProviderDispatchIntent(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("provider dispatch intent must be an object");
+  }
+  const accepted = input.accepted === true;
+  const action = requiredText(input.action, "action", 64).toUpperCase();
+  if (action !== "CONTINUE_TO_OFFER") throw new Error("provider dispatch requires explicit continue-to-offer intent");
+  if (!accepted) throw new Error("provider dispatch requires explicit user acceptance");
+
+  return {
+    accepted: true,
+    action,
+    offerId: requiredText(input.offerId, "offerId", 128),
+    providerId: requiredText(input.providerId, "providerId", 128),
+    consentVersion: requiredText(input.consentVersion, "consentVersion", 50),
+    acceptedAt: (() => {
+      const value = requiredText(input.acceptedAt, "acceptedAt", 64);
+      if (!Number.isFinite(Date.parse(value))) throw new TypeError("acceptedAt must be a valid timestamp");
+      return new Date(Date.parse(value)).toISOString();
+    })(),
+  };
+}
+
+module.exports = {
+  verifyProviderDispatchIntent,
+};

--- a/functions/src/providerContractConfig.js
+++ b/functions/src/providerContractConfig.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const COMMERCIAL_MODELS = new Set(["CPL", "CPA", "REVENUE_SHARE", "DIRECT"]);
+const DELIVERY_MODES = new Set(["API", "CRM", "SFTP_REPORT", "MANUAL_OPERATOR"]);
+const CONVERSION_EVIDENCE_MODES = new Set(["POSTBACK", "WEBHOOK", "REPORT_IMPORT", "MANUAL_VERIFIED"]);
+
+function required(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function optional(value, maxLength = 200) {
+  if (value == null || value === "") return "";
+  const text = String(value).trim();
+  if (text.length > maxLength) throw new TypeError(`value exceeds ${maxLength} characters`);
+  return text;
+}
+
+function normalizeProviderContract(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("provider contract must be an object");
+  }
+
+  const commercialModel = required(input.commercialModel, "commercialModel", 30);
+  const deliveryMode = required(input.deliveryMode, "deliveryMode", 30);
+  const conversionEvidenceMode = required(input.conversionEvidenceMode, "conversionEvidenceMode", 30);
+  if (!COMMERCIAL_MODELS.has(commercialModel)) throw new TypeError("commercialModel is unsupported");
+  if (!DELIVERY_MODES.has(deliveryMode)) throw new TypeError("deliveryMode is unsupported");
+  if (!CONVERSION_EVIDENCE_MODES.has(conversionEvidenceMode)) {
+    throw new TypeError("conversionEvidenceMode is unsupported");
+  }
+
+  const credentialSecretName = optional(input.credentialSecretName, 160);
+  if (["API", "CRM", "SFTP_REPORT"].includes(deliveryMode) && !credentialSecretName) {
+    throw new TypeError("remote delivery mode requires a Secret Manager reference");
+  }
+  if (/sk-|password|secret=|token=/i.test(credentialSecretName)) {
+    throw new TypeError("credentialSecretName must be a secret reference, not credential material");
+  }
+
+  const attributionField = optional(input.attributionField, 80);
+  if (!attributionField && commercialModel !== "DIRECT") {
+    throw new TypeError("attributable commercial model requires attributionField");
+  }
+
+  const activeFrom = required(input.activeFrom, "activeFrom", 64);
+  const activeUntil = optional(input.activeUntil, 64);
+  if (activeUntil && Date.parse(activeUntil) <= Date.parse(activeFrom)) {
+    throw new TypeError("activeUntil must be after activeFrom");
+  }
+
+  return {
+    contractId: required(input.contractId, "contractId", 128),
+    providerId: required(input.providerId, "providerId", 128),
+    commercialModel,
+    deliveryMode,
+    conversionEvidenceMode,
+    adapterKey: required(input.adapterKey, "adapterKey", 128),
+    credentialSecretName,
+    attributionField,
+    campaignId: optional(input.campaignId, 128),
+    activeFrom,
+    activeUntil,
+    enabled: input.enabled === true,
+  };
+}
+
+function isContractActive(contractInput, nowMs = Date.now()) {
+  const contract = normalizeProviderContract(contractInput);
+  if (!contract.enabled) return false;
+  const start = Date.parse(contract.activeFrom);
+  const end = contract.activeUntil ? Date.parse(contract.activeUntil) : Number.POSITIVE_INFINITY;
+  if (!Number.isFinite(start)) return false;
+  return nowMs >= start && nowMs < end;
+}
+
+function buildAttribution(contractInput, clickId) {
+  const contract = normalizeProviderContract(contractInput);
+  const normalizedClickId = required(clickId, "clickId", 160);
+  if (!contract.attributionField) return {};
+  return {
+    [contract.attributionField]: normalizedClickId,
+    ...(contract.campaignId ? { campaignId: contract.campaignId } : {}),
+  };
+}
+
+module.exports = {
+  COMMERCIAL_MODELS,
+  DELIVERY_MODES,
+  CONVERSION_EVIDENCE_MODES,
+  normalizeProviderContract,
+  isContractActive,
+  buildAttribution,
+};

--- a/functions/src/providerContractConfig.js
+++ b/functions/src/providerContractConfig.js
@@ -18,6 +18,15 @@ function optional(value, maxLength = 200) {
   return text;
 }
 
+function validateTimestamp(value, field, { optional: allowEmpty = false } = {}) {
+  const text = allowEmpty ? optional(value, 64) : required(value, field, 64);
+  if (!text && allowEmpty) return "";
+  if (!Number.isFinite(Date.parse(text))) {
+    throw new TypeError(`${field} must be a valid timestamp`);
+  }
+  return text;
+}
+
 function normalizeProviderContract(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("provider contract must be an object");
@@ -45,8 +54,8 @@ function normalizeProviderContract(input) {
     throw new TypeError("attributable commercial model requires attributionField");
   }
 
-  const activeFrom = required(input.activeFrom, "activeFrom", 64);
-  const activeUntil = optional(input.activeUntil, 64);
+  const activeFrom = validateTimestamp(input.activeFrom, "activeFrom");
+  const activeUntil = validateTimestamp(input.activeUntil, "activeUntil", { optional: true });
   if (activeUntil && Date.parse(activeUntil) <= Date.parse(activeFrom)) {
     throw new TypeError("activeUntil must be after activeFrom");
   }
@@ -72,7 +81,6 @@ function isContractActive(contractInput, nowMs = Date.now()) {
   if (!contract.enabled) return false;
   const start = Date.parse(contract.activeFrom);
   const end = contract.activeUntil ? Date.parse(contract.activeUntil) : Number.POSITIVE_INFINITY;
-  if (!Number.isFinite(start)) return false;
   return nowMs >= start && nowMs < end;
 }
 

--- a/functions/src/providerCredentialRotationPolicy.js
+++ b/functions/src/providerCredentialRotationPolicy.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const ROTATION_STATES = Object.freeze({
+  HEALTHY: "HEALTHY",
+  ROTATE_SOON: "ROTATE_SOON",
+  EXPIRED: "EXPIRED",
+  UNCONFIGURED: "UNCONFIGURED",
+});
+
+function evaluateCredentialRotation(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError("credential rotation input must be an object");
+  const expiresAt = typeof input.expiresAt === "string" ? Date.parse(input.expiresAt) : NaN;
+  if (!Number.isFinite(expiresAt)) return { state: ROTATION_STATES.UNCONFIGURED, reason: "credential expiry is not configured" };
+
+  const nowMs = Number.isFinite(Number(input.nowMs)) ? Number(input.nowMs) : Date.now();
+  const rotateBeforeMs = Number.isFinite(Number(input.rotateBeforeMs)) && Number(input.rotateBeforeMs) > 0
+    ? Number(input.rotateBeforeMs)
+    : 7 * 24 * 60 * 60 * 1000;
+  const remainingMs = expiresAt - nowMs;
+
+  if (remainingMs <= 0) return { state: ROTATION_STATES.EXPIRED, reason: "provider credential expired", remainingMs: 0, blocksDispatch: true };
+  if (remainingMs <= rotateBeforeMs) return { state: ROTATION_STATES.ROTATE_SOON, reason: "provider credential rotation window reached", remainingMs, blocksDispatch: false };
+  return { state: ROTATION_STATES.HEALTHY, reason: "provider credential within validity window", remainingMs, blocksDispatch: false };
+}
+
+module.exports = {
+  ROTATION_STATES,
+  evaluateCredentialRotation,
+};

--- a/functions/src/providerDataMinimization.js
+++ b/functions/src/providerDataMinimization.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const ALLOWED_EXTERNAL_FIELDS = Object.freeze([
+  "contactName",
+  "phone",
+  "contactEmail",
+  "requestedProvider",
+  "category",
+  "offerId",
+  "consentVersion",
+  "source",
+]);
+
+const FORBIDDEN_EXTERNAL_FIELDS = new Set([
+  "gmailRaw",
+  "gmailMessageId",
+  "currentSpend",
+  "commission",
+  "commissionAmount",
+  "internalUserId",
+  "firebaseUid",
+  "rankingScore",
+  "aiReasoning",
+]);
+
+function buildMinimizedProviderPayload(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("provider payload input must be an object");
+  }
+  for (const key of Object.keys(input)) {
+    if (FORBIDDEN_EXTERNAL_FIELDS.has(key)) {
+      throw new TypeError(`provider payload contains forbidden internal field: ${key}`);
+    }
+  }
+
+  const output = {};
+  for (const key of ALLOWED_EXTERNAL_FIELDS) {
+    if (input[key] != null && String(input[key]).trim() !== "") output[key] = input[key];
+  }
+
+  for (const field of ["contactName", "phone", "contactEmail", "requestedProvider", "category", "offerId", "consentVersion"]) {
+    if (output[field] == null || String(output[field]).trim() === "") throw new TypeError(`${field} is required`);
+  }
+  output.source = "CLICKANDSAVE_VERIFIED_OPPORTUNITY";
+  return output;
+}
+
+module.exports = {
+  ALLOWED_EXTERNAL_FIELDS,
+  FORBIDDEN_EXTERNAL_FIELDS,
+  buildMinimizedProviderPayload,
+};

--- a/functions/src/providerDispatchEnvelope.js
+++ b/functions/src/providerDispatchEnvelope.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const crypto = require("node:crypto");
+const { buildProviderDispatchPayload } = require("./providerDispatch");
 
 const QUEUE_STATES = Object.freeze({
   READY: "READY",
@@ -9,6 +10,18 @@ const QUEUE_STATES = Object.freeze({
   RETRY_WAIT: "RETRY_WAIT",
   DEAD_LETTER: "DEAD_LETTER",
 });
+
+const ALLOWED_PROVIDER_PAYLOAD_KEYS = new Set([
+  "leadId",
+  "contactName",
+  "phone",
+  "contactEmail",
+  "requestedProvider",
+  "category",
+  "offerId",
+  "consentVersion",
+  "source",
+]);
 
 function required(value, field, maxLength = 200) {
   const text = typeof value === "string" ? value.trim() : "";
@@ -27,6 +40,32 @@ function dispatchId({ leadId, providerId, offerId, contractId }) {
   return crypto.createHash("sha256").update(material).digest("hex");
 }
 
+function normalizeMinimalProviderPayload(rawPayload, { leadId, offerId }) {
+  if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+    throw new TypeError("payload is required");
+  }
+
+  for (const key of Object.keys(rawPayload)) {
+    if (!ALLOWED_PROVIDER_PAYLOAD_KEYS.has(key)) {
+      throw new TypeError(`provider payload contains unsupported field: ${key}`);
+    }
+  }
+
+  const payload = buildProviderDispatchPayload(rawPayload);
+  if (!payload) throw new TypeError("provider payload is incomplete");
+  if (payload.leadId !== leadId) {
+    throw new TypeError("provider payload leadId does not match dispatch leadId");
+  }
+  if (payload.offerId !== offerId) {
+    throw new TypeError("provider payload offerId does not match dispatch offerId");
+  }
+  if (rawPayload.source && rawPayload.source !== payload.source) {
+    throw new TypeError("provider payload source is unsupported");
+  }
+
+  return payload;
+}
+
 function buildDispatchEnvelope(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("dispatch input must be an object");
@@ -36,17 +75,7 @@ function buildDispatchEnvelope(input) {
   const offerId = required(input.offerId, "offerId", 128);
   const contractId = required(input.contractId, "contractId", 128);
   const adapterKey = required(input.adapterKey, "adapterKey", 128);
-
-  const payload = input.payload && typeof input.payload === "object" && !Array.isArray(input.payload)
-    ? { ...input.payload }
-    : null;
-  if (!payload) throw new TypeError("payload is required");
-
-  for (const forbidden of ["uid", "gmail", "gmailContent", "currentMonthlyCost", "potentialMonthlySaving", "commissionAmount"]) {
-    if (Object.prototype.hasOwnProperty.call(payload, forbidden)) {
-      throw new TypeError(`provider payload contains forbidden field: ${forbidden}`);
-    }
-  }
+  const payload = normalizeMinimalProviderPayload(input.payload, { leadId, offerId });
 
   return {
     dispatchId: dispatchId({ leadId, providerId, offerId, contractId }),

--- a/functions/src/providerDispatchEnvelope.js
+++ b/functions/src/providerDispatchEnvelope.js
@@ -1,0 +1,111 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+const QUEUE_STATES = Object.freeze({
+  READY: "READY",
+  IN_FLIGHT: "IN_FLIGHT",
+  ACKNOWLEDGED: "ACKNOWLEDGED",
+  RETRY_WAIT: "RETRY_WAIT",
+  DEAD_LETTER: "DEAD_LETTER",
+});
+
+function required(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function dispatchId({ leadId, providerId, offerId, contractId }) {
+  const material = [
+    required(leadId, "leadId", 128),
+    required(providerId, "providerId", 128),
+    required(offerId, "offerId", 128),
+    required(contractId, "contractId", 128),
+  ].join(":");
+  return crypto.createHash("sha256").update(material).digest("hex");
+}
+
+function buildDispatchEnvelope(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("dispatch input must be an object");
+  }
+  const leadId = required(input.leadId, "leadId", 128);
+  const providerId = required(input.providerId, "providerId", 128);
+  const offerId = required(input.offerId, "offerId", 128);
+  const contractId = required(input.contractId, "contractId", 128);
+  const adapterKey = required(input.adapterKey, "adapterKey", 128);
+
+  const payload = input.payload && typeof input.payload === "object" && !Array.isArray(input.payload)
+    ? { ...input.payload }
+    : null;
+  if (!payload) throw new TypeError("payload is required");
+
+  for (const forbidden of ["uid", "gmail", "gmailContent", "currentMonthlyCost", "potentialMonthlySaving", "commissionAmount"]) {
+    if (Object.prototype.hasOwnProperty.call(payload, forbidden)) {
+      throw new TypeError(`provider payload contains forbidden field: ${forbidden}`);
+    }
+  }
+
+  return {
+    dispatchId: dispatchId({ leadId, providerId, offerId, contractId }),
+    leadId,
+    providerId,
+    offerId,
+    contractId,
+    adapterKey,
+    state: QUEUE_STATES.READY,
+    attempt: 0,
+    payload,
+    providerReference: "",
+    lastErrorCode: "",
+  };
+}
+
+function beginAttempt(envelope) {
+  if (!envelope || envelope.state === QUEUE_STATES.ACKNOWLEDGED || envelope.state === QUEUE_STATES.DEAD_LETTER) {
+    throw new Error("terminal dispatch cannot start another attempt");
+  }
+  if (![QUEUE_STATES.READY, QUEUE_STATES.RETRY_WAIT].includes(envelope.state)) {
+    throw new Error("dispatch is not ready for an attempt");
+  }
+  return {
+    ...envelope,
+    state: QUEUE_STATES.IN_FLIGHT,
+    attempt: Math.max(0, Number(envelope.attempt) || 0) + 1,
+  };
+}
+
+function applyAcknowledgement(envelope, providerReference) {
+  if (!envelope || envelope.state !== QUEUE_STATES.IN_FLIGHT) {
+    throw new Error("only in-flight dispatch can be acknowledged");
+  }
+  return {
+    ...envelope,
+    state: QUEUE_STATES.ACKNOWLEDGED,
+    providerReference: required(providerReference, "providerReference", 200),
+    lastErrorCode: "",
+  };
+}
+
+function applyFailure(envelope, { retryable, errorCode, deadLetter = false }) {
+  if (!envelope || envelope.state !== QUEUE_STATES.IN_FLIGHT) {
+    throw new Error("only in-flight dispatch can fail");
+  }
+  const terminal = deadLetter === true || retryable !== true;
+  return {
+    ...envelope,
+    state: terminal ? QUEUE_STATES.DEAD_LETTER : QUEUE_STATES.RETRY_WAIT,
+    lastErrorCode: required(errorCode, "errorCode", 100),
+  };
+}
+
+module.exports = {
+  QUEUE_STATES,
+  dispatchId,
+  buildDispatchEnvelope,
+  beginAttempt,
+  applyAcknowledgement,
+  applyFailure,
+};

--- a/functions/src/providerDispatchPlanner.js
+++ b/functions/src/providerDispatchPlanner.js
@@ -4,6 +4,8 @@ const { CAPABILITIES, assertAdapterCapability } = require("./providerAdapterRegi
 const { assertDispatchAllowed, nextRetry } = require("./providerIntegrationFramework");
 const { QUEUE_STATES } = require("./providerDispatchEnvelope");
 const { isContractActive } = require("./providerContractConfig");
+const { evaluateCircuit } = require("./providerCircuitBreaker");
+const { RATE_LIMIT_ACTIONS, planRateLimit } = require("./providerRateLimitPlanner");
 
 const PLAN_ACTIONS = Object.freeze({
   DISPATCH: "DISPATCH",
@@ -17,6 +19,52 @@ function requiredObject(value, field) {
     throw new TypeError(`${field} must be an object`);
   }
   return value;
+}
+
+function planResilientDispatch(source, envelope, nowMs) {
+  const circuit = evaluateCircuit(source.circuitState || {}, nowMs);
+  if (!circuit.allowRequest) {
+    return {
+      action: PLAN_ACTIONS.WAIT,
+      reason: "provider circuit breaker is open",
+      dispatchId: envelope.dispatchId,
+      delayMs: circuit.delayMs,
+      circuitState: circuit.state,
+      circuitProbe: false,
+    };
+  }
+
+  const rateLimit = planRateLimit({
+    policy: source.rateLimitPolicy,
+    usage: source.rateLimitUsage,
+    nowMs,
+  });
+  if (rateLimit.action === RATE_LIMIT_ACTIONS.WAIT) {
+    return {
+      action: PLAN_ACTIONS.WAIT,
+      reason: "provider rate limit reached",
+      dispatchId: envelope.dispatchId,
+      delayMs: rateLimit.delayMs,
+      circuitState: circuit.state,
+      circuitProbe: circuit.probe,
+      rateLimitAction: rateLimit.action,
+      rateLimitResetAtMs: rateLimit.resetAtMs,
+    };
+  }
+
+  return {
+    action: PLAN_ACTIONS.DISPATCH,
+    reason: "provider, contract, adapter and resilience gates verified",
+    dispatchId: envelope.dispatchId,
+    circuitState: circuit.state,
+    circuitProbe: circuit.probe,
+    rateLimitAction: rateLimit.action,
+    ...(rateLimit.action === RATE_LIMIT_ACTIONS.ALLOW ? {
+      rateLimitResetAtMs: rateLimit.resetAtMs,
+      remainingRequests: rateLimit.remainingRequests,
+      nextRateLimitUsage: rateLimit.nextUsage,
+    } : {}),
+  };
 }
 
 function planDispatch(input) {
@@ -88,11 +136,7 @@ function planDispatch(input) {
     };
   }
 
-  return {
-    action: PLAN_ACTIONS.DISPATCH,
-    reason: "provider, contract and adapter capability verified",
-    dispatchId: envelope.dispatchId,
-  };
+  return planResilientDispatch(source, envelope, nowMs);
 }
 
 module.exports = {

--- a/functions/src/providerDispatchPlanner.js
+++ b/functions/src/providerDispatchPlanner.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const { CAPABILITIES, assertAdapterCapability } = require("./providerAdapterRegistry");
+const { assertDispatchAllowed, nextRetry } = require("./providerIntegrationFramework");
+const { QUEUE_STATES } = require("./providerDispatchEnvelope");
+const { isContractActive } = require("./providerContractConfig");
+
+const PLAN_ACTIONS = Object.freeze({
+  DISPATCH: "DISPATCH",
+  WAIT: "WAIT",
+  DEAD_LETTER: "DEAD_LETTER",
+  NOOP: "NOOP",
+});
+
+function requiredObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value;
+}
+
+function planDispatch(input) {
+  const source = requiredObject(input, "dispatch planner input");
+  const envelope = requiredObject(source.envelope, "envelope");
+  const providerConfig = assertDispatchAllowed(requiredObject(source.providerConfig, "providerConfig"));
+  const contract = requiredObject(source.contract, "contract");
+  const registry = source.adapterRegistry;
+  const nowMs = Number.isFinite(Number(source.nowMs)) ? Number(source.nowMs) : Date.now();
+
+  if (envelope.providerId !== providerConfig.providerId) {
+    throw new Error("dispatch provider does not match provider config");
+  }
+  if (envelope.adapterKey !== providerConfig.adapterKey) {
+    throw new Error("dispatch adapter does not match provider config");
+  }
+  if (envelope.providerId !== contract.providerId || envelope.contractId !== contract.contractId) {
+    throw new Error("dispatch does not match provider contract");
+  }
+  if (envelope.adapterKey !== contract.adapterKey) {
+    throw new Error("dispatch adapter does not match provider contract");
+  }
+
+  assertAdapterCapability(registry, envelope.adapterKey, CAPABILITIES.DISPATCH);
+
+  if (!isContractActive(contract, nowMs)) {
+    return {
+      action: PLAN_ACTIONS.NOOP,
+      reason: "provider contract is inactive",
+      dispatchId: envelope.dispatchId,
+    };
+  }
+
+  if (envelope.state === QUEUE_STATES.ACKNOWLEDGED || envelope.state === QUEUE_STATES.DEAD_LETTER) {
+    return {
+      action: PLAN_ACTIONS.NOOP,
+      reason: "dispatch is terminal",
+      dispatchId: envelope.dispatchId,
+    };
+  }
+
+  if (envelope.state === QUEUE_STATES.IN_FLIGHT) {
+    return {
+      action: PLAN_ACTIONS.WAIT,
+      reason: "dispatch attempt already in flight",
+      dispatchId: envelope.dispatchId,
+    };
+  }
+
+  if (![QUEUE_STATES.READY, QUEUE_STATES.RETRY_WAIT].includes(envelope.state)) {
+    throw new Error(`unsupported dispatch queue state: ${envelope.state}`);
+  }
+
+  if (envelope.state === QUEUE_STATES.RETRY_WAIT) {
+    const retry = nextRetry(Math.max(1, Number(envelope.attempt) || 1), source.retryAfterMs, source.maxAttempts);
+    if (retry.deadLetter) {
+      return {
+        action: PLAN_ACTIONS.DEAD_LETTER,
+        reason: "retry limit reached",
+        dispatchId: envelope.dispatchId,
+        delayMs: 0,
+      };
+    }
+    return {
+      action: PLAN_ACTIONS.WAIT,
+      reason: "retry backoff required",
+      dispatchId: envelope.dispatchId,
+      delayMs: retry.delayMs,
+    };
+  }
+
+  return {
+    action: PLAN_ACTIONS.DISPATCH,
+    reason: "provider, contract and adapter capability verified",
+    dispatchId: envelope.dispatchId,
+  };
+}
+
+module.exports = {
+  PLAN_ACTIONS,
+  planDispatch,
+};

--- a/functions/src/providerEventAudit.js
+++ b/functions/src/providerEventAudit.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+const AUDIT_EVENT_TYPES = Object.freeze({
+  DISPATCH_PLANNED: "DISPATCH_PLANNED",
+  DISPATCH_ACKNOWLEDGED: "DISPATCH_ACKNOWLEDGED",
+  EVIDENCE_ACCEPTED: "EVIDENCE_ACCEPTED",
+  LIFECYCLE_ADVANCED: "LIFECYCLE_ADVANCED",
+  COMMISSION_CONFIRMED: "COMMISSION_CONFIRMED",
+  SETTLEMENT_MATCHED: "SETTLEMENT_MATCHED",
+  DEAD_LETTERED: "DEAD_LETTERED",
+});
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function normalizeAuditEvent(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("provider audit event must be an object");
+  }
+  const eventType = requiredText(input.eventType, "eventType", 64).toUpperCase();
+  if (!Object.values(AUDIT_EVENT_TYPES).includes(eventType)) throw new TypeError(`unsupported provider audit event: ${eventType}`);
+
+  const occurredAt = requiredText(input.occurredAt, "occurredAt", 64);
+  if (!Number.isFinite(Date.parse(occurredAt))) throw new TypeError("occurredAt must be a valid timestamp");
+
+  const event = {
+    eventType,
+    providerId: requiredText(input.providerId, "providerId", 128),
+    contractId: requiredText(input.contractId, "contractId", 128),
+    subjectId: requiredText(input.subjectId, "subjectId", 200),
+    evidenceId: typeof input.evidenceId === "string" ? input.evidenceId.trim().slice(0, 200) : "",
+    actor: typeof input.actor === "string" && input.actor.trim() ? input.actor.trim().slice(0, 80) : "SYSTEM",
+    occurredAt: new Date(Date.parse(occurredAt)).toISOString(),
+  };
+
+  const fingerprintMaterial = [
+    event.eventType,
+    event.providerId,
+    event.contractId,
+    event.subjectId,
+    event.evidenceId,
+    event.actor,
+    event.occurredAt,
+  ].join(":");
+  event.auditEventId = crypto.createHash("sha256").update(fingerprintMaterial).digest("hex");
+  return event;
+}
+
+function appendAuditEvent(existingEvents, input) {
+  if (!Array.isArray(existingEvents)) throw new TypeError("existing audit events must be an array");
+  const normalized = normalizeAuditEvent(input);
+  const seen = new Set(existingEvents.map((event) => normalizeAuditEvent(event).auditEventId));
+  if (seen.has(normalized.auditEventId)) return existingEvents.map(normalizeAuditEvent);
+  return [...existingEvents.map(normalizeAuditEvent), normalized];
+}
+
+module.exports = {
+  AUDIT_EVENT_TYPES,
+  normalizeAuditEvent,
+  appendAuditEvent,
+};

--- a/functions/src/providerEvidenceCorrelation.js
+++ b/functions/src/providerEvidenceCorrelation.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const { QUEUE_STATES } = require("./providerDispatchEnvelope");
+
+function requiredObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value;
+}
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function correlateEvidenceToDispatch(input) {
+  const source = requiredObject(input, "evidence correlation input");
+  const evidence = requiredObject(source.evidence, "evidence");
+  const dispatch = requiredObject(source.dispatch, "dispatch");
+
+  if (dispatch.state !== QUEUE_STATES.ACKNOWLEDGED) {
+    throw new Error("provider evidence can only correlate to an acknowledged dispatch");
+  }
+
+  const evidenceProviderId = requiredText(evidence.providerId, "evidence.providerId", 128);
+  const evidenceContractId = requiredText(evidence.contractId, "evidence.contractId", 128);
+  const evidenceProviderReference = requiredText(evidence.providerReference, "evidence.providerReference", 200);
+  const dispatchProviderId = requiredText(dispatch.providerId, "dispatch.providerId", 128);
+  const dispatchContractId = requiredText(dispatch.contractId, "dispatch.contractId", 128);
+  const dispatchProviderReference = requiredText(dispatch.providerReference, "dispatch.providerReference", 200);
+  const dispatchId = requiredText(dispatch.dispatchId, "dispatch.dispatchId", 128);
+
+  if (evidenceProviderId !== dispatchProviderId) {
+    throw new Error("provider evidence does not match dispatch provider");
+  }
+  if (evidenceContractId !== dispatchContractId) {
+    throw new Error("provider evidence does not match dispatch contract");
+  }
+  if (evidenceProviderReference !== dispatchProviderReference) {
+    throw new Error("provider evidence does not match acknowledged provider reference");
+  }
+
+  return Object.freeze({
+    matched: true,
+    dispatchId,
+    providerId: dispatchProviderId,
+    contractId: dispatchContractId,
+    providerReference: dispatchProviderReference,
+    evidenceEventId: requiredText(evidence.evidenceEventId, "evidence.evidenceEventId", 128),
+    kind: requiredText(evidence.kind, "evidence.kind", 40).toUpperCase(),
+    observedAt: requiredText(evidence.observedAt, "evidence.observedAt", 64),
+  });
+}
+
+module.exports = {
+  correlateEvidenceToDispatch,
+};

--- a/functions/src/providerEvidenceIngestion.js
+++ b/functions/src/providerEvidenceIngestion.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+const EVIDENCE_KINDS = Object.freeze({
+  ACKNOWLEDGEMENT: "ACKNOWLEDGEMENT",
+  STATUS: "STATUS",
+  CONVERSION: "CONVERSION",
+  ACTIVATION: "ACTIVATION",
+  COMMISSION: "COMMISSION",
+});
+
+const SOURCES = new Set(["WEBHOOK", "POSTBACK", "REPORT_IMPORT", "MANUAL_VERIFIED"]);
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function normalizeIsoTime(value, field) {
+  const text = requiredText(value, field, 64);
+  const parsed = Date.parse(text);
+  if (!Number.isFinite(parsed)) throw new TypeError(`${field} must be a valid timestamp`);
+  return new Date(parsed).toISOString();
+}
+
+function deriveEvidenceEventId(input) {
+  const material = [
+    requiredText(input.providerId, "providerId", 128),
+    requiredText(input.providerReference, "providerReference", 200),
+    requiredText(input.kind, "kind", 40),
+    requiredText(input.externalEventId, "externalEventId", 200),
+  ].join(":");
+  return crypto.createHash("sha256").update(material).digest("hex");
+}
+
+function normalizeProviderEvidence(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("provider evidence must be an object");
+  }
+
+  const kind = requiredText(input.kind, "kind", 40).toUpperCase();
+  if (!Object.values(EVIDENCE_KINDS).includes(kind)) {
+    throw new TypeError(`unsupported evidence kind: ${kind}`);
+  }
+
+  const source = requiredText(input.source, "source", 40).toUpperCase();
+  if (!SOURCES.has(source)) throw new TypeError(`unsupported evidence source: ${source}`);
+
+  const normalized = {
+    providerId: requiredText(input.providerId, "providerId", 128),
+    contractId: requiredText(input.contractId, "contractId", 128),
+    providerReference: requiredText(input.providerReference, "providerReference", 200),
+    externalEventId: requiredText(input.externalEventId, "externalEventId", 200),
+    kind,
+    source,
+    observedAt: normalizeIsoTime(input.observedAt, "observedAt"),
+  };
+
+  if (input.amount != null) {
+    const amount = Number(input.amount);
+    if (!Number.isFinite(amount) || amount < 0) throw new TypeError("amount must be non-negative");
+    normalized.amount = Math.round(amount * 100) / 100;
+    normalized.currency = typeof input.currency === "string" && input.currency.trim()
+      ? input.currency.trim().toUpperCase().slice(0, 8)
+      : "ILS";
+  }
+
+  normalized.evidenceEventId = deriveEvidenceEventId(normalized);
+  return normalized;
+}
+
+function dedupeProviderEvidence(events) {
+  if (!Array.isArray(events)) throw new TypeError("provider evidence events must be an array");
+  const unique = new Map();
+  for (const event of events.map(normalizeProviderEvidence)) {
+    if (!unique.has(event.evidenceEventId)) unique.set(event.evidenceEventId, event);
+  }
+  return [...unique.values()];
+}
+
+module.exports = {
+  EVIDENCE_KINDS,
+  deriveEvidenceEventId,
+  normalizeProviderEvidence,
+  dedupeProviderEvidence,
+};

--- a/functions/src/providerEvidenceIngestion.js
+++ b/functions/src/providerEvidenceIngestion.js
@@ -11,6 +11,7 @@ const EVIDENCE_KINDS = Object.freeze({
 });
 
 const SOURCES = new Set(["WEBHOOK", "POSTBACK", "REPORT_IMPORT", "MANUAL_VERIFIED"]);
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 function requiredText(value, field, maxLength = 200) {
   const text = typeof value === "string" ? value.trim() : "";
@@ -19,10 +20,13 @@ function requiredText(value, field, maxLength = 200) {
   return text;
 }
 
-function normalizeIsoTime(value, field) {
+function normalizeIsoTime(value, field, nowMs, maxFutureSkewMs) {
   const text = requiredText(value, field, 64);
   const parsed = Date.parse(text);
   if (!Number.isFinite(parsed)) throw new TypeError(`${field} must be a valid timestamp`);
+  if (parsed > nowMs + maxFutureSkewMs) {
+    throw new TypeError(`${field} cannot be implausibly far in the future`);
+  }
   return new Date(parsed).toISOString();
 }
 
@@ -36,10 +40,15 @@ function deriveEvidenceEventId(input) {
   return crypto.createHash("sha256").update(material).digest("hex");
 }
 
-function normalizeProviderEvidence(input) {
+function normalizeProviderEvidence(input, options = {}) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("provider evidence must be an object");
   }
+
+  const nowMs = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
+  const maxFutureSkewMs = Number.isFinite(options.maxFutureSkewMs)
+    ? Math.max(0, options.maxFutureSkewMs)
+    : MAX_FUTURE_SKEW_MS;
 
   const kind = requiredText(input.kind, "kind", 40).toUpperCase();
   if (!Object.values(EVIDENCE_KINDS).includes(kind)) {
@@ -56,7 +65,7 @@ function normalizeProviderEvidence(input) {
     externalEventId: requiredText(input.externalEventId, "externalEventId", 200),
     kind,
     source,
-    observedAt: normalizeIsoTime(input.observedAt, "observedAt"),
+    observedAt: normalizeIsoTime(input.observedAt, "observedAt", nowMs, maxFutureSkewMs),
   };
 
   if (input.amount != null) {
@@ -72,10 +81,10 @@ function normalizeProviderEvidence(input) {
   return normalized;
 }
 
-function dedupeProviderEvidence(events) {
+function dedupeProviderEvidence(events, options = {}) {
   if (!Array.isArray(events)) throw new TypeError("provider evidence events must be an array");
   const unique = new Map();
-  for (const event of events.map(normalizeProviderEvidence)) {
+  for (const event of events.map((item) => normalizeProviderEvidence(item, options))) {
     if (!unique.has(event.evidenceEventId)) unique.set(event.evidenceEventId, event);
   }
   return [...unique.values()];
@@ -83,6 +92,7 @@ function dedupeProviderEvidence(events) {
 
 module.exports = {
   EVIDENCE_KINDS,
+  MAX_FUTURE_SKEW_MS,
   deriveEvidenceEventId,
   normalizeProviderEvidence,
   dedupeProviderEvidence,

--- a/functions/src/providerExceptionTriage.js
+++ b/functions/src/providerExceptionTriage.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const EXCEPTION_TYPES = Object.freeze({
+  DEAD_LETTER: "DEAD_LETTER",
+  WEBHOOK_AUTH_FAILED: "WEBHOOK_AUTH_FAILED",
+  SETTLEMENT_PARTIAL: "SETTLEMENT_PARTIAL",
+  SETTLEMENT_OVERPAID: "SETTLEMENT_OVERPAID",
+  SETTLEMENT_MISMATCH: "SETTLEMENT_MISMATCH",
+  PROVIDER_DEGRADED: "PROVIDER_DEGRADED",
+});
+
+const SEVERITIES = Object.freeze({
+  INFO: "INFO",
+  WARNING: "WARNING",
+  HIGH: "HIGH",
+  CRITICAL: "CRITICAL",
+});
+
+function triageProviderException(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("provider exception must be an object");
+  }
+  const type = typeof input.type === "string" ? input.type.trim().toUpperCase() : "";
+  if (!Object.values(EXCEPTION_TYPES).includes(type)) throw new TypeError(`unsupported provider exception type: ${type}`);
+
+  const mapping = {
+    [EXCEPTION_TYPES.WEBHOOK_AUTH_FAILED]: { severity: SEVERITIES.CRITICAL, action: "VERIFY_WEBHOOK_SECRET_AND_SOURCE", blocksAutomation: true },
+    [EXCEPTION_TYPES.DEAD_LETTER]: { severity: SEVERITIES.HIGH, action: "REVIEW_DEAD_LETTER_AND_PROVIDER_HEALTH", blocksAutomation: true },
+    [EXCEPTION_TYPES.SETTLEMENT_MISMATCH]: { severity: SEVERITIES.HIGH, action: "RECONCILE_PARTNER_REFERENCE_AND_CURRENCY", blocksAutomation: true },
+    [EXCEPTION_TYPES.SETTLEMENT_PARTIAL]: { severity: SEVERITIES.WARNING, action: "WAIT_OR_RECONCILE_REMAINING_PAYMENT", blocksAutomation: true },
+    [EXCEPTION_TYPES.SETTLEMENT_OVERPAID]: { severity: SEVERITIES.WARNING, action: "REVIEW_OVERPAYMENT_BEFORE_POSTING", blocksAutomation: true },
+    [EXCEPTION_TYPES.PROVIDER_DEGRADED]: { severity: SEVERITIES.WARNING, action: "REVIEW_PROVIDER_FAILURE_RATE", blocksAutomation: false },
+  };
+
+  return {
+    type,
+    providerId: typeof input.providerId === "string" ? input.providerId.trim().slice(0, 128) : "",
+    reference: typeof input.reference === "string" ? input.reference.trim().slice(0, 200) : "",
+    ...mapping[type],
+  };
+}
+
+module.exports = {
+  EXCEPTION_TYPES,
+  SEVERITIES,
+  triageProviderException,
+};

--- a/functions/src/providerIncidentFreezePolicy.js
+++ b/functions/src/providerIncidentFreezePolicy.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const FREEZE_REASONS = new Set([
+  "WEBHOOK_AUTH_FAILURE",
+  "CREDENTIAL_COMPROMISE",
+  "PROVIDER_OUTAGE",
+  "DATA_INTEGRITY_RISK",
+  "MANUAL_OPERATOR_FREEZE",
+]);
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function evaluateProviderFreeze(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError("provider freeze input must be an object");
+  const providerId = requiredText(input.providerId, "providerId", 128);
+  if (input.frozen !== true) {
+    return { providerId, frozen: false, blocksDispatch: false, reason: "provider integration is not frozen" };
+  }
+  const reason = requiredText(input.reason, "reason", 64).toUpperCase();
+  if (!FREEZE_REASONS.has(reason)) throw new TypeError(`unsupported provider freeze reason: ${reason}`);
+  const frozenAt = requiredText(input.frozenAt, "frozenAt", 64);
+  if (!Number.isFinite(Date.parse(frozenAt))) throw new TypeError("frozenAt must be a valid timestamp");
+  return {
+    providerId,
+    frozen: true,
+    blocksDispatch: true,
+    reason,
+    frozenAt: new Date(Date.parse(frozenAt)).toISOString(),
+    operatorReference: typeof input.operatorReference === "string" ? input.operatorReference.trim().slice(0, 200) : "",
+  };
+}
+
+module.exports = {
+  FREEZE_REASONS,
+  evaluateProviderFreeze,
+};

--- a/functions/src/providerIntegrationFramework.js
+++ b/functions/src/providerIntegrationFramework.js
@@ -22,6 +22,14 @@ function requiredText(value, field, maxLength = 200) {
   return normalized;
 }
 
+function requiredTimestamp(value, field) {
+  const normalized = requiredText(value, field, 64);
+  if (!Number.isFinite(Date.parse(normalized))) {
+    throw new TypeError(`${field} must be a valid timestamp`);
+  }
+  return normalized;
+}
+
 function normalizeProviderConfig(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("provider config must be an object");
@@ -115,11 +123,11 @@ function normalizeLifecycleEvidence(input) {
 
   const providerReference = requiredText(input.providerReference, "providerReference", 200);
   const evidenceSource = requiredText(input.evidenceSource, "evidenceSource", 80);
-  const observedAt = requiredText(input.observedAt, "observedAt", 64);
+  const observedAt = requiredTimestamp(input.observedAt, "observedAt");
 
   const amount = input.amount == null ? null : Number(input.amount);
-  if (stage === "COMMISSION_CONFIRMED" && (!Number.isFinite(amount) || amount < 0)) {
-    throw new TypeError("commission confirmation requires a non-negative amount");
+  if (stage === "COMMISSION_CONFIRMED" && (!Number.isFinite(amount) || amount <= 0)) {
+    throw new TypeError("commission confirmation requires a positive amount");
   }
 
   return {

--- a/functions/src/providerIntegrationFramework.js
+++ b/functions/src/providerIntegrationFramework.js
@@ -1,0 +1,146 @@
+"use strict";
+
+const CONNECTION_STATES = Object.freeze({
+  READY_FOR_ADAPTER: "READY_FOR_ADAPTER",
+  ACTUALLY_CONNECTED: "ACTUALLY_CONNECTED",
+  DISABLED: "DISABLED",
+});
+
+const DISPATCH_OUTCOMES = Object.freeze({
+  ACKNOWLEDGED: "ACKNOWLEDGED",
+  RETRYABLE_FAILURE: "RETRYABLE_FAILURE",
+  PERMANENT_FAILURE: "PERMANENT_FAILURE",
+});
+
+const MAX_ATTEMPTS_DEFAULT = 5;
+const MAX_BACKOFF_MS = 6 * 60 * 60 * 1000;
+
+function requiredText(value, field, maxLength = 200) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) throw new TypeError(`${field} is required`);
+  if (normalized.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return normalized;
+}
+
+function normalizeProviderConfig(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("provider config must be an object");
+  }
+
+  const providerId = requiredText(input.providerId, "providerId", 128);
+  const adapterKey = requiredText(input.adapterKey, "adapterKey", 128);
+  const enabled = input.enabled === true;
+  const adapterImplemented = input.adapterImplemented === true;
+  const credentialsConfigured = input.credentialsConfigured === true;
+  const connectionVerified = input.connectionVerified === true;
+
+  let integrationState = CONNECTION_STATES.READY_FOR_ADAPTER;
+  if (!enabled) integrationState = CONNECTION_STATES.DISABLED;
+  else if (adapterImplemented && credentialsConfigured && connectionVerified) {
+    integrationState = CONNECTION_STATES.ACTUALLY_CONNECTED;
+  }
+
+  return {
+    providerId,
+    adapterKey,
+    enabled,
+    adapterImplemented,
+    credentialsConfigured,
+    connectionVerified,
+    integrationState,
+  };
+}
+
+function assertDispatchAllowed(config) {
+  const normalized = normalizeProviderConfig(config);
+  if (normalized.integrationState !== CONNECTION_STATES.ACTUALLY_CONNECTED) {
+    throw new Error("provider is not actually connected");
+  }
+  return normalized;
+}
+
+function normalizeAdapterResult(result) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    throw new TypeError("adapter result must be an object");
+  }
+  const outcome = requiredText(result.outcome, "outcome", 40);
+  if (!Object.values(DISPATCH_OUTCOMES).includes(outcome)) {
+    throw new TypeError("adapter outcome is unsupported");
+  }
+
+  const providerReference = typeof result.providerReference === "string"
+    ? result.providerReference.trim().slice(0, 200)
+    : "";
+
+  if (outcome === DISPATCH_OUTCOMES.ACKNOWLEDGED && !providerReference) {
+    throw new TypeError("acknowledged dispatch requires providerReference evidence");
+  }
+
+  return {
+    outcome,
+    providerReference,
+    retryAfterMs: Number.isFinite(Number(result.retryAfterMs))
+      ? Math.max(0, Math.min(MAX_BACKOFF_MS, Math.round(Number(result.retryAfterMs))))
+      : 0,
+    evidenceType: typeof result.evidenceType === "string"
+      ? result.evidenceType.trim().slice(0, 80)
+      : "",
+  };
+}
+
+function nextRetry(attempt, retryAfterMs = 0, maxAttempts = MAX_ATTEMPTS_DEFAULT) {
+  const currentAttempt = Math.max(1, Math.floor(Number(attempt) || 1));
+  const attemptsLimit = Math.max(1, Math.floor(Number(maxAttempts) || MAX_ATTEMPTS_DEFAULT));
+  if (currentAttempt >= attemptsLimit) {
+    return { shouldRetry: false, deadLetter: true, delayMs: 0 };
+  }
+
+  const exponential = Math.min(MAX_BACKOFF_MS, 30_000 * (2 ** (currentAttempt - 1)));
+  const requested = Math.max(0, Math.min(MAX_BACKOFF_MS, Math.round(Number(retryAfterMs) || 0)));
+  return {
+    shouldRetry: true,
+    deadLetter: false,
+    delayMs: Math.max(exponential, requested),
+  };
+}
+
+function normalizeLifecycleEvidence(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("lifecycle evidence must be an object");
+  }
+  const stage = requiredText(input.stage, "stage", 40);
+  if (!["CONTACTED", "QUOTED", "ACTIVATED", "COMMISSION_CONFIRMED"].includes(stage)) {
+    throw new TypeError("unsupported lifecycle evidence stage");
+  }
+
+  const providerReference = requiredText(input.providerReference, "providerReference", 200);
+  const evidenceSource = requiredText(input.evidenceSource, "evidenceSource", 80);
+  const observedAt = requiredText(input.observedAt, "observedAt", 64);
+
+  const amount = input.amount == null ? null : Number(input.amount);
+  if (stage === "COMMISSION_CONFIRMED" && (!Number.isFinite(amount) || amount < 0)) {
+    throw new TypeError("commission confirmation requires a non-negative amount");
+  }
+
+  return {
+    stage,
+    providerReference,
+    evidenceSource,
+    observedAt,
+    amount: Number.isFinite(amount) ? Math.round(amount * 100) / 100 : null,
+    currency: typeof input.currency === "string" && input.currency.trim()
+      ? input.currency.trim().toUpperCase().slice(0, 8)
+      : "ILS",
+  };
+}
+
+module.exports = {
+  CONNECTION_STATES,
+  DISPATCH_OUTCOMES,
+  MAX_ATTEMPTS_DEFAULT,
+  normalizeProviderConfig,
+  assertDispatchAllowed,
+  normalizeAdapterResult,
+  nextRetry,
+  normalizeLifecycleEvidence,
+};

--- a/functions/src/providerIntegrationReadiness.js
+++ b/functions/src/providerIntegrationReadiness.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const READINESS_STATES = Object.freeze({
+  NOT_READY: "NOT_READY",
+  READY_FOR_SANDBOX: "READY_FOR_SANDBOX",
+  READY_FOR_PRODUCTION: "READY_FOR_PRODUCTION",
+});
+
+function evaluateIntegrationReadiness(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError("integration readiness input must be an object");
+
+  const checks = {
+    adapterImplemented: input.adapterImplemented === true,
+    credentialsReferenced: input.credentialsReferenced === true,
+    connectionVerified: input.connectionVerified === true,
+    dispatchCapability: input.dispatchCapability === true,
+    evidencePathVerified: input.evidencePathVerified === true,
+    webhookOrReportVerified: input.webhookOrReportVerified === true,
+    commercialContractActive: input.commercialContractActive === true,
+    dataMinimizationVerified: input.dataMinimizationVerified === true,
+  };
+
+  const requiredSandbox = ["adapterImplemented", "credentialsReferenced", "dispatchCapability", "dataMinimizationVerified"];
+  const requiredProduction = [...requiredSandbox, "connectionVerified", "evidencePathVerified", "webhookOrReportVerified", "commercialContractActive"];
+  const missingSandbox = requiredSandbox.filter((key) => !checks[key]);
+  const missingProduction = requiredProduction.filter((key) => !checks[key]);
+
+  if (missingSandbox.length > 0) {
+    return { state: READINESS_STATES.NOT_READY, missing: missingSandbox, checks };
+  }
+  if (missingProduction.length > 0) {
+    return { state: READINESS_STATES.READY_FOR_SANDBOX, missing: missingProduction, checks };
+  }
+  return { state: READINESS_STATES.READY_FOR_PRODUCTION, missing: [], checks };
+}
+
+module.exports = {
+  READINESS_STATES,
+  evaluateIntegrationReadiness,
+};

--- a/functions/src/providerIntegrationStatus.js
+++ b/functions/src/providerIntegrationStatus.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const OPERATOR_STATES = Object.freeze({
+  DISABLED: "DISABLED",
+  READY_FOR_ADAPTER: "READY_FOR_ADAPTER",
+  CONNECTION_UNVERIFIED: "CONNECTION_UNVERIFIED",
+  ACTUALLY_CONNECTED: "ACTUALLY_CONNECTED",
+  DEGRADED: "DEGRADED",
+});
+
+function number(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function deriveIntegrationStatus(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("integration status input must be an object");
+  }
+
+  if (input.enabled !== true) {
+    return { state: OPERATOR_STATES.DISABLED, actionable: false, reason: "provider integration disabled" };
+  }
+  if (input.adapterImplemented !== true || input.credentialsConfigured !== true) {
+    return { state: OPERATOR_STATES.READY_FOR_ADAPTER, actionable: false, reason: "adapter or credentials not configured" };
+  }
+  if (input.connectionVerified !== true) {
+    return { state: OPERATOR_STATES.CONNECTION_UNVERIFIED, actionable: false, reason: "provider connection not verified" };
+  }
+
+  const attempted = number(input.attemptedLast24h);
+  const failed = number(input.failedLast24h);
+  const deadLetter = number(input.deadLetterCount);
+  const failureRate = attempted > 0 ? failed / attempted : 0;
+
+  if (deadLetter > 0 || failureRate >= 0.2) {
+    return {
+      state: OPERATOR_STATES.DEGRADED,
+      actionable: true,
+      reason: deadLetter > 0 ? "dead-letter items require operator review" : "provider failure rate is elevated",
+      failureRate: Math.round(failureRate * 10000) / 10000,
+      deadLetterCount: deadLetter,
+    };
+  }
+
+  return {
+    state: OPERATOR_STATES.ACTUALLY_CONNECTED,
+    actionable: true,
+    reason: "provider connection verified",
+    failureRate: Math.round(failureRate * 10000) / 10000,
+    deadLetterCount: deadLetter,
+  };
+}
+
+function buildPrivacySafePartnerFunnel(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("partner funnel input must be an object");
+  }
+  const verifiedOpportunities = number(input.verifiedOpportunities);
+  const consentedRequests = number(input.consentedRequests);
+  const acknowledgedDispatches = number(input.acknowledgedDispatches);
+  const activations = number(input.activations);
+  const confirmedCommission = Math.round(number(input.confirmedCommission) * 100) / 100;
+
+  return {
+    verifiedOpportunities,
+    consentedRequests,
+    acknowledgedDispatches,
+    activations,
+    confirmedCommission,
+    requestRate: verifiedOpportunities > 0 ? Math.round((consentedRequests / verifiedOpportunities) * 10000) / 10000 : 0,
+    activationRate: acknowledgedDispatches > 0 ? Math.round((activations / acknowledgedDispatches) * 10000) / 10000 : 0,
+  };
+}
+
+module.exports = {
+  OPERATOR_STATES,
+  deriveIntegrationStatus,
+  buildPrivacySafePartnerFunnel,
+};

--- a/functions/src/providerLifecycleEvidenceAdapter.js
+++ b/functions/src/providerLifecycleEvidenceAdapter.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const { normalizeLifecycleEvidence } = require("./providerIntegrationFramework");
+
+function requiredObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value;
+}
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function buildLifecycleEvidenceFromProviderEvidence(evidenceInput, correlationInput) {
+  const evidence = requiredObject(evidenceInput, "provider evidence");
+  const correlation = requiredObject(correlationInput, "evidence correlation");
+
+  if (correlation.matched !== true) {
+    throw new Error("provider lifecycle evidence must be correlated to an acknowledged dispatch");
+  }
+
+  const evidenceEventId = requiredText(evidence.evidenceEventId, "evidence.evidenceEventId", 128);
+  if (evidenceEventId !== requiredText(correlation.evidenceEventId, "correlation.evidenceEventId", 128)) {
+    throw new Error("provider lifecycle evidence event does not match correlation event");
+  }
+
+  const providerReference = requiredText(evidence.providerReference, "evidence.providerReference", 200);
+  if (providerReference !== requiredText(correlation.providerReference, "correlation.providerReference", 200)) {
+    throw new Error("provider lifecycle evidence reference does not match correlation reference");
+  }
+
+  const kind = requiredText(evidence.kind, "evidence.kind", 40).toUpperCase();
+  const source = requiredText(evidence.source, "evidence.source", 40).toUpperCase();
+  const observedAt = requiredText(evidence.observedAt, "evidence.observedAt", 64);
+
+  if (kind === "ACTIVATION") {
+    return normalizeLifecycleEvidence({
+      stage: "ACTIVATED",
+      providerReference,
+      evidenceSource: `PROVIDER_${source}`,
+      observedAt,
+    });
+  }
+
+  if (kind === "COMMISSION") {
+    return normalizeLifecycleEvidence({
+      stage: "COMMISSION_CONFIRMED",
+      providerReference,
+      evidenceSource: `PROVIDER_${source}`,
+      observedAt,
+      amount: evidence.amount,
+      currency: evidence.currency,
+    });
+  }
+
+  throw new TypeError(`provider evidence kind does not map unambiguously to lifecycle stage: ${kind}`);
+}
+
+module.exports = {
+  buildLifecycleEvidenceFromProviderEvidence,
+};

--- a/functions/src/providerOffboardingPolicy.js
+++ b/functions/src/providerOffboardingPolicy.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const OFFBOARD_ACTIONS = Object.freeze({
+  DISABLE_NEW_DISPATCH: "DISABLE_NEW_DISPATCH",
+  DRAIN_IN_FLIGHT: "DRAIN_IN_FLIGHT",
+  ROTATE_CREDENTIALS: "ROTATE_CREDENTIALS",
+  ARCHIVE_CONTRACT: "ARCHIVE_CONTRACT",
+  COMPLETE: "COMPLETE",
+});
+
+function planProviderOffboarding(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError("provider offboarding input must be an object");
+  const providerId = typeof input.providerId === "string" ? input.providerId.trim() : "";
+  if (!providerId) throw new TypeError("providerId is required");
+
+  if (input.newDispatchDisabled !== true) {
+    return { action: OFFBOARD_ACTIONS.DISABLE_NEW_DISPATCH, providerId, safeToArchive: false };
+  }
+  if (Number(input.inFlightCount || 0) > 0) {
+    return { action: OFFBOARD_ACTIONS.DRAIN_IN_FLIGHT, providerId, safeToArchive: false, inFlightCount: Number(input.inFlightCount) };
+  }
+  if (input.credentialsRotated !== true) {
+    return { action: OFFBOARD_ACTIONS.ROTATE_CREDENTIALS, providerId, safeToArchive: false };
+  }
+  if (input.contractArchived !== true) {
+    return { action: OFFBOARD_ACTIONS.ARCHIVE_CONTRACT, providerId, safeToArchive: false };
+  }
+  return { action: OFFBOARD_ACTIONS.COMPLETE, providerId, safeToArchive: true };
+}
+
+module.exports = {
+  OFFBOARD_ACTIONS,
+  planProviderOffboarding,
+};

--- a/functions/src/providerPaidTransitionGate.js
+++ b/functions/src/providerPaidTransitionGate.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const { COMMISSION_STATES, normalizeCommissionRecord, reconcileCommission } = require("./providerReconciliation");
+const { SETTLEMENT_RESULTS, reconcileSettlement } = require("./providerSettlementReconciliation");
+
+function applyVerifiedSettlementToCommission(commissionInput, settlementEvidenceInput) {
+  const commission = normalizeCommissionRecord(commissionInput);
+  if (commission.state !== COMMISSION_STATES.CONFIRMED && commission.state !== COMMISSION_STATES.PAID) {
+    throw new Error("paid transition requires confirmed commission");
+  }
+
+  const settlement = reconcileSettlement(commission, settlementEvidenceInput);
+  if (settlement.result !== SETTLEMENT_RESULTS.MATCHED || settlement.canMarkPaid !== true) {
+    return {
+      applied: false,
+      reason: "settlement does not exactly match confirmed commission",
+      settlement,
+      commission,
+    };
+  }
+
+  if (commission.state === COMMISSION_STATES.PAID) {
+    return {
+      applied: false,
+      reason: "commission is already paid",
+      settlement,
+      commission,
+    };
+  }
+
+  const updated = reconcileCommission(commission, {
+    state: COMMISSION_STATES.PAID,
+    confirmedAmount: settlement.paidAmount,
+    evidenceSource: "SETTLEMENT_EVIDENCE",
+    evidenceObservedAt: settlementEvidenceInput.paidAt,
+  });
+
+  return {
+    applied: true,
+    reason: "verified settlement exactly matches confirmed commission",
+    settlementEvidenceId: settlement.settlementEvidenceId,
+    settlement,
+    commission: updated,
+  };
+}
+
+module.exports = {
+  applyVerifiedSettlementToCommission,
+};

--- a/functions/src/providerPartnerFinanceSummary.js
+++ b/functions/src/providerPartnerFinanceSummary.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const { buildPartnerMetrics, normalizeCommissionRecord } = require("./providerReconciliation");
+
+function roundMoney(value) {
+  return Math.round(Number(value || 0) * 100) / 100;
+}
+
+function buildPartnerFinanceSummary(records) {
+  const normalized = (Array.isArray(records) ? records : []).map(normalizeCommissionRecord);
+  const metrics = buildPartnerMetrics(normalized);
+  const outstandingConfirmed = roundMoney(metrics.confirmedAmount - metrics.paidAmount);
+  const unconfirmedExpected = roundMoney(metrics.expectedAmount - metrics.confirmedAmount);
+
+  return {
+    records: metrics.records,
+    expectedAmount: metrics.expectedAmount,
+    confirmedAmount: metrics.confirmedAmount,
+    paidAmount: metrics.paidAmount,
+    outstandingConfirmed: Math.max(0, outstandingConfirmed),
+    unconfirmedExpected: Math.max(0, unconfirmedExpected),
+    rejectedCount: metrics.rejectedCount,
+    collectionRate: metrics.confirmedAmount > 0
+      ? Math.round((metrics.paidAmount / metrics.confirmedAmount) * 10000) / 10000
+      : 0,
+  };
+}
+
+module.exports = {
+  buildPartnerFinanceSummary,
+};

--- a/functions/src/providerRateLimitPlanner.js
+++ b/functions/src/providerRateLimitPlanner.js
@@ -1,0 +1,100 @@
+"use strict";
+
+const RATE_LIMIT_ACTIONS = Object.freeze({
+  ALLOW: "ALLOW",
+  WAIT: "WAIT",
+  UNCONFIGURED: "UNCONFIGURED",
+});
+
+const MAX_WINDOW_MS = 24 * 60 * 60 * 1000;
+const MAX_REQUESTS_PER_WINDOW = 1_000_000;
+
+function positiveInteger(value, field, max) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0 || number > max) {
+    throw new TypeError(`${field} must be an integer between 1 and ${max}`);
+  }
+  return number;
+}
+
+function normalizeRateLimitPolicy(input) {
+  if (input == null) return { configured: false };
+  if (typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("rate limit policy must be an object");
+  }
+  if (input.configured === false) return { configured: false };
+
+  return {
+    configured: true,
+    maxRequests: positiveInteger(input.maxRequests, "maxRequests", MAX_REQUESTS_PER_WINDOW),
+    windowMs: positiveInteger(input.windowMs, "windowMs", MAX_WINDOW_MS),
+  };
+}
+
+function normalizeUsage(input, policy, nowMs) {
+  if (input == null) {
+    return { usedRequests: 0, windowStartedAtMs: nowMs };
+  }
+  if (typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("rate limit usage must be an object");
+  }
+
+  const usedRequests = Number(input.usedRequests);
+  if (!Number.isInteger(usedRequests) || usedRequests < 0) {
+    throw new TypeError("usedRequests must be a non-negative integer");
+  }
+  const windowStartedAtMs = Number(input.windowStartedAtMs);
+  if (!Number.isFinite(windowStartedAtMs)) {
+    throw new TypeError("windowStartedAtMs must be finite");
+  }
+
+  if (nowMs >= windowStartedAtMs + policy.windowMs) {
+    return { usedRequests: 0, windowStartedAtMs: nowMs };
+  }
+
+  return { usedRequests, windowStartedAtMs };
+}
+
+function planRateLimit({ policy: policyInput, usage: usageInput, nowMs = Date.now() } = {}) {
+  const policy = normalizeRateLimitPolicy(policyInput);
+  if (!policy.configured) {
+    return {
+      action: RATE_LIMIT_ACTIONS.UNCONFIGURED,
+      reason: "provider rate limit policy is not configured",
+    };
+  }
+
+  const now = Number(nowMs);
+  if (!Number.isFinite(now)) throw new TypeError("nowMs must be finite");
+  const usage = normalizeUsage(usageInput, policy, now);
+  const resetAtMs = usage.windowStartedAtMs + policy.windowMs;
+
+  if (usage.usedRequests >= policy.maxRequests) {
+    return {
+      action: RATE_LIMIT_ACTIONS.WAIT,
+      reason: "provider rate limit reached",
+      delayMs: Math.max(0, resetAtMs - now),
+      resetAtMs,
+      remainingRequests: 0,
+    };
+  }
+
+  return {
+    action: RATE_LIMIT_ACTIONS.ALLOW,
+    reason: "provider rate limit capacity available",
+    resetAtMs,
+    remainingRequests: Math.max(0, policy.maxRequests - usage.usedRequests - 1),
+    nextUsage: {
+      usedRequests: usage.usedRequests + 1,
+      windowStartedAtMs: usage.windowStartedAtMs,
+    },
+  };
+}
+
+module.exports = {
+  RATE_LIMIT_ACTIONS,
+  MAX_WINDOW_MS,
+  MAX_REQUESTS_PER_WINDOW,
+  normalizeRateLimitPolicy,
+  planRateLimit,
+};

--- a/functions/src/providerReconciliation.js
+++ b/functions/src/providerReconciliation.js
@@ -20,6 +20,15 @@ function money(value, field) {
   return Math.round(amount * 100) / 100;
 }
 
+function normalizeEvidenceTimestamp(value) {
+  if (value == null || value === "") return "";
+  const normalized = String(value).trim().slice(0, 64);
+  if (!Number.isFinite(Date.parse(normalized))) {
+    throw new TypeError("evidenceObservedAt must be a valid timestamp");
+  }
+  return normalized;
+}
+
 function normalizeCommissionRecord(input) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new TypeError("commission record must be an object");
@@ -40,9 +49,7 @@ function normalizeCommissionRecord(input) {
     evidenceSource: typeof input.evidenceSource === "string"
       ? input.evidenceSource.trim().slice(0, 80)
       : "",
-    evidenceObservedAt: typeof input.evidenceObservedAt === "string"
-      ? input.evidenceObservedAt.trim().slice(0, 64)
-      : "",
+    evidenceObservedAt: normalizeEvidenceTimestamp(input.evidenceObservedAt),
   };
 
   if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID, COMMISSION_STATES.REJECTED].includes(state)) {
@@ -50,8 +57,10 @@ function normalizeCommissionRecord(input) {
       throw new TypeError("resolved commission state requires provider evidence");
     }
   }
-  if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID].includes(state) && record.confirmedAmount == null) {
-    throw new TypeError("confirmed or paid commission requires confirmedAmount");
+  if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID].includes(state)) {
+    if (record.confirmedAmount == null || record.confirmedAmount <= 0) {
+      throw new TypeError("confirmed or paid commission requires a positive confirmedAmount");
+    }
   }
   return record;
 }

--- a/functions/src/providerReconciliation.js
+++ b/functions/src/providerReconciliation.js
@@ -1,0 +1,109 @@
+"use strict";
+
+const COMMISSION_STATES = Object.freeze({
+  EXPECTED: "EXPECTED",
+  CONFIRMED: "CONFIRMED",
+  PAID: "PAID",
+  REJECTED: "REJECTED",
+});
+
+function text(value, field, maxLength = 200) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized) throw new TypeError(`${field} is required`);
+  if (normalized.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return normalized;
+}
+
+function money(value, field) {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount < 0) throw new TypeError(`${field} must be a non-negative number`);
+  return Math.round(amount * 100) / 100;
+}
+
+function normalizeCommissionRecord(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("commission record must be an object");
+  }
+  const state = text(input.state, "state", 30);
+  if (!Object.values(COMMISSION_STATES).includes(state)) throw new TypeError("commission state is unsupported");
+
+  const record = {
+    commissionId: text(input.commissionId, "commissionId", 128),
+    partnerId: text(input.partnerId, "partnerId", 128),
+    providerReference: text(input.providerReference, "providerReference", 200),
+    state,
+    expectedAmount: money(input.expectedAmount ?? 0, "expectedAmount"),
+    confirmedAmount: input.confirmedAmount == null ? null : money(input.confirmedAmount, "confirmedAmount"),
+    currency: typeof input.currency === "string" && input.currency.trim()
+      ? input.currency.trim().toUpperCase().slice(0, 8)
+      : "ILS",
+    evidenceSource: typeof input.evidenceSource === "string"
+      ? input.evidenceSource.trim().slice(0, 80)
+      : "",
+    evidenceObservedAt: typeof input.evidenceObservedAt === "string"
+      ? input.evidenceObservedAt.trim().slice(0, 64)
+      : "",
+  };
+
+  if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID, COMMISSION_STATES.REJECTED].includes(state)) {
+    if (!record.evidenceSource || !record.evidenceObservedAt) {
+      throw new TypeError("resolved commission state requires provider evidence");
+    }
+  }
+  if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID].includes(state) && record.confirmedAmount == null) {
+    throw new TypeError("confirmed or paid commission requires confirmedAmount");
+  }
+  return record;
+}
+
+function reconcileCommission(currentInput, evidenceInput) {
+  const current = normalizeCommissionRecord(currentInput);
+  if (!evidenceInput || typeof evidenceInput !== "object" || Array.isArray(evidenceInput)) {
+    throw new TypeError("reconciliation evidence must be an object");
+  }
+  const nextState = text(evidenceInput.state, "state", 30);
+  if (![COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID, COMMISSION_STATES.REJECTED].includes(nextState)) {
+    throw new TypeError("reconciliation evidence state is unsupported");
+  }
+  if (current.state === COMMISSION_STATES.PAID && nextState !== COMMISSION_STATES.PAID) {
+    throw new Error("paid commission cannot be downgraded");
+  }
+
+  return normalizeCommissionRecord({
+    ...current,
+    state: nextState,
+    confirmedAmount: evidenceInput.confirmedAmount ?? current.confirmedAmount,
+    evidenceSource: evidenceInput.evidenceSource,
+    evidenceObservedAt: evidenceInput.evidenceObservedAt,
+  });
+}
+
+function buildPartnerMetrics(records) {
+  const normalized = (Array.isArray(records) ? records : []).map(normalizeCommissionRecord);
+  const metrics = {
+    records: normalized.length,
+    expectedAmount: 0,
+    confirmedAmount: 0,
+    paidAmount: 0,
+    rejectedCount: 0,
+  };
+  for (const record of normalized) {
+    metrics.expectedAmount += record.expectedAmount;
+    if ([COMMISSION_STATES.CONFIRMED, COMMISSION_STATES.PAID].includes(record.state)) {
+      metrics.confirmedAmount += record.confirmedAmount || 0;
+    }
+    if (record.state === COMMISSION_STATES.PAID) metrics.paidAmount += record.confirmedAmount || 0;
+    if (record.state === COMMISSION_STATES.REJECTED) metrics.rejectedCount += 1;
+  }
+  metrics.expectedAmount = Math.round(metrics.expectedAmount * 100) / 100;
+  metrics.confirmedAmount = Math.round(metrics.confirmedAmount * 100) / 100;
+  metrics.paidAmount = Math.round(metrics.paidAmount * 100) / 100;
+  return metrics;
+}
+
+module.exports = {
+  COMMISSION_STATES,
+  normalizeCommissionRecord,
+  reconcileCommission,
+  buildPartnerMetrics,
+};

--- a/functions/src/providerReportImportPlanner.js
+++ b/functions/src/providerReportImportPlanner.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+const IMPORT_RESULTS = Object.freeze({
+  ACCEPTED: "ACCEPTED",
+  DUPLICATE: "DUPLICATE",
+  QUARANTINED: "QUARANTINED",
+});
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function deriveImportEventId(input) {
+  const material = [
+    requiredText(input.providerId, "providerId", 128),
+    requiredText(input.reportId, "reportId", 200),
+    requiredText(input.externalEventId, "externalEventId", 200),
+    requiredText(input.eventType, "eventType", 64).toUpperCase(),
+  ].join(":");
+  return crypto.createHash("sha256").update(material).digest("hex");
+}
+
+function planProviderReportImport(events, existingEventIds = []) {
+  if (!Array.isArray(events)) throw new TypeError("provider report events must be an array");
+  if (!Array.isArray(existingEventIds)) throw new TypeError("existingEventIds must be an array");
+
+  const seen = new Set(existingEventIds.filter((value) => typeof value === "string" && value));
+  const results = [];
+
+  for (const raw of events) {
+    try {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new TypeError("report event must be an object");
+      const eventType = requiredText(raw.eventType, "eventType", 64).toUpperCase();
+      if (!["CONVERSION", "COMMISSION", "SETTLEMENT"].includes(eventType)) {
+        throw new TypeError(`unsupported report event type: ${eventType}`);
+      }
+      const importEventId = deriveImportEventId({ ...raw, eventType });
+      if (seen.has(importEventId)) {
+        results.push({ result: IMPORT_RESULTS.DUPLICATE, importEventId, eventType });
+        continue;
+      }
+      seen.add(importEventId);
+      results.push({
+        result: IMPORT_RESULTS.ACCEPTED,
+        importEventId,
+        eventType,
+        providerId: requiredText(raw.providerId, "providerId", 128),
+        reportId: requiredText(raw.reportId, "reportId", 200),
+        externalEventId: requiredText(raw.externalEventId, "externalEventId", 200),
+        payload: raw.payload && typeof raw.payload === "object" && !Array.isArray(raw.payload) ? raw.payload : {},
+      });
+    } catch (error) {
+      results.push({
+        result: IMPORT_RESULTS.QUARANTINED,
+        reason: error instanceof Error ? error.message : "invalid report event",
+      });
+    }
+  }
+
+  return results;
+}
+
+module.exports = {
+  IMPORT_RESULTS,
+  deriveImportEventId,
+  planProviderReportImport,
+};

--- a/functions/src/providerSandboxProbePlanner.js
+++ b/functions/src/providerSandboxProbePlanner.js
@@ -1,0 +1,26 @@
+"use strict";
+
+function planSandboxProbe(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError("sandbox probe input must be an object");
+  const providerId = typeof input.providerId === "string" ? input.providerId.trim() : "";
+  const adapterKey = typeof input.adapterKey === "string" ? input.adapterKey.trim() : "";
+  if (!providerId) throw new TypeError("providerId is required");
+  if (!adapterKey) throw new TypeError("adapterKey is required");
+  if (input.adapterImplemented !== true) return { allowed: false, reason: "adapter is not implemented", providerId, adapterKey };
+  if (input.credentialsReferenced !== true) return { allowed: false, reason: "credentials are not referenced", providerId, adapterKey };
+  if (input.statusLookupCapability !== true) return { allowed: false, reason: "adapter lacks non-destructive status lookup capability", providerId, adapterKey };
+  if (input.productionTraffic === true) return { allowed: false, reason: "sandbox probe cannot use production traffic", providerId, adapterKey };
+
+  return {
+    allowed: true,
+    reason: "non-destructive provider connectivity probe allowed",
+    providerId,
+    adapterKey,
+    operation: "STATUS_LOOKUP",
+    syntheticReference: true,
+  };
+}
+
+module.exports = {
+  planSandboxProbe,
+};

--- a/functions/src/providerSettlementEvidence.js
+++ b/functions/src/providerSettlementEvidence.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+const SETTLEMENT_SOURCES = new Set(["BANK_REPORT", "PROVIDER_PAYOUT_REPORT", "MANUAL_VERIFIED"]);
+
+function requiredText(value, field, maxLength = 200) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function positiveMoney(value, field) {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) throw new TypeError(`${field} must be a positive number`);
+  return Math.round(amount * 100) / 100;
+}
+
+function normalizeTimestamp(value, field) {
+  const text = requiredText(value, field, 64);
+  if (!Number.isFinite(Date.parse(text))) throw new TypeError(`${field} must be a valid timestamp`);
+  return new Date(Date.parse(text)).toISOString();
+}
+
+function deriveSettlementEvidenceId(input) {
+  const material = [
+    requiredText(input.partnerId, "partnerId", 128),
+    requiredText(input.providerReference, "providerReference", 200),
+    requiredText(input.externalPaymentId, "externalPaymentId", 200),
+    requiredText(input.currency, "currency", 8).toUpperCase(),
+    String(positiveMoney(input.amount, "amount")),
+  ].join(":");
+  return crypto.createHash("sha256").update(material).digest("hex");
+}
+
+function normalizeSettlementEvidence(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("settlement evidence must be an object");
+  }
+
+  const source = requiredText(input.source, "source", 40).toUpperCase();
+  if (!SETTLEMENT_SOURCES.has(source)) throw new TypeError(`unsupported settlement source: ${source}`);
+
+  const evidence = {
+    partnerId: requiredText(input.partnerId, "partnerId", 128),
+    providerReference: requiredText(input.providerReference, "providerReference", 200),
+    externalPaymentId: requiredText(input.externalPaymentId, "externalPaymentId", 200),
+    amount: positiveMoney(input.amount, "amount"),
+    currency: requiredText(input.currency || "ILS", "currency", 8).toUpperCase(),
+    source,
+    paidAt: normalizeTimestamp(input.paidAt, "paidAt"),
+  };
+  evidence.settlementEvidenceId = deriveSettlementEvidenceId(evidence);
+  return evidence;
+}
+
+function dedupeSettlementEvidence(events) {
+  if (!Array.isArray(events)) throw new TypeError("settlement evidence events must be an array");
+  const unique = new Map();
+  for (const event of events.map(normalizeSettlementEvidence)) {
+    if (!unique.has(event.settlementEvidenceId)) unique.set(event.settlementEvidenceId, event);
+  }
+  return [...unique.values()];
+}
+
+module.exports = {
+  SETTLEMENT_SOURCES,
+  deriveSettlementEvidenceId,
+  normalizeSettlementEvidence,
+  dedupeSettlementEvidence,
+};

--- a/functions/src/providerSettlementReconciliation.js
+++ b/functions/src/providerSettlementReconciliation.js
@@ -1,0 +1,56 @@
+"use strict";
+
+const { COMMISSION_STATES, normalizeCommissionRecord } = require("./providerReconciliation");
+const { normalizeSettlementEvidence } = require("./providerSettlementEvidence");
+
+const SETTLEMENT_RESULTS = Object.freeze({
+  MATCHED: "MATCHED",
+  PARTIAL: "PARTIAL",
+  OVERPAID: "OVERPAID",
+  MISMATCH: "MISMATCH",
+});
+
+function reconcileSettlement(commissionInput, evidenceInput) {
+  const commission = normalizeCommissionRecord(commissionInput);
+  const evidence = normalizeSettlementEvidence(evidenceInput);
+
+  if (commission.state !== COMMISSION_STATES.CONFIRMED && commission.state !== COMMISSION_STATES.PAID) {
+    throw new Error("settlement requires a confirmed commission");
+  }
+  if (commission.partnerId !== evidence.partnerId) {
+    return { result: SETTLEMENT_RESULTS.MISMATCH, reason: "partner mismatch" };
+  }
+  if (commission.providerReference !== evidence.providerReference) {
+    return { result: SETTLEMENT_RESULTS.MISMATCH, reason: "provider reference mismatch" };
+  }
+  if (commission.currency !== evidence.currency) {
+    return { result: SETTLEMENT_RESULTS.MISMATCH, reason: "currency mismatch" };
+  }
+
+  const expected = commission.confirmedAmount || 0;
+  const paid = evidence.amount;
+  const delta = Math.round((paid - expected) * 100) / 100;
+  const result = paid === expected
+    ? SETTLEMENT_RESULTS.MATCHED
+    : paid < expected
+      ? SETTLEMENT_RESULTS.PARTIAL
+      : SETTLEMENT_RESULTS.OVERPAID;
+
+  return {
+    result,
+    reason: result === SETTLEMENT_RESULTS.MATCHED ? "settlement matches confirmed commission" : "settlement amount differs from confirmed commission",
+    commissionId: commission.commissionId,
+    providerReference: commission.providerReference,
+    settlementEvidenceId: evidence.settlementEvidenceId,
+    confirmedAmount: expected,
+    paidAmount: paid,
+    delta,
+    currency: commission.currency,
+    canMarkPaid: result === SETTLEMENT_RESULTS.MATCHED,
+  };
+}
+
+module.exports = {
+  SETTLEMENT_RESULTS,
+  reconcileSettlement,
+};

--- a/functions/src/providerSlaPolicy.js
+++ b/functions/src/providerSlaPolicy.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const SLA_STATES = Object.freeze({
+  HEALTHY: "HEALTHY",
+  WARNING: "WARNING",
+  BREACHED: "BREACHED",
+  UNCONFIGURED: "UNCONFIGURED",
+});
+
+function normalizeSlaPolicy(input) {
+  if (input == null) return null;
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new TypeError("provider SLA policy must be an object");
+  const acknowledgementMs = Number(input.acknowledgementMs);
+  const statusFreshnessMs = Number(input.statusFreshnessMs);
+  if (!Number.isFinite(acknowledgementMs) || acknowledgementMs <= 0) throw new TypeError("acknowledgementMs must be positive");
+  if (!Number.isFinite(statusFreshnessMs) || statusFreshnessMs <= 0) throw new TypeError("statusFreshnessMs must be positive");
+  return {
+    acknowledgementMs: Math.round(acknowledgementMs),
+    statusFreshnessMs: Math.round(statusFreshnessMs),
+  };
+}
+
+function evaluateProviderSla(input = {}) {
+  const policy = normalizeSlaPolicy(input.policy);
+  if (!policy) return { state: SLA_STATES.UNCONFIGURED, reason: "provider SLA policy is not configured" };
+
+  const ackLatencyMs = Number(input.ackLatencyMs);
+  const statusAgeMs = Number(input.statusAgeMs);
+  const ackRatio = Number.isFinite(ackLatencyMs) && ackLatencyMs >= 0 ? ackLatencyMs / policy.acknowledgementMs : 0;
+  const statusRatio = Number.isFinite(statusAgeMs) && statusAgeMs >= 0 ? statusAgeMs / policy.statusFreshnessMs : 0;
+  const worstRatio = Math.max(ackRatio, statusRatio);
+
+  if (worstRatio > 1) return { state: SLA_STATES.BREACHED, reason: "provider SLA threshold exceeded", worstRatio };
+  if (worstRatio >= 0.8) return { state: SLA_STATES.WARNING, reason: "provider SLA is approaching threshold", worstRatio };
+  return { state: SLA_STATES.HEALTHY, reason: "provider SLA within threshold", worstRatio };
+}
+
+module.exports = {
+  SLA_STATES,
+  normalizeSlaPolicy,
+  evaluateProviderSla,
+};

--- a/functions/src/providerVerifiedEvidenceIntake.js
+++ b/functions/src/providerVerifiedEvidenceIntake.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const { normalizeProviderEvidence } = require("./providerEvidenceIngestion");
+
+const SIGNED_SOURCES = new Set(["WEBHOOK", "POSTBACK"]);
+
+function requiredObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+  return value;
+}
+
+function ingestVerifiedProviderEvidence(input, options = {}) {
+  const source = requiredObject(input, "verified evidence intake");
+  const evidence = requiredObject(source.evidence, "evidence");
+  const evidenceSource = typeof evidence.source === "string" ? evidence.source.trim().toUpperCase() : "";
+
+  if (SIGNED_SOURCES.has(evidenceSource)) {
+    const verification = requiredObject(source.verification, "verification");
+    if (verification.verified !== true) {
+      throw new Error("signed provider evidence requires verified webhook authenticity");
+    }
+    if (!Number.isFinite(Number(verification.timestampMs))) {
+      throw new TypeError("verified webhook evidence requires verification timestamp evidence");
+    }
+  }
+
+  return normalizeProviderEvidence(evidence, options);
+}
+
+module.exports = {
+  SIGNED_SOURCES,
+  ingestVerifiedProviderEvidence,
+};

--- a/functions/src/providerWebhookVerification.js
+++ b/functions/src/providerWebhookVerification.js
@@ -1,0 +1,105 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+const DEFAULT_REPLAY_WINDOW_MS = 5 * 60 * 1000;
+const MAX_REPLAY_WINDOW_MS = 60 * 60 * 1000;
+const SIGNATURE_PREFIX = "sha256=";
+
+function requiredText(value, field, maxLength = 4096) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) throw new TypeError(`${field} is required`);
+  if (text.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return text;
+}
+
+function normalizeReplayWindow(value) {
+  if (value == null) return DEFAULT_REPLAY_WINDOW_MS;
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0 || number > MAX_REPLAY_WINDOW_MS) {
+    throw new TypeError(`replayWindowMs must be an integer between 1 and ${MAX_REPLAY_WINDOW_MS}`);
+  }
+  return number;
+}
+
+function normalizeTimestampMs(value, field = "timestampMs") {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) throw new TypeError(`${field} must be a positive finite timestamp`);
+  return Math.round(number);
+}
+
+function rawBodyBuffer(value) {
+  if (Buffer.isBuffer(value)) return value;
+  if (typeof value === "string") return Buffer.from(value, "utf8");
+  throw new TypeError("rawBody must be a string or Buffer");
+}
+
+function normalizeSignature(value) {
+  const text = requiredText(value, "signature", 256).toLowerCase();
+  if (!text.startsWith(SIGNATURE_PREFIX)) {
+    throw new TypeError("signature must use sha256= prefix");
+  }
+  const hex = text.slice(SIGNATURE_PREFIX.length);
+  if (!/^[a-f0-9]{64}$/.test(hex)) throw new TypeError("signature must contain a 64-character sha256 hex digest");
+  return hex;
+}
+
+function signingMaterial(timestampMs, body) {
+  return Buffer.concat([
+    Buffer.from(String(timestampMs), "utf8"),
+    Buffer.from(".", "utf8"),
+    body,
+  ]);
+}
+
+function deriveWebhookSignature({ rawBody, timestampMs, secretMaterial }) {
+  const body = rawBodyBuffer(rawBody);
+  const timestamp = normalizeTimestampMs(timestampMs);
+  const secret = requiredText(secretMaterial, "secretMaterial", 4096);
+  const digest = crypto.createHmac("sha256", secret).update(signingMaterial(timestamp, body)).digest("hex");
+  return `${SIGNATURE_PREFIX}${digest}`;
+}
+
+function verifyProviderWebhook(input = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("webhook verification input must be an object");
+  }
+
+  const body = rawBodyBuffer(input.rawBody);
+  const timestampMs = normalizeTimestampMs(input.timestampMs);
+  const nowMs = input.nowMs == null ? Date.now() : normalizeTimestampMs(input.nowMs, "nowMs");
+  const replayWindowMs = normalizeReplayWindow(input.replayWindowMs);
+  const secret = requiredText(input.secretMaterial, "secretMaterial", 4096);
+  const suppliedHex = normalizeSignature(input.signature);
+  const ageMs = Math.abs(nowMs - timestampMs);
+
+  if (ageMs > replayWindowMs) {
+    return {
+      verified: false,
+      reason: "webhook timestamp is outside the replay window",
+      timestampMs,
+      ageMs,
+    };
+  }
+
+  const expectedHex = crypto.createHmac("sha256", secret)
+    .update(signingMaterial(timestampMs, body))
+    .digest("hex");
+  const supplied = Buffer.from(suppliedHex, "hex");
+  const expected = Buffer.from(expectedHex, "hex");
+  const verified = supplied.length === expected.length && crypto.timingSafeEqual(supplied, expected);
+
+  return {
+    verified,
+    reason: verified ? "provider webhook signature verified" : "provider webhook signature mismatch",
+    timestampMs,
+    ageMs,
+  };
+}
+
+module.exports = {
+  DEFAULT_REPLAY_WINDOW_MS,
+  MAX_REPLAY_WINDOW_MS,
+  deriveWebhookSignature,
+  verifyProviderWebhook,
+};

--- a/functions/test/providerAdapterHealthScore.test.js
+++ b/functions/test/providerAdapterHealthScore.test.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { calculateAdapterHealthScore } = require("../src/providerAdapterHealthScore");
+
+test("perfect provider health scores 100", () => {
+  assert.deepEqual(calculateAdapterHealthScore({ successRate: 1, ackWithinSlaRate: 1, freshnessRate: 1, deadLetterRate: 0, authFailureRate: 0 }), { score: 100, state: "HEALTHY" });
+});
+
+test("elevated failures degrade provider health", () => {
+  const result = calculateAdapterHealthScore({ successRate: 0.6, ackWithinSlaRate: 0.7, freshnessRate: 0.8, deadLetterRate: 0.2, authFailureRate: 0.1 });
+  assert.ok(result.score < 90);
+  assert.notEqual(result.state, "HEALTHY");
+});
+
+test("rates are clamped instead of creating impossible scores", () => {
+  const result = calculateAdapterHealthScore({ successRate: 2, ackWithinSlaRate: 2, freshnessRate: 2, deadLetterRate: -1, authFailureRate: -1 });
+  assert.equal(result.score, 100);
+});

--- a/functions/test/providerAdapterRegistry.test.js
+++ b/functions/test/providerAdapterRegistry.test.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  CAPABILITIES,
+  normalizeAdapterDescriptor,
+  createAdapterRegistry,
+  assertAdapterCapability,
+} = require("../src/providerAdapterRegistry");
+
+function descriptor(overrides = {}) {
+  return {
+    adapterKey: "provider-a-v1",
+    providerId: "provider-a",
+    version: "1",
+    implemented: true,
+    capabilities: [CAPABILITIES.DISPATCH, CAPABILITIES.STATUS_LOOKUP],
+    ...overrides,
+  };
+}
+
+test("implemented adapter declares only known capabilities", () => {
+  const normalized = normalizeAdapterDescriptor(descriptor());
+  assert.deepEqual(normalized.capabilities, [CAPABILITIES.DISPATCH, CAPABILITIES.STATUS_LOOKUP].sort());
+});
+
+test("unimplemented adapter cannot claim capabilities", () => {
+  assert.throws(() => normalizeAdapterDescriptor(descriptor({ implemented: false })), /cannot declare capabilities/);
+});
+
+test("unknown capability is rejected", () => {
+  assert.throws(() => normalizeAdapterDescriptor(descriptor({ capabilities: ["MAGIC"] })), /unsupported adapter capability/);
+});
+
+test("registry rejects duplicate adapter keys", () => {
+  assert.throws(() => createAdapterRegistry([descriptor(), descriptor()]), /duplicate adapterKey/);
+});
+
+test("capability assertion succeeds only when explicitly implemented", () => {
+  const registry = createAdapterRegistry([descriptor()]);
+  assert.equal(assertAdapterCapability(registry, "provider-a-v1", CAPABILITIES.DISPATCH).providerId, "provider-a");
+  assert.throws(() => assertAdapterCapability(registry, "provider-a-v1", CAPABILITIES.COMMISSION_RECONCILIATION), /does not support capability/);
+});
+
+test("missing adapter never masquerades as implemented", () => {
+  const registry = createAdapterRegistry([descriptor()]);
+  assert.throws(() => assertAdapterCapability(registry, "missing-adapter", CAPABILITIES.DISPATCH), /not implemented/);
+});

--- a/functions/test/providerCircuitBreaker.test.js
+++ b/functions/test/providerCircuitBreaker.test.js
@@ -1,0 +1,92 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  CIRCUIT_STATES,
+  normalizeCircuitState,
+  evaluateCircuit,
+  recordCircuitSuccess,
+  recordCircuitFailure,
+} = require("../src/providerCircuitBreaker");
+
+const NOW = 1_000_000;
+
+function closed(overrides = {}) {
+  return {
+    state: CIRCUIT_STATES.CLOSED,
+    failureThreshold: 3,
+    recoveryTimeoutMs: 60_000,
+    consecutiveFailures: 0,
+    ...overrides,
+  };
+}
+
+test("closed circuit allows dispatch", () => {
+  assert.deepEqual(evaluateCircuit(closed(), NOW), {
+    state: CIRCUIT_STATES.CLOSED,
+    allowRequest: true,
+    delayMs: 0,
+    probe: false,
+  });
+});
+
+test("circuit opens only after configured consecutive failure threshold", () => {
+  const first = recordCircuitFailure(closed(), NOW);
+  const second = recordCircuitFailure(first, NOW + 1);
+  const third = recordCircuitFailure(second, NOW + 2);
+  assert.equal(first.state, CIRCUIT_STATES.CLOSED);
+  assert.equal(second.state, CIRCUIT_STATES.CLOSED);
+  assert.equal(third.state, CIRCUIT_STATES.OPEN);
+  assert.equal(third.openedAtMs, NOW + 2);
+});
+
+test("open circuit blocks dispatch until recovery timeout", () => {
+  const open = {
+    ...closed({ state: CIRCUIT_STATES.OPEN, consecutiveFailures: 3 }),
+    openedAtMs: NOW,
+  };
+  const decision = evaluateCircuit(open, NOW + 10_000);
+  assert.equal(decision.allowRequest, false);
+  assert.equal(decision.delayMs, 50_000);
+});
+
+test("open circuit transitions to a single half-open probe after timeout", () => {
+  const open = {
+    ...closed({ state: CIRCUIT_STATES.OPEN, consecutiveFailures: 3 }),
+    openedAtMs: NOW,
+  };
+  const decision = evaluateCircuit(open, NOW + 60_000);
+  assert.equal(decision.state, CIRCUIT_STATES.HALF_OPEN);
+  assert.equal(decision.allowRequest, true);
+  assert.equal(decision.probe, true);
+
+  const blocked = evaluateCircuit({ ...open, probeInFlight: true }, NOW + 60_000);
+  assert.equal(blocked.allowRequest, false);
+});
+
+test("successful probe closes and resets circuit", () => {
+  const reset = recordCircuitSuccess({
+    ...closed(),
+    state: CIRCUIT_STATES.HALF_OPEN,
+    consecutiveFailures: 3,
+    probeInFlight: true,
+  });
+  assert.equal(reset.state, CIRCUIT_STATES.CLOSED);
+  assert.equal(reset.consecutiveFailures, 0);
+  assert.equal(reset.openedAtMs, null);
+});
+
+test("failed half-open probe reopens immediately", () => {
+  const failed = recordCircuitFailure({
+    ...closed(),
+    state: CIRCUIT_STATES.HALF_OPEN,
+    consecutiveFailures: 3,
+  }, NOW);
+  assert.equal(failed.state, CIRCUIT_STATES.OPEN);
+  assert.equal(failed.openedAtMs, NOW);
+});
+
+test("invalid open state without openedAt timestamp is rejected", () => {
+  assert.throws(() => normalizeCircuitState({ state: CIRCUIT_STATES.OPEN }), /openedAtMs/);
+});

--- a/functions/test/providerCommissionEvidenceAdapter.test.js
+++ b/functions/test/providerCommissionEvidenceAdapter.test.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { COMMISSION_STATES } = require("../src/providerReconciliation");
+const { reconcileCommissionFromProviderEvidence } = require("../src/providerCommissionEvidenceAdapter");
+
+function current(overrides = {}) {
+  return {
+    commissionId: "commission-1",
+    partnerId: "provider-a",
+    providerReference: "crm-123",
+    state: COMMISSION_STATES.EXPECTED,
+    expectedAmount: 75.5,
+    confirmedAmount: null,
+    currency: "ILS",
+    ...overrides,
+  };
+}
+
+function evidence(overrides = {}) {
+  return {
+    evidenceEventId: "evt-hash-1",
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    kind: "COMMISSION",
+    source: "WEBHOOK",
+    observedAt: "2026-08-08T20:00:00.000Z",
+    amount: 75.5,
+    currency: "ILS",
+    ...overrides,
+  };
+}
+
+function correlation(overrides = {}) {
+  return {
+    matched: true,
+    dispatchId: "dispatch-1",
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    evidenceEventId: "evt-hash-1",
+    kind: "COMMISSION",
+    observedAt: "2026-08-08T20:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("correlated provider commission evidence confirms expected commission", () => {
+  const reconciled = reconcileCommissionFromProviderEvidence(current(), evidence(), correlation());
+  assert.equal(reconciled.state, COMMISSION_STATES.CONFIRMED);
+  assert.equal(reconciled.confirmedAmount, 75.5);
+  assert.equal(reconciled.currency, "ILS");
+  assert.equal(reconciled.evidenceSource, "PROVIDER_WEBHOOK");
+  assert.equal(reconciled.evidenceObservedAt, "2026-08-08T20:00:00.000Z");
+});
+
+test("adapter never marks a commission paid from generic commission evidence", () => {
+  const reconciled = reconcileCommissionFromProviderEvidence(current(), evidence(), correlation());
+  assert.notEqual(reconciled.state, COMMISSION_STATES.PAID);
+});
+
+test("uncorrelated evidence cannot confirm commission", () => {
+  assert.throws(() => reconcileCommissionFromProviderEvidence(
+    current(),
+    evidence(),
+    correlation({ matched: false }),
+  ), /correlated/);
+});
+
+test("non-commission provider evidence cannot confirm commission", () => {
+  assert.throws(() => reconcileCommissionFromProviderEvidence(
+    current(),
+    evidence({ kind: "ACTIVATION" }),
+    correlation({ kind: "ACTIVATION" }),
+  ), /only COMMISSION/);
+});
+
+test("provider reference mismatch cannot cross-attribute commission", () => {
+  assert.throws(() => reconcileCommissionFromProviderEvidence(
+    current(),
+    evidence({ providerReference: "crm-other" }),
+    correlation(),
+  ), /provider reference/);
+});
+
+test("evidence event id must match the correlated event", () => {
+  assert.throws(() => reconcileCommissionFromProviderEvidence(
+    current(),
+    evidence({ evidenceEventId: "evt-other" }),
+    correlation(),
+  ), /event does not match/);
+});
+
+test("currency mismatch cannot silently change commercial accounting", () => {
+  assert.throws(() => reconcileCommissionFromProviderEvidence(
+    current(),
+    evidence({ currency: "USD" }),
+    correlation(),
+  ), /currency/);
+});
+
+test("zero or negative provider commission evidence is rejected", () => {
+  assert.throws(() => reconcileCommissionFromProviderEvidence(current(), evidence({ amount: 0 }), correlation()), /positive amount/);
+  assert.throws(() => reconcileCommissionFromProviderEvidence(current(), evidence({ amount: -1 }), correlation()), /positive amount/);
+});

--- a/functions/test/providerConsentIntentGate.test.js
+++ b/functions/test/providerConsentIntentGate.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { verifyProviderDispatchIntent } = require("../src/providerConsentIntentGate");
+
+function intent(overrides = {}) {
+  return {
+    accepted: true,
+    action: "CONTINUE_TO_OFFER",
+    offerId: "offer-1",
+    providerId: "provider-a",
+    consentVersion: "v1",
+    acceptedAt: "2026-08-08T20:00:00Z",
+    ...overrides,
+  };
+}
+
+test("accepts explicit continue-to-offer intent", () => {
+  const result = verifyProviderDispatchIntent(intent());
+  assert.equal(result.accepted, true);
+  assert.equal(result.action, "CONTINUE_TO_OFFER");
+});
+
+test("rejects missing explicit acceptance", () => {
+  assert.throws(() => verifyProviderDispatchIntent(intent({ accepted: false })), /explicit user acceptance/);
+});
+
+test("rejects unrelated action", () => {
+  assert.throws(() => verifyProviderDispatchIntent(intent({ action: "OPEN_SCREEN" })), /continue-to-offer intent/);
+});
+
+test("requires valid acceptance timestamp", () => {
+  assert.throws(() => verifyProviderDispatchIntent(intent({ acceptedAt: "invalid" })), /valid timestamp/);
+});

--- a/functions/test/providerContractConfig.test.js
+++ b/functions/test/providerContractConfig.test.js
@@ -1,0 +1,70 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  normalizeProviderContract,
+  isContractActive,
+  buildAttribution,
+} = require("../src/providerContractConfig");
+
+function contract(overrides = {}) {
+  return {
+    contractId: "contract-1",
+    providerId: "provider-a",
+    commercialModel: "CPA",
+    deliveryMode: "API",
+    conversionEvidenceMode: "POSTBACK",
+    adapterKey: "provider-a-v1",
+    credentialSecretName: "PROVIDER_A_API_CREDENTIALS",
+    attributionField: "sub_id",
+    campaignId: "campaign-1",
+    activeFrom: "2026-08-01T00:00:00Z",
+    activeUntil: "2026-09-01T00:00:00Z",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+test("normalizes an attributable provider contract without credential material", () => {
+  const normalized = normalizeProviderContract(contract());
+  assert.equal(normalized.commercialModel, "CPA");
+  assert.equal(normalized.credentialSecretName, "PROVIDER_A_API_CREDENTIALS");
+});
+
+test("remote delivery requires a Secret Manager reference", () => {
+  assert.throws(() => normalizeProviderContract(contract({ credentialSecretName: "" })), /Secret Manager reference/);
+});
+
+test("credential material is rejected from contract config", () => {
+  assert.throws(() => normalizeProviderContract(contract({ credentialSecretName: "sk-secret-material" })), /secret reference/);
+});
+
+test("non-direct commercial models require attribution field", () => {
+  assert.throws(() => normalizeProviderContract(contract({ attributionField: "" })), /attributionField/);
+});
+
+test("contract activity is deterministic and independent of commission amount", () => {
+  const midAugust = Date.parse("2026-08-15T12:00:00Z");
+  assert.equal(isContractActive(contract(), midAugust), true);
+  assert.equal(isContractActive(contract({ enabled: false }), midAugust), false);
+  assert.equal(isContractActive(contract(), Date.parse("2026-09-02T00:00:00Z")), false);
+});
+
+test("buildAttribution binds external provider attribution to clickId", () => {
+  assert.deepEqual(buildAttribution(contract(), "click-123"), {
+    sub_id: "click-123",
+    campaignId: "campaign-1",
+  });
+});
+
+test("direct agreements may omit external attribution field", () => {
+  const direct = contract({
+    commercialModel: "DIRECT",
+    deliveryMode: "MANUAL_OPERATOR",
+    conversionEvidenceMode: "MANUAL_VERIFIED",
+    credentialSecretName: "",
+    attributionField: "",
+  });
+  assert.deepEqual(buildAttribution(direct, "click-123"), {});
+});

--- a/functions/test/providerContractConfig.test.js
+++ b/functions/test/providerContractConfig.test.js
@@ -44,6 +44,12 @@ test("non-direct commercial models require attribution field", () => {
   assert.throws(() => normalizeProviderContract(contract({ attributionField: "" })), /attributionField/);
 });
 
+test("contract active window requires valid timestamps in chronological order", () => {
+  assert.throws(() => normalizeProviderContract(contract({ activeFrom: "not-a-date" })), /activeFrom must be a valid timestamp/);
+  assert.throws(() => normalizeProviderContract(contract({ activeUntil: "not-a-date" })), /activeUntil must be a valid timestamp/);
+  assert.throws(() => normalizeProviderContract(contract({ activeUntil: "2026-07-31T23:59:59Z" })), /after activeFrom/);
+});
+
 test("contract activity is deterministic and independent of commission amount", () => {
   const midAugust = Date.parse("2026-08-15T12:00:00Z");
   assert.equal(isContractActive(contract(), midAugust), true);

--- a/functions/test/providerCredentialRotationPolicy.test.js
+++ b/functions/test/providerCredentialRotationPolicy.test.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { ROTATION_STATES, evaluateCredentialRotation } = require("../src/providerCredentialRotationPolicy");
+
+const NOW = Date.parse("2026-08-08T20:00:00Z");
+
+test("missing expiry remains explicitly unconfigured", () => {
+  assert.equal(evaluateCredentialRotation({ nowMs: NOW }).state, ROTATION_STATES.UNCONFIGURED);
+});
+
+test("healthy credential stays active", () => {
+  const result = evaluateCredentialRotation({ nowMs: NOW, expiresAt: "2026-09-08T20:00:00Z" });
+  assert.equal(result.state, ROTATION_STATES.HEALTHY);
+  assert.equal(result.blocksDispatch, false);
+});
+
+test("credential near expiry asks for rotation without blocking yet", () => {
+  const result = evaluateCredentialRotation({ nowMs: NOW, expiresAt: "2026-08-10T20:00:00Z" });
+  assert.equal(result.state, ROTATION_STATES.ROTATE_SOON);
+  assert.equal(result.blocksDispatch, false);
+});
+
+test("expired credential blocks dispatch", () => {
+  const result = evaluateCredentialRotation({ nowMs: NOW, expiresAt: "2026-08-07T20:00:00Z" });
+  assert.equal(result.state, ROTATION_STATES.EXPIRED);
+  assert.equal(result.blocksDispatch, true);
+});

--- a/functions/test/providerDataMinimization.test.js
+++ b/functions/test/providerDataMinimization.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { buildMinimizedProviderPayload } = require("../src/providerDataMinimization");
+
+function payload(overrides = {}) {
+  return {
+    contactName: "Test User",
+    phone: "0500000000",
+    contactEmail: "test@example.com",
+    requestedProvider: "provider-a",
+    category: "internet",
+    offerId: "offer-1",
+    consentVersion: "v1",
+    source: "anything",
+    ...overrides,
+  };
+}
+
+test("keeps only allowed external fields and canonical source", () => {
+  const result = buildMinimizedProviderPayload(payload());
+  assert.equal(result.source, "CLICKANDSAVE_VERIFIED_OPPORTUNITY");
+  assert.deepEqual(Object.keys(result).sort(), ["category", "consentVersion", "contactEmail", "contactName", "offerId", "phone", "requestedProvider", "source"].sort());
+});
+
+test("forbids internal financial and Gmail context", () => {
+  assert.throws(() => buildMinimizedProviderPayload(payload({ gmailRaw: "raw" })), /forbidden internal field/);
+  assert.throws(() => buildMinimizedProviderPayload(payload({ currentSpend: 300 })), /forbidden internal field/);
+  assert.throws(() => buildMinimizedProviderPayload(payload({ commissionAmount: 50 })), /forbidden internal field/);
+});
+
+test("requires minimum contact and offer fields", () => {
+  assert.throws(() => buildMinimizedProviderPayload(payload({ offerId: "" })), /offerId is required/);
+});

--- a/functions/test/providerDispatchEnvelope.test.js
+++ b/functions/test/providerDispatchEnvelope.test.js
@@ -26,6 +26,7 @@ function input(overrides = {}) {
       requestedProvider: "Provider A",
       category: "אינטרנט",
       offerId: "offer-1",
+      consentVersion: "v1",
     },
     ...overrides,
   };
@@ -38,18 +39,46 @@ test("dispatch identity is deterministic for the same lead/provider/offer/contra
   assert.equal(first.length, 64);
 });
 
-test("dispatch envelope starts READY with zero attempts", () => {
+test("dispatch envelope starts READY with zero attempts and normalized minimal payload", () => {
   const envelope = buildDispatchEnvelope(input());
   assert.equal(envelope.state, QUEUE_STATES.READY);
   assert.equal(envelope.attempt, 0);
+  assert.deepEqual(envelope.payload, {
+    leadId: "lead-1",
+    contactName: "Test User",
+    phone: "0501234567",
+    contactEmail: "test@example.com",
+    requestedProvider: "Provider A",
+    category: "אינטרנט",
+    offerId: "offer-1",
+    consentVersion: "v1",
+    source: "CLICKANDSAVE_VERIFIED_OPPORTUNITY",
+  });
 });
 
-test("provider payload rejects internal financial and identity context", () => {
-  for (const forbidden of ["uid", "gmailContent", "currentMonthlyCost", "potentialMonthlySaving", "commissionAmount"]) {
+test("provider payload rejects every field outside the minimum-data allowlist", () => {
+  for (const forbidden of ["uid", "gmailContent", "currentMonthlyCost", "potentialMonthlySaving", "commissionAmount", "metadata"]) {
+    const value = forbidden === "metadata" ? { gmailContent: "private" } : "private";
     assert.throws(() => buildDispatchEnvelope(input({
-      payload: { ...input().payload, [forbidden]: "private" },
-    })), /forbidden field/);
+      payload: { ...input().payload, [forbidden]: value },
+    })), /unsupported field/);
   }
+});
+
+test("provider payload identifiers must match the dispatch envelope", () => {
+  assert.throws(() => buildDispatchEnvelope(input({
+    payload: { ...input().payload, leadId: "other-lead" },
+  })), /leadId does not match/);
+
+  assert.throws(() => buildDispatchEnvelope(input({
+    payload: { ...input().payload, offerId: "other-offer" },
+  })), /offerId does not match/);
+});
+
+test("provider payload cannot override the verified source marker", () => {
+  assert.throws(() => buildDispatchEnvelope(input({
+    payload: { ...input().payload, source: "MANUAL" },
+  })), /source is unsupported/);
 });
 
 test("attempt transitions READY to IN_FLIGHT and increments exactly once", () => {

--- a/functions/test/providerDispatchEnvelope.test.js
+++ b/functions/test/providerDispatchEnvelope.test.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  QUEUE_STATES,
+  dispatchId,
+  buildDispatchEnvelope,
+  beginAttempt,
+  applyAcknowledgement,
+  applyFailure,
+} = require("../src/providerDispatchEnvelope");
+
+function input(overrides = {}) {
+  return {
+    leadId: "lead-1",
+    providerId: "provider-a",
+    offerId: "offer-1",
+    contractId: "contract-1",
+    adapterKey: "provider-a-v1",
+    payload: {
+      leadId: "lead-1",
+      contactName: "Test User",
+      phone: "0501234567",
+      contactEmail: "test@example.com",
+      requestedProvider: "Provider A",
+      category: "אינטרנט",
+      offerId: "offer-1",
+    },
+    ...overrides,
+  };
+}
+
+test("dispatch identity is deterministic for the same lead/provider/offer/contract", () => {
+  const first = dispatchId(input());
+  const second = dispatchId(input());
+  assert.equal(first, second);
+  assert.equal(first.length, 64);
+});
+
+test("dispatch envelope starts READY with zero attempts", () => {
+  const envelope = buildDispatchEnvelope(input());
+  assert.equal(envelope.state, QUEUE_STATES.READY);
+  assert.equal(envelope.attempt, 0);
+});
+
+test("provider payload rejects internal financial and identity context", () => {
+  for (const forbidden of ["uid", "gmailContent", "currentMonthlyCost", "potentialMonthlySaving", "commissionAmount"]) {
+    assert.throws(() => buildDispatchEnvelope(input({
+      payload: { ...input().payload, [forbidden]: "private" },
+    })), /forbidden field/);
+  }
+});
+
+test("attempt transitions READY to IN_FLIGHT and increments exactly once", () => {
+  const inFlight = beginAttempt(buildDispatchEnvelope(input()));
+  assert.equal(inFlight.state, QUEUE_STATES.IN_FLIGHT);
+  assert.equal(inFlight.attempt, 1);
+  assert.throws(() => beginAttempt(inFlight), /not ready/);
+});
+
+test("acknowledgement requires provider reference and makes dispatch terminal", () => {
+  const inFlight = beginAttempt(buildDispatchEnvelope(input()));
+  assert.throws(() => applyAcknowledgement(inFlight, ""), /providerReference/);
+  const acked = applyAcknowledgement(inFlight, "crm-123");
+  assert.equal(acked.state, QUEUE_STATES.ACKNOWLEDGED);
+  assert.equal(acked.providerReference, "crm-123");
+  assert.throws(() => beginAttempt(acked), /terminal/);
+});
+
+test("retryable failure enters RETRY_WAIT while permanent failure dead-letters", () => {
+  const inFlight = beginAttempt(buildDispatchEnvelope(input()));
+  const retry = applyFailure(inFlight, { retryable: true, errorCode: "HTTP_503" });
+  assert.equal(retry.state, QUEUE_STATES.RETRY_WAIT);
+  assert.equal(beginAttempt(retry).attempt, 2);
+
+  const inFlightAgain = beginAttempt(buildDispatchEnvelope(input()));
+  const dead = applyFailure(inFlightAgain, { retryable: false, errorCode: "INVALID_REQUEST" });
+  assert.equal(dead.state, QUEUE_STATES.DEAD_LETTER);
+  assert.throws(() => beginAttempt(dead), /terminal/);
+});

--- a/functions/test/providerDispatchPlanner.test.js
+++ b/functions/test/providerDispatchPlanner.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { createAdapterRegistry, CAPABILITIES } = require("../src/providerAdapterRegistry");
+const { buildDispatchEnvelope, beginAttempt, applyAcknowledgement, applyFailure } = require("../src/providerDispatchEnvelope");
+const { PLAN_ACTIONS, planDispatch } = require("../src/providerDispatchPlanner");
+
+function registry(capabilities = [CAPABILITIES.DISPATCH]) {
+  return createAdapterRegistry([{
+    adapterKey: "provider-a-v1",
+    providerId: "provider-a",
+    implemented: true,
+    capabilities,
+  }]);
+}
+
+function providerConfig(overrides = {}) {
+  return {
+    providerId: "provider-a",
+    adapterKey: "provider-a-v1",
+    enabled: true,
+    adapterImplemented: true,
+    credentialsConfigured: true,
+    connectionVerified: true,
+    ...overrides,
+  };
+}
+
+function contract(overrides = {}) {
+  return {
+    contractId: "contract-1",
+    providerId: "provider-a",
+    commercialModel: "CPA",
+    deliveryMode: "API",
+    conversionEvidenceMode: "POSTBACK",
+    adapterKey: "provider-a-v1",
+    credentialSecretName: "PROVIDER_A_API_CREDENTIALS",
+    attributionField: "sub_id",
+    activeFrom: "2026-08-01T00:00:00Z",
+    activeUntil: "2026-09-01T00:00:00Z",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function envelope() {
+  return buildDispatchEnvelope({
+    leadId: "lead-1",
+    providerId: "provider-a",
+    offerId: "offer-1",
+    contractId: "contract-1",
+    adapterKey: "provider-a-v1",
+    payload: { leadId: "lead-1", offerId: "offer-1", phone: "0501234567" },
+  });
+}
+
+function input(overrides = {}) {
+  return {
+    envelope: envelope(),
+    providerConfig: providerConfig(),
+    contract: contract(),
+    adapterRegistry: registry(),
+    nowMs: Date.parse("2026-08-15T12:00:00Z"),
+    ...overrides,
+  };
+}
+
+test("ready dispatch is planned only after provider, contract and adapter capability all verify", () => {
+  const plan = planDispatch(input());
+  assert.equal(plan.action, PLAN_ACTIONS.DISPATCH);
+});
+
+test("planner rejects provider that is not actually connected", () => {
+  assert.throws(() => planDispatch(input({
+    providerConfig: providerConfig({ connectionVerified: false }),
+  })), /not actually connected/);
+});
+
+test("planner rejects adapter without DISPATCH capability", () => {
+  assert.throws(() => planDispatch(input({
+    adapterRegistry: registry([CAPABILITIES.STATUS_LOOKUP]),
+  })), /does not support capability/);
+});
+
+test("inactive commercial contract never dispatches", () => {
+  const plan = planDispatch(input({ nowMs: Date.parse("2026-10-01T00:00:00Z") }));
+  assert.equal(plan.action, PLAN_ACTIONS.NOOP);
+  assert.match(plan.reason, /inactive/);
+});
+
+test("terminal acknowledged dispatch is a no-op", () => {
+  const acknowledged = applyAcknowledgement(beginAttempt(envelope()), "crm-123");
+  const plan = planDispatch(input({ envelope: acknowledged }));
+  assert.equal(plan.action, PLAN_ACTIONS.NOOP);
+});
+
+test("in-flight dispatch is never duplicated", () => {
+  const inFlight = beginAttempt(envelope());
+  const plan = planDispatch(input({ envelope: inFlight }));
+  assert.equal(plan.action, PLAN_ACTIONS.WAIT);
+});
+
+test("retry wait honors bounded backoff", () => {
+  const failed = applyFailure(beginAttempt(envelope()), { retryable: true, errorCode: "HTTP_503" });
+  const plan = planDispatch(input({ envelope: failed, retryAfterMs: 120000 }));
+  assert.equal(plan.action, PLAN_ACTIONS.WAIT);
+  assert.equal(plan.delayMs, 120000);
+});
+
+test("retry limit routes item to dead letter instead of endless retry", () => {
+  const failed = { ...applyFailure(beginAttempt(envelope()), { retryable: true, errorCode: "HTTP_503" }), attempt: 5 };
+  const plan = planDispatch(input({ envelope: failed, maxAttempts: 5 }));
+  assert.equal(plan.action, PLAN_ACTIONS.DEAD_LETTER);
+});
+
+test("provider, contract and adapter identity must agree", () => {
+  assert.throws(() => planDispatch(input({ contract: contract({ providerId: "provider-b" }) })), /does not match provider contract/);
+});

--- a/functions/test/providerDispatchPlanner.test.js
+++ b/functions/test/providerDispatchPlanner.test.js
@@ -51,7 +51,16 @@ function envelope() {
     offerId: "offer-1",
     contractId: "contract-1",
     adapterKey: "provider-a-v1",
-    payload: { leadId: "lead-1", offerId: "offer-1", phone: "0501234567" },
+    payload: {
+      leadId: "lead-1",
+      contactName: "Test User",
+      phone: "0501234567",
+      contactEmail: "test@example.com",
+      requestedProvider: "Provider A",
+      category: "אינטרנט",
+      offerId: "offer-1",
+      consentVersion: "v1",
+    },
   });
 }
 

--- a/functions/test/providerDispatchPlanner.test.js
+++ b/functions/test/providerDispatchPlanner.test.js
@@ -4,6 +4,8 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const { createAdapterRegistry, CAPABILITIES } = require("../src/providerAdapterRegistry");
 const { buildDispatchEnvelope, beginAttempt, applyAcknowledgement, applyFailure } = require("../src/providerDispatchEnvelope");
+const { CIRCUIT_STATES } = require("../src/providerCircuitBreaker");
+const { RATE_LIMIT_ACTIONS } = require("../src/providerRateLimitPlanner");
 const { PLAN_ACTIONS, planDispatch } = require("../src/providerDispatchPlanner");
 
 function registry(capabilities = [CAPABILITIES.DISPATCH]) {
@@ -78,6 +80,8 @@ function input(overrides = {}) {
 test("ready dispatch is planned only after provider, contract and adapter capability all verify", () => {
   const plan = planDispatch(input());
   assert.equal(plan.action, PLAN_ACTIONS.DISPATCH);
+  assert.equal(plan.circuitState, CIRCUIT_STATES.CLOSED);
+  assert.equal(plan.rateLimitAction, RATE_LIMIT_ACTIONS.UNCONFIGURED);
 });
 
 test("planner rejects provider that is not actually connected", () => {
@@ -125,4 +129,68 @@ test("retry limit routes item to dead letter instead of endless retry", () => {
 
 test("provider, contract and adapter identity must agree", () => {
   assert.throws(() => planDispatch(input({ contract: contract({ providerId: "provider-b" }) })), /does not match provider contract/);
+});
+
+test("open provider circuit blocks dispatch until the recovery window", () => {
+  const nowMs = Date.parse("2026-08-15T12:00:00Z");
+  const plan = planDispatch(input({
+    nowMs,
+    circuitState: {
+      state: CIRCUIT_STATES.OPEN,
+      failureThreshold: 5,
+      recoveryTimeoutMs: 60_000,
+      consecutiveFailures: 5,
+      openedAtMs: nowMs - 10_000,
+    },
+  }));
+  assert.equal(plan.action, PLAN_ACTIONS.WAIT);
+  assert.equal(plan.delayMs, 50_000);
+  assert.equal(plan.circuitState, CIRCUIT_STATES.OPEN);
+});
+
+test("expired open circuit permits exactly a half-open probe decision", () => {
+  const nowMs = Date.parse("2026-08-15T12:00:00Z");
+  const plan = planDispatch(input({
+    nowMs,
+    circuitState: {
+      state: CIRCUIT_STATES.OPEN,
+      failureThreshold: 5,
+      recoveryTimeoutMs: 60_000,
+      consecutiveFailures: 5,
+      openedAtMs: nowMs - 60_000,
+    },
+  }));
+  assert.equal(plan.action, PLAN_ACTIONS.DISPATCH);
+  assert.equal(plan.circuitState, CIRCUIT_STATES.HALF_OPEN);
+  assert.equal(plan.circuitProbe, true);
+});
+
+test("configured provider rate limit blocks dispatch when capacity is exhausted", () => {
+  const nowMs = Date.parse("2026-08-15T12:00:00Z");
+  const plan = planDispatch(input({
+    nowMs,
+    rateLimitPolicy: { maxRequests: 2, windowMs: 60_000 },
+    rateLimitUsage: { usedRequests: 2, windowStartedAtMs: nowMs - 15_000 },
+  }));
+  assert.equal(plan.action, PLAN_ACTIONS.WAIT);
+  assert.equal(plan.rateLimitAction, RATE_LIMIT_ACTIONS.WAIT);
+  assert.equal(plan.delayMs, 45_000);
+});
+
+test("configured provider rate limit returns the next usage reservation without mutating input", () => {
+  const nowMs = Date.parse("2026-08-15T12:00:00Z");
+  const usage = { usedRequests: 1, windowStartedAtMs: nowMs - 15_000 };
+  const plan = planDispatch(input({
+    nowMs,
+    rateLimitPolicy: { maxRequests: 3, windowMs: 60_000 },
+    rateLimitUsage: usage,
+  }));
+  assert.equal(plan.action, PLAN_ACTIONS.DISPATCH);
+  assert.equal(plan.rateLimitAction, RATE_LIMIT_ACTIONS.ALLOW);
+  assert.equal(plan.remainingRequests, 1);
+  assert.deepEqual(plan.nextRateLimitUsage, {
+    usedRequests: 2,
+    windowStartedAtMs: usage.windowStartedAtMs,
+  });
+  assert.deepEqual(usage, { usedRequests: 1, windowStartedAtMs: nowMs - 15_000 });
 });

--- a/functions/test/providerEventAudit.test.js
+++ b/functions/test/providerEventAudit.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { normalizeAuditEvent, appendAuditEvent } = require("../src/providerEventAudit");
+
+function event(overrides = {}) {
+  return {
+    eventType: "EVIDENCE_ACCEPTED",
+    providerId: "provider-a",
+    contractId: "contract-1",
+    subjectId: "crm-123",
+    evidenceId: "evidence-1",
+    actor: "SYSTEM",
+    occurredAt: "2026-08-08T20:00:00Z",
+    ...overrides,
+  };
+}
+
+test("normalizes audit event and derives deterministic id", () => {
+  const first = normalizeAuditEvent(event());
+  const second = normalizeAuditEvent(event());
+  assert.equal(first.auditEventId, second.auditEventId);
+  assert.equal(first.auditEventId.length, 64);
+});
+
+test("duplicate audit event is idempotent", () => {
+  const first = appendAuditEvent([], event());
+  const second = appendAuditEvent(first, event());
+  assert.equal(second.length, 1);
+});
+
+test("different lifecycle step yields another audit event", () => {
+  const list = appendAuditEvent(appendAuditEvent([], event()), event({ eventType: "LIFECYCLE_ADVANCED" }));
+  assert.equal(list.length, 2);
+});
+
+test("unsupported audit event is rejected", () => {
+  assert.throws(() => normalizeAuditEvent(event({ eventType: "MAGIC_SUCCESS" })), /unsupported provider audit event/);
+});

--- a/functions/test/providerEvidenceCorrelation.test.js
+++ b/functions/test/providerEvidenceCorrelation.test.js
@@ -1,0 +1,80 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { QUEUE_STATES } = require("../src/providerDispatchEnvelope");
+const { correlateEvidenceToDispatch } = require("../src/providerEvidenceCorrelation");
+
+function dispatch(overrides = {}) {
+  return {
+    dispatchId: "dispatch-1",
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    state: QUEUE_STATES.ACKNOWLEDGED,
+    ...overrides,
+  };
+}
+
+function evidence(overrides = {}) {
+  return {
+    evidenceEventId: "evt-hash-1",
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    kind: "ACTIVATION",
+    observedAt: "2026-08-08T20:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("correlates verified evidence only to the acknowledged dispatch identity", () => {
+  assert.deepEqual(correlateEvidenceToDispatch({ evidence: evidence(), dispatch: dispatch() }), {
+    matched: true,
+    dispatchId: "dispatch-1",
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    evidenceEventId: "evt-hash-1",
+    kind: "ACTIVATION",
+    observedAt: "2026-08-08T20:00:00.000Z",
+  });
+});
+
+test("unacknowledged dispatch cannot receive downstream provider evidence", () => {
+  assert.throws(() => correlateEvidenceToDispatch({
+    evidence: evidence(),
+    dispatch: dispatch({ state: QUEUE_STATES.IN_FLIGHT }),
+  }), /acknowledged dispatch/);
+});
+
+test("provider mismatch is rejected", () => {
+  assert.throws(() => correlateEvidenceToDispatch({
+    evidence: evidence({ providerId: "provider-b" }),
+    dispatch: dispatch(),
+  }), /dispatch provider/);
+});
+
+test("contract mismatch is rejected", () => {
+  assert.throws(() => correlateEvidenceToDispatch({
+    evidence: evidence({ contractId: "contract-2" }),
+    dispatch: dispatch(),
+  }), /dispatch contract/);
+});
+
+test("provider reference mismatch is rejected to prevent cross-customer attribution", () => {
+  assert.throws(() => correlateEvidenceToDispatch({
+    evidence: evidence({ providerReference: "crm-other" }),
+    dispatch: dispatch(),
+  }), /acknowledged provider reference/);
+});
+
+test("correlation result contains no provider payload or personal contact fields", () => {
+  const result = correlateEvidenceToDispatch({
+    evidence: { ...evidence(), phone: "0500000000", contactEmail: "private@example.com" },
+    dispatch: { ...dispatch(), payload: { phone: "0500000000" } },
+  });
+  assert.equal(Object.hasOwn(result, "phone"), false);
+  assert.equal(Object.hasOwn(result, "contactEmail"), false);
+  assert.equal(Object.hasOwn(result, "payload"), false);
+});

--- a/functions/test/providerEvidenceIngestion.test.js
+++ b/functions/test/providerEvidenceIngestion.test.js
@@ -4,9 +4,12 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const {
   EVIDENCE_KINDS,
+  MAX_FUTURE_SKEW_MS,
   normalizeProviderEvidence,
   dedupeProviderEvidence,
 } = require("../src/providerEvidenceIngestion");
+
+const NOW_MS = Date.parse("2026-08-08T20:10:00Z");
 
 function evidence(overrides = {}) {
   return {
@@ -21,35 +24,39 @@ function evidence(overrides = {}) {
   };
 }
 
+function normalize(input) {
+  return normalizeProviderEvidence(input, { nowMs: NOW_MS });
+}
+
 test("normalizes externally attributable provider evidence", () => {
-  const normalized = normalizeProviderEvidence(evidence());
+  const normalized = normalize(evidence());
   assert.equal(normalized.providerReference, "crm-123");
   assert.equal(normalized.observedAt, "2026-08-08T20:00:00.000Z");
   assert.equal(normalized.evidenceEventId.length, 64);
 });
 
 test("same external provider event derives the same evidence id", () => {
-  const first = normalizeProviderEvidence(evidence());
-  const second = normalizeProviderEvidence(evidence());
+  const first = normalize(evidence());
+  const second = normalize(evidence());
   assert.equal(first.evidenceEventId, second.evidenceEventId);
 });
 
 test("different external event id produces a different evidence id", () => {
-  const first = normalizeProviderEvidence(evidence());
-  const second = normalizeProviderEvidence(evidence({ externalEventId: "evt-2" }));
+  const first = normalize(evidence());
+  const second = normalize(evidence({ externalEventId: "evt-2" }));
   assert.notEqual(first.evidenceEventId, second.evidenceEventId);
 });
 
 test("unsupported source cannot masquerade as verified provider evidence", () => {
-  assert.throws(() => normalizeProviderEvidence(evidence({ source: "INTERNAL_GUESS" })), /unsupported evidence source/);
+  assert.throws(() => normalize(evidence({ source: "INTERNAL_GUESS" })), /unsupported evidence source/);
 });
 
 test("invalid or missing provider reference is rejected", () => {
-  assert.throws(() => normalizeProviderEvidence(evidence({ providerReference: "" })), /providerReference is required/);
+  assert.throws(() => normalize(evidence({ providerReference: "" })), /providerReference is required/);
 });
 
 test("commission evidence may carry non-negative monetary evidence", () => {
-  const normalized = normalizeProviderEvidence(evidence({
+  const normalized = normalize(evidence({
     kind: EVIDENCE_KINDS.COMMISSION,
     amount: 75.5,
     currency: "ils",
@@ -59,7 +66,18 @@ test("commission evidence may carry non-negative monetary evidence", () => {
 });
 
 test("negative monetary evidence is rejected", () => {
-  assert.throws(() => normalizeProviderEvidence(evidence({ amount: -1 })), /non-negative/);
+  assert.throws(() => normalize(evidence({ amount: -1 })), /non-negative/);
+});
+
+test("evidence timestamp allows small provider clock skew but rejects implausible future time", () => {
+  const withinSkew = normalizeProviderEvidence(evidence({
+    observedAt: new Date(NOW_MS + MAX_FUTURE_SKEW_MS).toISOString(),
+  }), { nowMs: NOW_MS });
+  assert.equal(withinSkew.observedAt, new Date(NOW_MS + MAX_FUTURE_SKEW_MS).toISOString());
+
+  assert.throws(() => normalizeProviderEvidence(evidence({
+    observedAt: new Date(NOW_MS + MAX_FUTURE_SKEW_MS + 1).toISOString(),
+  }), { nowMs: NOW_MS }), /future/);
 });
 
 test("evidence import is idempotent by evidenceEventId", () => {
@@ -67,6 +85,6 @@ test("evidence import is idempotent by evidenceEventId", () => {
     evidence(),
     evidence(),
     evidence({ externalEventId: "evt-2" }),
-  ]);
+  ], { nowMs: NOW_MS });
   assert.equal(unique.length, 2);
 });

--- a/functions/test/providerEvidenceIngestion.test.js
+++ b/functions/test/providerEvidenceIngestion.test.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  EVIDENCE_KINDS,
+  normalizeProviderEvidence,
+  dedupeProviderEvidence,
+} = require("../src/providerEvidenceIngestion");
+
+function evidence(overrides = {}) {
+  return {
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    externalEventId: "evt-1",
+    kind: EVIDENCE_KINDS.ACTIVATION,
+    source: "WEBHOOK",
+    observedAt: "2026-08-08T20:00:00Z",
+    ...overrides,
+  };
+}
+
+test("normalizes externally attributable provider evidence", () => {
+  const normalized = normalizeProviderEvidence(evidence());
+  assert.equal(normalized.providerReference, "crm-123");
+  assert.equal(normalized.observedAt, "2026-08-08T20:00:00.000Z");
+  assert.equal(normalized.evidenceEventId.length, 64);
+});
+
+test("same external provider event derives the same evidence id", () => {
+  const first = normalizeProviderEvidence(evidence());
+  const second = normalizeProviderEvidence(evidence());
+  assert.equal(first.evidenceEventId, second.evidenceEventId);
+});
+
+test("different external event id produces a different evidence id", () => {
+  const first = normalizeProviderEvidence(evidence());
+  const second = normalizeProviderEvidence(evidence({ externalEventId: "evt-2" }));
+  assert.notEqual(first.evidenceEventId, second.evidenceEventId);
+});
+
+test("unsupported source cannot masquerade as verified provider evidence", () => {
+  assert.throws(() => normalizeProviderEvidence(evidence({ source: "INTERNAL_GUESS" })), /unsupported evidence source/);
+});
+
+test("invalid or missing provider reference is rejected", () => {
+  assert.throws(() => normalizeProviderEvidence(evidence({ providerReference: "" })), /providerReference is required/);
+});
+
+test("commission evidence may carry non-negative monetary evidence", () => {
+  const normalized = normalizeProviderEvidence(evidence({
+    kind: EVIDENCE_KINDS.COMMISSION,
+    amount: 75.5,
+    currency: "ils",
+  }));
+  assert.equal(normalized.amount, 75.5);
+  assert.equal(normalized.currency, "ILS");
+});
+
+test("negative monetary evidence is rejected", () => {
+  assert.throws(() => normalizeProviderEvidence(evidence({ amount: -1 })), /non-negative/);
+});
+
+test("evidence import is idempotent by evidenceEventId", () => {
+  const unique = dedupeProviderEvidence([
+    evidence(),
+    evidence(),
+    evidence({ externalEventId: "evt-2" }),
+  ]);
+  assert.equal(unique.length, 2);
+});

--- a/functions/test/providerExceptionTriage.test.js
+++ b/functions/test/providerExceptionTriage.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { triageProviderException, SEVERITIES } = require("../src/providerExceptionTriage");
+
+test("webhook auth failure is critical and blocks automation", () => {
+  const result = triageProviderException({ type: "WEBHOOK_AUTH_FAILED", providerId: "provider-a" });
+  assert.equal(result.severity, SEVERITIES.CRITICAL);
+  assert.equal(result.blocksAutomation, true);
+});
+
+test("partial settlement requires review before paid transition", () => {
+  const result = triageProviderException({ type: "SETTLEMENT_PARTIAL" });
+  assert.equal(result.severity, SEVERITIES.WARNING);
+  assert.equal(result.blocksAutomation, true);
+});
+
+test("degraded provider does not necessarily block all automation", () => {
+  const result = triageProviderException({ type: "PROVIDER_DEGRADED" });
+  assert.equal(result.blocksAutomation, false);
+});
+
+test("unknown exception type is rejected", () => {
+  assert.throws(() => triageProviderException({ type: "UNKNOWN" }), /unsupported provider exception type/);
+});

--- a/functions/test/providerIncidentFreezePolicy.test.js
+++ b/functions/test/providerIncidentFreezePolicy.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { evaluateProviderFreeze } = require("../src/providerIncidentFreezePolicy");
+
+test("unfrozen provider remains dispatchable", () => {
+  const result = evaluateProviderFreeze({ providerId: "provider-a", frozen: false });
+  assert.equal(result.blocksDispatch, false);
+});
+
+test("incident freeze blocks dispatch", () => {
+  const result = evaluateProviderFreeze({
+    providerId: "provider-a",
+    frozen: true,
+    reason: "PROVIDER_OUTAGE",
+    frozenAt: "2026-08-08T20:00:00Z",
+    operatorReference: "incident-1",
+  });
+  assert.equal(result.blocksDispatch, true);
+  assert.equal(result.reason, "PROVIDER_OUTAGE");
+});
+
+test("unsupported freeze reason is rejected", () => {
+  assert.throws(() => evaluateProviderFreeze({ providerId: "provider-a", frozen: true, reason: "UNKNOWN", frozenAt: "2026-08-08T20:00:00Z" }), /unsupported provider freeze reason/);
+});

--- a/functions/test/providerIntegrationFramework.test.js
+++ b/functions/test/providerIntegrationFramework.test.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  CONNECTION_STATES,
+  DISPATCH_OUTCOMES,
+  normalizeProviderConfig,
+  assertDispatchAllowed,
+  normalizeAdapterResult,
+  nextRetry,
+  normalizeLifecycleEvidence,
+} = require("../src/providerIntegrationFramework");
+
+function config(overrides = {}) {
+  return {
+    providerId: "provider-a",
+    adapterKey: "provider-a-v1",
+    enabled: true,
+    adapterImplemented: false,
+    credentialsConfigured: false,
+    connectionVerified: false,
+    ...overrides,
+  };
+}
+
+test("provider remains READY_FOR_ADAPTER until adapter, credentials and connection are all verified", () => {
+  assert.equal(normalizeProviderConfig(config()).integrationState, CONNECTION_STATES.READY_FOR_ADAPTER);
+  assert.equal(normalizeProviderConfig(config({ adapterImplemented: true })).integrationState, CONNECTION_STATES.READY_FOR_ADAPTER);
+  assert.equal(normalizeProviderConfig(config({ adapterImplemented: true, credentialsConfigured: true })).integrationState, CONNECTION_STATES.READY_FOR_ADAPTER);
+  assert.equal(normalizeProviderConfig(config({
+    adapterImplemented: true,
+    credentialsConfigured: true,
+    connectionVerified: true,
+  })).integrationState, CONNECTION_STATES.ACTUALLY_CONNECTED);
+});
+
+test("disabled provider cannot be treated as connected", () => {
+  const normalized = normalizeProviderConfig(config({
+    enabled: false,
+    adapterImplemented: true,
+    credentialsConfigured: true,
+    connectionVerified: true,
+  }));
+  assert.equal(normalized.integrationState, CONNECTION_STATES.DISABLED);
+});
+
+test("dispatch is rejected unless provider is ACTUALLY_CONNECTED", () => {
+  assert.throws(() => assertDispatchAllowed(config()), /not actually connected/);
+  assert.doesNotThrow(() => assertDispatchAllowed(config({
+    adapterImplemented: true,
+    credentialsConfigured: true,
+    connectionVerified: true,
+  })));
+});
+
+test("acknowledged dispatch requires provider reference evidence", () => {
+  assert.throws(() => normalizeAdapterResult({ outcome: DISPATCH_OUTCOMES.ACKNOWLEDGED }), /providerReference/);
+  assert.deepEqual(normalizeAdapterResult({
+    outcome: DISPATCH_OUTCOMES.ACKNOWLEDGED,
+    providerReference: "crm-123",
+    evidenceType: "CRM_ACK",
+  }), {
+    outcome: DISPATCH_OUTCOMES.ACKNOWLEDGED,
+    providerReference: "crm-123",
+    retryAfterMs: 0,
+    evidenceType: "CRM_ACK",
+  });
+});
+
+test("retry policy uses bounded exponential backoff and dead letters at the limit", () => {
+  assert.deepEqual(nextRetry(1), { shouldRetry: true, deadLetter: false, delayMs: 30_000 });
+  assert.deepEqual(nextRetry(2, 120_000), { shouldRetry: true, deadLetter: false, delayMs: 120_000 });
+  assert.deepEqual(nextRetry(5), { shouldRetry: false, deadLetter: true, delayMs: 0 });
+});
+
+test("provider lifecycle advancement requires attributable external evidence", () => {
+  const evidence = normalizeLifecycleEvidence({
+    stage: "ACTIVATED",
+    providerReference: "activation-789",
+    evidenceSource: "PROVIDER_POSTBACK",
+    observedAt: "2026-08-08T19:00:00Z",
+  });
+  assert.equal(evidence.stage, "ACTIVATED");
+  assert.equal(evidence.providerReference, "activation-789");
+  assert.equal(evidence.evidenceSource, "PROVIDER_POSTBACK");
+});
+
+test("commission confirmation requires explicit amount evidence", () => {
+  assert.throws(() => normalizeLifecycleEvidence({
+    stage: "COMMISSION_CONFIRMED",
+    providerReference: "commission-1",
+    evidenceSource: "PROVIDER_REPORT",
+    observedAt: "2026-08-08T19:00:00Z",
+  }), /amount/);
+
+  const evidence = normalizeLifecycleEvidence({
+    stage: "COMMISSION_CONFIRMED",
+    providerReference: "commission-1",
+    evidenceSource: "PROVIDER_REPORT",
+    observedAt: "2026-08-08T19:00:00Z",
+    amount: 75.5,
+    currency: "ils",
+  });
+  assert.equal(evidence.amount, 75.5);
+  assert.equal(evidence.currency, "ILS");
+});

--- a/functions/test/providerIntegrationFramework.test.js
+++ b/functions/test/providerIntegrationFramework.test.js
@@ -86,13 +86,30 @@ test("provider lifecycle advancement requires attributable external evidence", (
   assert.equal(evidence.evidenceSource, "PROVIDER_POSTBACK");
 });
 
-test("commission confirmation requires explicit amount evidence", () => {
+test("lifecycle evidence requires a valid observedAt timestamp", () => {
+  assert.throws(() => normalizeLifecycleEvidence({
+    stage: "ACTIVATED",
+    providerReference: "activation-789",
+    evidenceSource: "PROVIDER_POSTBACK",
+    observedAt: "not-a-timestamp",
+  }), /valid timestamp/);
+});
+
+test("commission confirmation requires explicit positive amount evidence", () => {
   assert.throws(() => normalizeLifecycleEvidence({
     stage: "COMMISSION_CONFIRMED",
     providerReference: "commission-1",
     evidenceSource: "PROVIDER_REPORT",
     observedAt: "2026-08-08T19:00:00Z",
-  }), /amount/);
+  }), /positive amount/);
+
+  assert.throws(() => normalizeLifecycleEvidence({
+    stage: "COMMISSION_CONFIRMED",
+    providerReference: "commission-1",
+    evidenceSource: "PROVIDER_REPORT",
+    observedAt: "2026-08-08T19:00:00Z",
+    amount: 0,
+  }), /positive amount/);
 
   const evidence = normalizeLifecycleEvidence({
     stage: "COMMISSION_CONFIRMED",

--- a/functions/test/providerIntegrationReadiness.test.js
+++ b/functions/test/providerIntegrationReadiness.test.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { READINESS_STATES, evaluateIntegrationReadiness } = require("../src/providerIntegrationReadiness");
+
+function ready(overrides = {}) {
+  return {
+    adapterImplemented: true,
+    credentialsReferenced: true,
+    connectionVerified: true,
+    dispatchCapability: true,
+    evidencePathVerified: true,
+    webhookOrReportVerified: true,
+    commercialContractActive: true,
+    dataMinimizationVerified: true,
+    ...overrides,
+  };
+}
+
+test("missing adapter basics is not ready", () => {
+  const result = evaluateIntegrationReadiness(ready({ adapterImplemented: false }));
+  assert.equal(result.state, READINESS_STATES.NOT_READY);
+  assert.ok(result.missing.includes("adapterImplemented"));
+});
+
+test("sandbox readiness does not pretend production readiness", () => {
+  const result = evaluateIntegrationReadiness(ready({ connectionVerified: false, webhookOrReportVerified: false }));
+  assert.equal(result.state, READINESS_STATES.READY_FOR_SANDBOX);
+  assert.ok(result.missing.includes("connectionVerified"));
+});
+
+test("all evidence and commercial checks are required for production", () => {
+  const result = evaluateIntegrationReadiness(ready());
+  assert.equal(result.state, READINESS_STATES.READY_FOR_PRODUCTION);
+  assert.deepEqual(result.missing, []);
+});

--- a/functions/test/providerIntegrationStatus.test.js
+++ b/functions/test/providerIntegrationStatus.test.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  OPERATOR_STATES,
+  deriveIntegrationStatus,
+  buildPrivacySafePartnerFunnel,
+} = require("../src/providerIntegrationStatus");
+
+test("integration is never shown as connected before connection verification", () => {
+  assert.equal(deriveIntegrationStatus({ enabled: false }).state, OPERATOR_STATES.DISABLED);
+  assert.equal(deriveIntegrationStatus({ enabled: true }).state, OPERATOR_STATES.READY_FOR_ADAPTER);
+  assert.equal(deriveIntegrationStatus({
+    enabled: true,
+    adapterImplemented: true,
+    credentialsConfigured: true,
+  }).state, OPERATOR_STATES.CONNECTION_UNVERIFIED);
+});
+
+test("verified healthy provider is ACTUALLY_CONNECTED", () => {
+  const status = deriveIntegrationStatus({
+    enabled: true,
+    adapterImplemented: true,
+    credentialsConfigured: true,
+    connectionVerified: true,
+    attemptedLast24h: 100,
+    failedLast24h: 3,
+    deadLetterCount: 0,
+  });
+  assert.equal(status.state, OPERATOR_STATES.ACTUALLY_CONNECTED);
+  assert.equal(status.actionable, true);
+  assert.equal(status.failureRate, 0.03);
+});
+
+test("dead letters or elevated failure rate mark integration degraded", () => {
+  assert.equal(deriveIntegrationStatus({
+    enabled: true,
+    adapterImplemented: true,
+    credentialsConfigured: true,
+    connectionVerified: true,
+    attemptedLast24h: 10,
+    failedLast24h: 2,
+  }).state, OPERATOR_STATES.DEGRADED);
+
+  assert.equal(deriveIntegrationStatus({
+    enabled: true,
+    adapterImplemented: true,
+    credentialsConfigured: true,
+    connectionVerified: true,
+    attemptedLast24h: 100,
+    failedLast24h: 0,
+    deadLetterCount: 1,
+  }).state, OPERATOR_STATES.DEGRADED);
+});
+
+test("privacy-safe funnel contains aggregate counts only", () => {
+  const funnel = buildPrivacySafePartnerFunnel({
+    verifiedOpportunities: 100,
+    consentedRequests: 25,
+    acknowledgedDispatches: 20,
+    activations: 5,
+    confirmedCommission: 420.5,
+    uid: "must-not-leak",
+    gmailContent: "must-not-leak",
+  });
+  assert.deepEqual(funnel, {
+    verifiedOpportunities: 100,
+    consentedRequests: 25,
+    acknowledgedDispatches: 20,
+    activations: 5,
+    confirmedCommission: 420.5,
+    requestRate: 0.25,
+    activationRate: 0.25,
+  });
+  assert.equal(Object.hasOwn(funnel, "uid"), false);
+  assert.equal(Object.hasOwn(funnel, "gmailContent"), false);
+});

--- a/functions/test/providerLifecycleEvidenceAdapter.test.js
+++ b/functions/test/providerLifecycleEvidenceAdapter.test.js
@@ -1,0 +1,89 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { buildLifecycleEvidenceFromProviderEvidence } = require("../src/providerLifecycleEvidenceAdapter");
+
+function correlation(overrides = {}) {
+  return {
+    matched: true,
+    dispatchId: "dispatch-1",
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    evidenceEventId: "evt-hash-1",
+    kind: "ACTIVATION",
+    observedAt: "2026-08-08T20:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function evidence(overrides = {}) {
+  return {
+    evidenceEventId: "evt-hash-1",
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    kind: "ACTIVATION",
+    source: "WEBHOOK",
+    observedAt: "2026-08-08T20:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("activation evidence maps deterministically to ACTIVATED", () => {
+  const lifecycle = buildLifecycleEvidenceFromProviderEvidence(evidence(), correlation());
+  assert.equal(lifecycle.stage, "ACTIVATED");
+  assert.equal(lifecycle.providerReference, "crm-123");
+  assert.equal(lifecycle.evidenceSource, "PROVIDER_WEBHOOK");
+});
+
+test("commission evidence maps to COMMISSION_CONFIRMED with amount evidence", () => {
+  const lifecycle = buildLifecycleEvidenceFromProviderEvidence(
+    evidence({ kind: "COMMISSION", source: "REPORT_IMPORT", amount: 81.25, currency: "ils" }),
+    correlation({ kind: "COMMISSION" }),
+  );
+  assert.equal(lifecycle.stage, "COMMISSION_CONFIRMED");
+  assert.equal(lifecycle.amount, 81.25);
+  assert.equal(lifecycle.currency, "ILS");
+});
+
+test("uncorrelated evidence cannot advance lifecycle", () => {
+  assert.throws(() => buildLifecycleEvidenceFromProviderEvidence(
+    evidence(),
+    correlation({ matched: false }),
+  ), /correlated/);
+});
+
+test("evidence event must match correlation event", () => {
+  assert.throws(() => buildLifecycleEvidenceFromProviderEvidence(
+    evidence({ evidenceEventId: "evt-other" }),
+    correlation(),
+  ), /event does not match/);
+});
+
+test("provider reference must match correlation reference", () => {
+  assert.throws(() => buildLifecycleEvidenceFromProviderEvidence(
+    evidence({ providerReference: "crm-other" }),
+    correlation(),
+  ), /reference does not match/);
+});
+
+test("ambiguous STATUS or CONVERSION evidence is never guessed into a lifecycle stage", () => {
+  assert.throws(() => buildLifecycleEvidenceFromProviderEvidence(
+    evidence({ kind: "STATUS" }),
+    correlation({ kind: "STATUS" }),
+  ), /does not map unambiguously/);
+
+  assert.throws(() => buildLifecycleEvidenceFromProviderEvidence(
+    evidence({ kind: "CONVERSION" }),
+    correlation({ kind: "CONVERSION" }),
+  ), /does not map unambiguously/);
+});
+
+test("commission lifecycle confirmation requires positive amount", () => {
+  assert.throws(() => buildLifecycleEvidenceFromProviderEvidence(
+    evidence({ kind: "COMMISSION", amount: 0, currency: "ILS" }),
+    correlation({ kind: "COMMISSION" }),
+  ), /positive amount/);
+});

--- a/functions/test/providerOffboardingPolicy.test.js
+++ b/functions/test/providerOffboardingPolicy.test.js
@@ -1,0 +1,36 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { OFFBOARD_ACTIONS, planProviderOffboarding } = require("../src/providerOffboardingPolicy");
+
+function state(overrides = {}) {
+  return {
+    providerId: "provider-a",
+    newDispatchDisabled: false,
+    inFlightCount: 0,
+    credentialsRotated: false,
+    contractArchived: false,
+    ...overrides,
+  };
+}
+
+test("offboarding starts by disabling new dispatch", () => {
+  assert.equal(planProviderOffboarding(state()).action, OFFBOARD_ACTIONS.DISABLE_NEW_DISPATCH);
+});
+
+test("in-flight traffic must drain before credential rotation", () => {
+  const result = planProviderOffboarding(state({ newDispatchDisabled: true, inFlightCount: 2 }));
+  assert.equal(result.action, OFFBOARD_ACTIONS.DRAIN_IN_FLIGHT);
+});
+
+test("credentials rotate before contract archival", () => {
+  assert.equal(planProviderOffboarding(state({ newDispatchDisabled: true })).action, OFFBOARD_ACTIONS.ROTATE_CREDENTIALS);
+  assert.equal(planProviderOffboarding(state({ newDispatchDisabled: true, credentialsRotated: true })).action, OFFBOARD_ACTIONS.ARCHIVE_CONTRACT);
+});
+
+test("completed offboarding is safe to archive", () => {
+  const result = planProviderOffboarding(state({ newDispatchDisabled: true, credentialsRotated: true, contractArchived: true }));
+  assert.equal(result.action, OFFBOARD_ACTIONS.COMPLETE);
+  assert.equal(result.safeToArchive, true);
+});

--- a/functions/test/providerPaidTransitionGate.test.js
+++ b/functions/test/providerPaidTransitionGate.test.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { applyVerifiedSettlementToCommission } = require("../src/providerPaidTransitionGate");
+
+function commission(overrides = {}) {
+  return {
+    commissionId: "commission-1",
+    partnerId: "partner-a",
+    providerReference: "crm-123",
+    state: "CONFIRMED",
+    expectedAmount: 75.5,
+    confirmedAmount: 75.5,
+    currency: "ILS",
+    evidenceSource: "PROVIDER_REPORT",
+    evidenceObservedAt: "2026-08-08T19:00:00Z",
+    ...overrides,
+  };
+}
+
+function settlement(overrides = {}) {
+  return {
+    partnerId: "partner-a",
+    providerReference: "crm-123",
+    externalPaymentId: "payment-1",
+    amount: 75.5,
+    currency: "ILS",
+    source: "BANK_REPORT",
+    paidAt: "2026-08-08T20:00:00Z",
+    ...overrides,
+  };
+}
+
+test("exact verified settlement advances confirmed commission to paid", () => {
+  const result = applyVerifiedSettlementToCommission(commission(), settlement());
+  assert.equal(result.applied, true);
+  assert.equal(result.commission.state, "PAID");
+  assert.equal(result.commission.evidenceSource, "SETTLEMENT_EVIDENCE");
+  assert.equal(result.settlementEvidenceId.length, 64);
+});
+
+test("partial settlement cannot advance to paid", () => {
+  const result = applyVerifiedSettlementToCommission(commission(), settlement({ amount: 50 }));
+  assert.equal(result.applied, false);
+  assert.equal(result.commission.state, "CONFIRMED");
+});
+
+test("expected commission cannot bypass confirmation", () => {
+  assert.throws(() => applyVerifiedSettlementToCommission(commission({ state: "EXPECTED", confirmedAmount: null, evidenceSource: "", evidenceObservedAt: "" }), settlement()), /confirmed commission/);
+});
+
+test("already paid commission remains idempotent", () => {
+  const result = applyVerifiedSettlementToCommission(commission({ state: "PAID" }), settlement());
+  assert.equal(result.applied, false);
+  assert.equal(result.commission.state, "PAID");
+});

--- a/functions/test/providerPartnerFinanceSummary.test.js
+++ b/functions/test/providerPartnerFinanceSummary.test.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { buildPartnerFinanceSummary } = require("../src/providerPartnerFinanceSummary");
+
+function record(overrides = {}) {
+  return {
+    commissionId: "commission-1",
+    partnerId: "partner-a",
+    providerReference: "crm-123",
+    state: "EXPECTED",
+    expectedAmount: 100,
+    confirmedAmount: null,
+    currency: "ILS",
+    evidenceSource: "",
+    evidenceObservedAt: "",
+    ...overrides,
+  };
+}
+
+test("summarizes expected confirmed paid and outstanding amounts", () => {
+  const summary = buildPartnerFinanceSummary([
+    record(),
+    record({ commissionId: "commission-2", providerReference: "crm-124", state: "CONFIRMED", confirmedAmount: 80, evidenceSource: "REPORT", evidenceObservedAt: "2026-08-08T20:00:00Z" }),
+    record({ commissionId: "commission-3", providerReference: "crm-125", state: "PAID", confirmedAmount: 70, evidenceSource: "SETTLEMENT", evidenceObservedAt: "2026-08-08T21:00:00Z" }),
+  ]);
+  assert.equal(summary.expectedAmount, 300);
+  assert.equal(summary.confirmedAmount, 150);
+  assert.equal(summary.paidAmount, 70);
+  assert.equal(summary.outstandingConfirmed, 80);
+  assert.equal(summary.unconfirmedExpected, 150);
+});
+
+test("empty summary is stable", () => {
+  assert.deepEqual(buildPartnerFinanceSummary([]), {
+    records: 0,
+    expectedAmount: 0,
+    confirmedAmount: 0,
+    paidAmount: 0,
+    outstandingConfirmed: 0,
+    unconfirmedExpected: 0,
+    rejectedCount: 0,
+    collectionRate: 0,
+  });
+});

--- a/functions/test/providerRateLimitPlanner.test.js
+++ b/functions/test/providerRateLimitPlanner.test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  RATE_LIMIT_ACTIONS,
+  normalizeRateLimitPolicy,
+  planRateLimit,
+} = require("../src/providerRateLimitPlanner");
+
+const NOW = 1_000_000;
+const policy = { maxRequests: 3, windowMs: 60_000 };
+
+test("missing provider rate limit remains explicitly unconfigured", () => {
+  const decision = planRateLimit({ policy: null, nowMs: NOW });
+  assert.equal(decision.action, RATE_LIMIT_ACTIONS.UNCONFIGURED);
+});
+
+test("configured window allows request and returns deterministic next usage", () => {
+  const decision = planRateLimit({
+    policy,
+    usage: { usedRequests: 1, windowStartedAtMs: NOW },
+    nowMs: NOW + 1_000,
+  });
+  assert.equal(decision.action, RATE_LIMIT_ACTIONS.ALLOW);
+  assert.equal(decision.remainingRequests, 1);
+  assert.deepEqual(decision.nextUsage, {
+    usedRequests: 2,
+    windowStartedAtMs: NOW,
+  });
+});
+
+test("exhausted provider window waits until reset", () => {
+  const decision = planRateLimit({
+    policy,
+    usage: { usedRequests: 3, windowStartedAtMs: NOW },
+    nowMs: NOW + 10_000,
+  });
+  assert.equal(decision.action, RATE_LIMIT_ACTIONS.WAIT);
+  assert.equal(decision.delayMs, 50_000);
+  assert.equal(decision.remainingRequests, 0);
+});
+
+test("expired window resets usage before planning", () => {
+  const decision = planRateLimit({
+    policy,
+    usage: { usedRequests: 99, windowStartedAtMs: NOW },
+    nowMs: NOW + 60_000,
+  });
+  assert.equal(decision.action, RATE_LIMIT_ACTIONS.ALLOW);
+  assert.equal(decision.remainingRequests, 2);
+  assert.equal(decision.nextUsage.usedRequests, 1);
+  assert.equal(decision.nextUsage.windowStartedAtMs, NOW + 60_000);
+});
+
+test("framework refuses to invent invalid vendor limits", () => {
+  assert.throws(() => normalizeRateLimitPolicy({ maxRequests: 0, windowMs: 60_000 }), /maxRequests/);
+  assert.throws(() => normalizeRateLimitPolicy({ maxRequests: 10, windowMs: 0 }), /windowMs/);
+});
+
+test("usage counters must be explicit and valid", () => {
+  assert.throws(() => planRateLimit({
+    policy,
+    usage: { usedRequests: -1, windowStartedAtMs: NOW },
+    nowMs: NOW,
+  }), /usedRequests/);
+});

--- a/functions/test/providerReconciliation.test.js
+++ b/functions/test/providerReconciliation.test.js
@@ -27,7 +27,7 @@ test("expected commission does not require fabricated provider evidence", () => 
   assert.equal(record.confirmedAmount, null);
 });
 
-test("confirmed commission requires provider evidence and confirmed amount", () => {
+test("confirmed commission requires provider evidence and positive confirmed amount", () => {
   assert.throws(() => normalizeCommissionRecord(expected({
     state: COMMISSION_STATES.CONFIRMED,
   })), /evidence/);
@@ -36,7 +36,22 @@ test("confirmed commission requires provider evidence and confirmed amount", () 
     state: COMMISSION_STATES.CONFIRMED,
     evidenceSource: "PARTNER_REPORT",
     evidenceObservedAt: "2026-08-08T20:00:00Z",
-  })), /confirmedAmount/);
+  })), /positive confirmedAmount/);
+
+  assert.throws(() => normalizeCommissionRecord(expected({
+    state: COMMISSION_STATES.CONFIRMED,
+    confirmedAmount: 0,
+    evidenceSource: "PARTNER_REPORT",
+    evidenceObservedAt: "2026-08-08T20:00:00Z",
+  })), /positive confirmedAmount/);
+});
+
+test("resolved commission evidence requires a valid timestamp", () => {
+  assert.throws(() => normalizeCommissionRecord(expected({
+    state: COMMISSION_STATES.REJECTED,
+    evidenceSource: "PARTNER_REPORT",
+    evidenceObservedAt: "not-a-timestamp",
+  })), /valid timestamp/);
 });
 
 test("reconciliation upgrades expected commission only from explicit evidence", () => {

--- a/functions/test/providerReconciliation.test.js
+++ b/functions/test/providerReconciliation.test.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  COMMISSION_STATES,
+  normalizeCommissionRecord,
+  reconcileCommission,
+  buildPartnerMetrics,
+} = require("../src/providerReconciliation");
+
+function expected(overrides = {}) {
+  return {
+    commissionId: "c-1",
+    partnerId: "partner-a",
+    providerReference: "provider-ref-1",
+    state: COMMISSION_STATES.EXPECTED,
+    expectedAmount: 100,
+    currency: "ILS",
+    ...overrides,
+  };
+}
+
+test("expected commission does not require fabricated provider evidence", () => {
+  const record = normalizeCommissionRecord(expected());
+  assert.equal(record.state, COMMISSION_STATES.EXPECTED);
+  assert.equal(record.confirmedAmount, null);
+});
+
+test("confirmed commission requires provider evidence and confirmed amount", () => {
+  assert.throws(() => normalizeCommissionRecord(expected({
+    state: COMMISSION_STATES.CONFIRMED,
+  })), /evidence/);
+
+  assert.throws(() => normalizeCommissionRecord(expected({
+    state: COMMISSION_STATES.CONFIRMED,
+    evidenceSource: "PARTNER_REPORT",
+    evidenceObservedAt: "2026-08-08T20:00:00Z",
+  })), /confirmedAmount/);
+});
+
+test("reconciliation upgrades expected commission only from explicit evidence", () => {
+  const result = reconcileCommission(expected(), {
+    state: COMMISSION_STATES.CONFIRMED,
+    confirmedAmount: 85.5,
+    evidenceSource: "PARTNER_REPORT",
+    evidenceObservedAt: "2026-08-08T20:00:00Z",
+  });
+  assert.equal(result.state, COMMISSION_STATES.CONFIRMED);
+  assert.equal(result.confirmedAmount, 85.5);
+});
+
+test("paid commission cannot be downgraded", () => {
+  const paid = expected({
+    state: COMMISSION_STATES.PAID,
+    confirmedAmount: 90,
+    evidenceSource: "BANK_SETTLEMENT_REPORT",
+    evidenceObservedAt: "2026-08-08T20:00:00Z",
+  });
+  assert.throws(() => reconcileCommission(paid, {
+    state: COMMISSION_STATES.REJECTED,
+    evidenceSource: "PARTNER_REPORT",
+    evidenceObservedAt: "2026-08-09T20:00:00Z",
+  }), /cannot be downgraded/);
+});
+
+test("partner metrics contain aggregate commercial numbers only", () => {
+  const metrics = buildPartnerMetrics([
+    expected({ commissionId: "1", expectedAmount: 100 }),
+    expected({
+      commissionId: "2",
+      state: COMMISSION_STATES.CONFIRMED,
+      expectedAmount: 120,
+      confirmedAmount: 110,
+      evidenceSource: "PARTNER_REPORT",
+      evidenceObservedAt: "2026-08-08T20:00:00Z",
+    }),
+    expected({
+      commissionId: "3",
+      state: COMMISSION_STATES.PAID,
+      expectedAmount: 80,
+      confirmedAmount: 80,
+      evidenceSource: "BANK_SETTLEMENT_REPORT",
+      evidenceObservedAt: "2026-08-08T20:00:00Z",
+    }),
+    expected({
+      commissionId: "4",
+      state: COMMISSION_STATES.REJECTED,
+      expectedAmount: 50,
+      evidenceSource: "PARTNER_REPORT",
+      evidenceObservedAt: "2026-08-08T20:00:00Z",
+    }),
+  ]);
+  assert.deepEqual(metrics, {
+    records: 4,
+    expectedAmount: 350,
+    confirmedAmount: 190,
+    paidAmount: 80,
+    rejectedCount: 1,
+  });
+});

--- a/functions/test/providerReportImportPlanner.test.js
+++ b/functions/test/providerReportImportPlanner.test.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  IMPORT_RESULTS,
+  deriveImportEventId,
+  planProviderReportImport,
+} = require("../src/providerReportImportPlanner");
+
+function event(overrides = {}) {
+  return {
+    providerId: "provider-a",
+    reportId: "report-1",
+    externalEventId: "event-1",
+    eventType: "COMMISSION",
+    payload: { amount: 75.5 },
+    ...overrides,
+  };
+}
+
+test("accepts supported report event", () => {
+  const [result] = planProviderReportImport([event()]);
+  assert.equal(result.result, IMPORT_RESULTS.ACCEPTED);
+  assert.equal(result.importEventId.length, 64);
+});
+
+test("same external event is idempotent", () => {
+  const id = deriveImportEventId(event());
+  const [result] = planProviderReportImport([event()], [id]);
+  assert.equal(result.result, IMPORT_RESULTS.DUPLICATE);
+});
+
+test("unsupported report event is quarantined instead of applied", () => {
+  const [result] = planProviderReportImport([event({ eventType: "MAGIC_SUCCESS" })]);
+  assert.equal(result.result, IMPORT_RESULTS.QUARANTINED);
+});
+
+test("invalid event does not block valid event in same batch", () => {
+  const results = planProviderReportImport([null, event({ externalEventId: "event-2" })]);
+  assert.equal(results[0].result, IMPORT_RESULTS.QUARANTINED);
+  assert.equal(results[1].result, IMPORT_RESULTS.ACCEPTED);
+});

--- a/functions/test/providerSandboxProbePlanner.test.js
+++ b/functions/test/providerSandboxProbePlanner.test.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { planSandboxProbe } = require("../src/providerSandboxProbePlanner");
+
+function probe(overrides = {}) {
+  return {
+    providerId: "provider-a",
+    adapterKey: "adapter-a",
+    adapterImplemented: true,
+    credentialsReferenced: true,
+    statusLookupCapability: true,
+    productionTraffic: false,
+    ...overrides,
+  };
+}
+
+test("allows non-destructive sandbox probe", () => {
+  const result = planSandboxProbe(probe());
+  assert.equal(result.allowed, true);
+  assert.equal(result.operation, "STATUS_LOOKUP");
+  assert.equal(result.syntheticReference, true);
+});
+
+test("missing capability blocks probe", () => {
+  const result = planSandboxProbe(probe({ statusLookupCapability: false }));
+  assert.equal(result.allowed, false);
+});
+
+test("production traffic is never used for sandbox probe", () => {
+  const result = planSandboxProbe(probe({ productionTraffic: true }));
+  assert.equal(result.allowed, false);
+});

--- a/functions/test/providerSettlementEvidence.test.js
+++ b/functions/test/providerSettlementEvidence.test.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  normalizeSettlementEvidence,
+  dedupeSettlementEvidence,
+} = require("../src/providerSettlementEvidence");
+
+function sample(overrides = {}) {
+  return {
+    partnerId: "partner-a",
+    providerReference: "crm-123",
+    externalPaymentId: "payment-1",
+    amount: 75.5,
+    currency: "ils",
+    source: "BANK_REPORT",
+    paidAt: "2026-08-08T20:00:00Z",
+    ...overrides,
+  };
+}
+
+test("normalizes settlement evidence and derives stable id", () => {
+  const first = normalizeSettlementEvidence(sample());
+  const second = normalizeSettlementEvidence(sample());
+  assert.equal(first.currency, "ILS");
+  assert.equal(first.settlementEvidenceId, second.settlementEvidenceId);
+  assert.equal(first.settlementEvidenceId.length, 64);
+});
+
+test("rejects unsupported settlement source", () => {
+  assert.throws(() => normalizeSettlementEvidence(sample({ source: "INTERNAL_GUESS" })), /unsupported settlement source/);
+});
+
+test("requires positive paid amount", () => {
+  assert.throws(() => normalizeSettlementEvidence(sample({ amount: 0 })), /positive number/);
+});
+
+test("dedupes repeated payment evidence", () => {
+  const unique = dedupeSettlementEvidence([
+    sample(),
+    sample(),
+    sample({ externalPaymentId: "payment-2" }),
+  ]);
+  assert.equal(unique.length, 2);
+});

--- a/functions/test/providerSettlementReconciliation.test.js
+++ b/functions/test/providerSettlementReconciliation.test.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { reconcileSettlement, SETTLEMENT_RESULTS } = require("../src/providerSettlementReconciliation");
+
+function commission(overrides = {}) {
+  return {
+    commissionId: "commission-1",
+    partnerId: "partner-a",
+    providerReference: "crm-123",
+    state: "CONFIRMED",
+    expectedAmount: 75.5,
+    confirmedAmount: 75.5,
+    currency: "ILS",
+    evidenceSource: "PROVIDER_REPORT",
+    evidenceObservedAt: "2026-08-08T19:00:00Z",
+    ...overrides,
+  };
+}
+
+function settlement(overrides = {}) {
+  return {
+    partnerId: "partner-a",
+    providerReference: "crm-123",
+    externalPaymentId: "payment-1",
+    amount: 75.5,
+    currency: "ILS",
+    source: "BANK_REPORT",
+    paidAt: "2026-08-08T20:00:00Z",
+    ...overrides,
+  };
+}
+
+test("exact settlement can mark confirmed commission paid", () => {
+  const result = reconcileSettlement(commission(), settlement());
+  assert.equal(result.result, SETTLEMENT_RESULTS.MATCHED);
+  assert.equal(result.canMarkPaid, true);
+  assert.equal(result.delta, 0);
+});
+
+test("partial settlement cannot mark paid", () => {
+  const result = reconcileSettlement(commission(), settlement({ amount: 50 }));
+  assert.equal(result.result, SETTLEMENT_RESULTS.PARTIAL);
+  assert.equal(result.canMarkPaid, false);
+  assert.equal(result.delta, -25.5);
+});
+
+test("overpayment is surfaced instead of silently accepted", () => {
+  const result = reconcileSettlement(commission(), settlement({ amount: 80 }));
+  assert.equal(result.result, SETTLEMENT_RESULTS.OVERPAID);
+  assert.equal(result.canMarkPaid, false);
+});
+
+test("partner or currency mismatch never marks paid", () => {
+  assert.equal(reconcileSettlement(commission(), settlement({ partnerId: "partner-b" })).result, SETTLEMENT_RESULTS.MISMATCH);
+  assert.equal(reconcileSettlement(commission(), settlement({ currency: "USD" })).result, SETTLEMENT_RESULTS.MISMATCH);
+});
+
+test("expected commission cannot be settled before confirmation", () => {
+  assert.throws(() => reconcileSettlement(commission({ state: "EXPECTED", confirmedAmount: null, evidenceSource: "", evidenceObservedAt: "" }), settlement()), /confirmed commission/);
+});

--- a/functions/test/providerSlaPolicy.test.js
+++ b/functions/test/providerSlaPolicy.test.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { evaluateProviderSla, SLA_STATES } = require("../src/providerSlaPolicy");
+
+const policy = { acknowledgementMs: 1000, statusFreshnessMs: 10000 };
+
+test("unconfigured SLA remains explicit", () => {
+  assert.equal(evaluateProviderSla({}).state, SLA_STATES.UNCONFIGURED);
+});
+
+test("healthy SLA remains healthy", () => {
+  assert.equal(evaluateProviderSla({ policy, ackLatencyMs: 400, statusAgeMs: 2000 }).state, SLA_STATES.HEALTHY);
+});
+
+test("near-threshold SLA yields warning", () => {
+  assert.equal(evaluateProviderSla({ policy, ackLatencyMs: 850, statusAgeMs: 2000 }).state, SLA_STATES.WARNING);
+});
+
+test("threshold breach is surfaced", () => {
+  assert.equal(evaluateProviderSla({ policy, ackLatencyMs: 1200, statusAgeMs: 2000 }).state, SLA_STATES.BREACHED);
+});

--- a/functions/test/providerVerifiedEvidenceIntake.test.js
+++ b/functions/test/providerVerifiedEvidenceIntake.test.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { EVIDENCE_KINDS } = require("../src/providerEvidenceIngestion");
+const { ingestVerifiedProviderEvidence } = require("../src/providerVerifiedEvidenceIntake");
+
+const NOW_MS = Date.parse("2026-08-08T20:55:00Z");
+
+function evidence(overrides = {}) {
+  return {
+    providerId: "provider-a",
+    contractId: "contract-1",
+    providerReference: "crm-123",
+    externalEventId: "evt-1",
+    kind: EVIDENCE_KINDS.ACTIVATION,
+    source: "WEBHOOK",
+    observedAt: "2026-08-08T20:54:00Z",
+    ...overrides,
+  };
+}
+
+test("verified webhook may enter the provider evidence pipeline", () => {
+  const normalized = ingestVerifiedProviderEvidence({
+    verification: { verified: true, timestampMs: NOW_MS - 60_000 },
+    evidence: evidence(),
+  }, { nowMs: NOW_MS });
+  assert.equal(normalized.kind, EVIDENCE_KINDS.ACTIVATION);
+  assert.equal(normalized.source, "WEBHOOK");
+});
+
+test("unverified webhook cannot become activation evidence", () => {
+  assert.throws(() => ingestVerifiedProviderEvidence({
+    verification: { verified: false, timestampMs: NOW_MS - 60_000 },
+    evidence: evidence(),
+  }, { nowMs: NOW_MS }), /verified webhook authenticity/);
+});
+
+test("missing webhook verification cannot be bypassed", () => {
+  assert.throws(() => ingestVerifiedProviderEvidence({
+    evidence: evidence(),
+  }, { nowMs: NOW_MS }), /verification must be an object/);
+});
+
+test("verified signed evidence requires attributable verification timestamp", () => {
+  assert.throws(() => ingestVerifiedProviderEvidence({
+    verification: { verified: true },
+    evidence: evidence({ source: "POSTBACK" }),
+  }, { nowMs: NOW_MS }), /verification timestamp/);
+});
+
+test("report import remains evidence-source validated without webhook signature semantics", () => {
+  const normalized = ingestVerifiedProviderEvidence({
+    evidence: evidence({ source: "REPORT_IMPORT" }),
+  }, { nowMs: NOW_MS });
+  assert.equal(normalized.source, "REPORT_IMPORT");
+});

--- a/functions/test/providerWebhookVerification.test.js
+++ b/functions/test/providerWebhookVerification.test.js
@@ -1,0 +1,82 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  DEFAULT_REPLAY_WINDOW_MS,
+  deriveWebhookSignature,
+  verifyProviderWebhook,
+} = require("../src/providerWebhookVerification");
+
+const NOW_MS = Date.parse("2026-08-08T20:45:00Z");
+const SECRET = "unit-test-secret-material";
+const BODY = JSON.stringify({ eventId: "evt-1", status: "ACTIVATED" });
+
+function signedInput(overrides = {}) {
+  const timestampMs = overrides.timestampMs ?? NOW_MS - 30_000;
+  return {
+    rawBody: BODY,
+    timestampMs,
+    nowMs: NOW_MS,
+    secretMaterial: SECRET,
+    signature: deriveWebhookSignature({
+      rawBody: BODY,
+      timestampMs,
+      secretMaterial: SECRET,
+    }),
+    ...overrides,
+  };
+}
+
+test("valid provider webhook signature verifies inside the replay window", () => {
+  const result = verifyProviderWebhook(signedInput());
+  assert.equal(result.verified, true);
+  assert.match(result.reason, /verified/);
+  assert.equal(result.ageMs, 30_000);
+});
+
+test("tampered raw body fails signature verification", () => {
+  const input = signedInput();
+  const result = verifyProviderWebhook({ ...input, rawBody: `${BODY} ` });
+  assert.equal(result.verified, false);
+  assert.match(result.reason, /mismatch/);
+});
+
+test("wrong secret fails signature verification", () => {
+  const result = verifyProviderWebhook({
+    ...signedInput(),
+    secretMaterial: "wrong-secret",
+  });
+  assert.equal(result.verified, false);
+});
+
+test("stale webhook is rejected before evidence ingestion", () => {
+  const timestampMs = NOW_MS - DEFAULT_REPLAY_WINDOW_MS - 1;
+  const result = verifyProviderWebhook(signedInput({
+    timestampMs,
+    signature: deriveWebhookSignature({ rawBody: BODY, timestampMs, secretMaterial: SECRET }),
+  }));
+  assert.equal(result.verified, false);
+  assert.match(result.reason, /replay window/);
+});
+
+test("future webhook outside the replay window is rejected", () => {
+  const timestampMs = NOW_MS + DEFAULT_REPLAY_WINDOW_MS + 1;
+  const result = verifyProviderWebhook(signedInput({
+    timestampMs,
+    signature: deriveWebhookSignature({ rawBody: BODY, timestampMs, secretMaterial: SECRET }),
+  }));
+  assert.equal(result.verified, false);
+  assert.match(result.reason, /replay window/);
+});
+
+test("malformed signatures cannot be treated as verified", () => {
+  assert.throws(() => verifyProviderWebhook(signedInput({ signature: "bad" })), /sha256=/);
+  assert.throws(() => verifyProviderWebhook(signedInput({ signature: "sha256=abcd" })), /64-character/);
+});
+
+test("verification does not expose secret material in its result", () => {
+  const result = verifyProviderWebhook(signedInput());
+  assert.equal(Object.hasOwn(result, "secretMaterial"), false);
+  assert.equal(JSON.stringify(result).includes(SECRET), false);
+});


### PR DESCRIPTION
Continues Workstream C on the existing isolated provider-commerce branch after the prior draft PR was closed without merge.

Scope remains Provider/Commerce Integrations only. No Core financial/ranking/Gmail semantics, Android UI/contracts, or MCP changes.

Includes provider adapter/capability contracts, dispatch envelope/idempotency, resilience gates, webhook verification, verified evidence ingestion/correlation, lifecycle and commission evidence adapters, commission/settlement reconciliation, paid transition gate, batch report import planning, immutable audit events, exception triage, partner finance summary, SLA/health scoring, explicit savings-action intent gate, and external payload data minimization.

Guardrails:
- no fabricated provider endpoint/credential
- no inferred activation/commission/payment without external evidence
- no commission influence on recommendation ranking
- no Gmail/current-spend/internal AI data in provider payloads
- unconfigured provider limits/SLA stay explicitly unconfigured
- all new modules are deterministic and side-effect free until a real adapter is connected
