### PR TITLE
Ops: bootstrap keyless staging deployment WIF

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,10 +3,9 @@ name: Deploy Firebase Staging
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: Git ref to deploy after CI is green
+      source_sha:
+        description: Exact 40-character Stream A commit SHA to deploy after CI is green
         required: true
-        default: agent/ai-native-financial-core
         type: string
       confirm_project:
         description: Type clickandsaveai-staging to confirm the deployment target
@@ -29,21 +28,39 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Guard deployment source
+      - name: Guard immutable deployment source
         shell: bash
         env:
-          DEPLOY_REF: ${{ inputs.ref }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
-          if [[ "$DEPLOY_REF" != "agent/ai-native-financial-core" ]]; then
-            echo "Only agent/ai-native-financial-core may be deployed by this staging workflow." >&2
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo 'source_sha must be an exact lowercase 40-character Git commit SHA.' >&2
             exit 1
           fi
 
-      - name: Check out requested ref
+      - name: Check out exact source SHA
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+
+      - name: Verify SHA and Stream A lineage
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          if [[ "$ACTUAL_SHA" != "$SOURCE_SHA" ]]; then
+            echo "Expected $SOURCE_SHA but checked out $ACTUAL_SHA" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin agent/ai-native-financial-core
+          if ! git merge-base --is-ancestor "$SOURCE_SHA" origin/agent/ai-native-financial-core; then
+            echo 'The requested SHA is not part of Stream A (agent/ai-native-financial-core).' >&2
+            exit 1
+          fi
 
       - name: Verify staging deployment configuration
         env:
@@ -68,14 +85,6 @@ jobs:
           }
           NODE
 
-      - id: auth
-        name: Authenticate to Google Cloud with GitHub OIDC
-        uses: google-github-actions/auth@v3
-        with:
-          create_credentials_file: 'true'
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
-
       - name: Set up Node.js 22
         uses: actions/setup-node@v6
         with:
@@ -89,6 +98,14 @@ jobs:
       - name: Re-run backend tests before deployment
         working-directory: functions
         run: npm test
+
+      - id: auth
+        name: Authenticate to Google Cloud with GitHub OIDC
+        uses: google-github-actions/auth@v3
+        with:
+          create_credentials_file: 'true'
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
 
       - name: Install pinned Firebase CLI
         run: npm install --global firebase-tools@15.1.0

--- a/.github/workflows/ops-wif-ci.yml
+++ b/.github/workflows/ops-wif-ci.yml
@@ -8,12 +8,14 @@ on:
       - scripts/bootstrap-staging-wif.sh
       - scripts/verify-staging-wif.sh
       - scripts/configure-github-staging-vars.sh
+      - .github/workflows/deploy-staging.yml
       - .github/workflows/ops-wif-ci.yml
   pull_request:
     paths:
       - scripts/bootstrap-staging-wif.sh
       - scripts/verify-staging-wif.sh
       - scripts/configure-github-staging-vars.sh
+      - .github/workflows/deploy-staging.yml
       - .github/workflows/ops-wif-ci.yml
 
 permissions:
@@ -51,5 +53,25 @@ jobs:
           if grep -Eq 'service-accounts keys (create|upload)|iam service-accounts keys create' \
             scripts/bootstrap-staging-wif.sh scripts/verify-staging-wif.sh scripts/configure-github-staging-vars.sh; then
             echo 'Service-account key creation is forbidden for this bootstrap.' >&2
+            exit 1
+          fi
+
+      - name: Enforce immutable staging deployment source
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow='.github/workflows/deploy-staging.yml'
+
+          grep -Fq 'source_sha:' "$workflow"
+          grep -Fq 'ref: ${{ inputs.source_sha }}' "$workflow"
+          grep -Fq 'ACTUAL_SHA="$(git rev-parse HEAD)"' "$workflow"
+          grep -Fq 'if [[ "$ACTUAL_SHA" != "$SOURCE_SHA" ]]' "$workflow"
+          grep -Fq 'git merge-base --is-ancestor "$SOURCE_SHA" origin/agent/ai-native-financial-core' "$workflow"
+          grep -Fq -- '--project clickandsaveai-staging' "$workflow"
+          grep -Fq 'environment: staging' "$workflow"
+          grep -Fq 'id-token: write' "$workflow"
+
+          if grep -Fq 'default: agent/ai-native-financial-core' "$workflow"; then
+            echo 'Mutable branch deployment input is forbidden; deploy an exact commit SHA.' >&2
             exit 1
           fi

--- a/.github/workflows/ops-wif-ci.yml
+++ b/.github/workflows/ops-wif-ci.yml
@@ -40,9 +40,13 @@ jobs:
           grep -Fq 'GITHUB_REPOSITORY_ID="${GITHUB_REPOSITORY_ID:-1314210715}"' scripts/bootstrap-staging-wif.sh
           grep -Fq 'GITHUB_REPOSITORY_OWNER_ID="${GITHUB_REPOSITORY_OWNER_ID:-64756523}"' scripts/bootstrap-staging-wif.sh
           grep -Fq 'GITHUB_ENVIRONMENT="${GITHUB_ENVIRONMENT:-staging}"' scripts/bootstrap-staging-wif.sh
+          grep -Fq 'GITHUB_REF="${GITHUB_REF:-refs/heads/main}"' scripts/bootstrap-staging-wif.sh
+          grep -Fq 'GITHUB_JOB_WORKFLOW_REF="${GITHUB_JOB_WORKFLOW_REF:-vhanukaev1981/ClickAndSaveAI/.github/workflows/deploy-staging.yml@refs/heads/main}"' scripts/bootstrap-staging-wif.sh
           grep -Fq "assertion.repository_id=='\${GITHUB_REPOSITORY_ID}'" scripts/bootstrap-staging-wif.sh
           grep -Fq "assertion.repository_owner_id=='\${GITHUB_REPOSITORY_OWNER_ID}'" scripts/bootstrap-staging-wif.sh
           grep -Fq "assertion.environment=='\${GITHUB_ENVIRONMENT}'" scripts/bootstrap-staging-wif.sh
+          grep -Fq "assertion.ref=='\${GITHUB_REF}'" scripts/bootstrap-staging-wif.sh
+          grep -Fq "assertion.job_workflow_ref=='\${GITHUB_JOB_WORKFLOW_REF}'" scripts/bootstrap-staging-wif.sh
 
           if grep -Eq 'service-accounts keys (create|upload)|iam service-accounts keys create' \
             scripts/bootstrap-staging-wif.sh scripts/verify-staging-wif.sh scripts/configure-github-staging-vars.sh; then

--- a/.github/workflows/ops-wif-ci.yml
+++ b/.github/workflows/ops-wif-ci.yml
@@ -1,0 +1,44 @@
+name: Validate Staging WIF Bootstrap
+
+on:
+  push:
+    branches:
+      - ops/bootstrap-staging-wif
+    paths:
+      - scripts/bootstrap-staging-wif.sh
+      - scripts/verify-staging-wif.sh
+      - .github/workflows/ops-wif-ci.yml
+  pull_request:
+    paths:
+      - scripts/bootstrap-staging-wif.sh
+      - scripts/verify-staging-wif.sh
+      - .github/workflows/ops-wif-ci.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate Bash syntax
+        run: bash -n scripts/bootstrap-staging-wif.sh scripts/verify-staging-wif.sh
+
+      - name: Enforce keyless and scoped trust guardrails
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -Fq 'GITHUB_REPOSITORY_ID="${GITHUB_REPOSITORY_ID:-1314210715}"' scripts/bootstrap-staging-wif.sh
+          grep -Fq 'GITHUB_REPOSITORY_OWNER_ID="${GITHUB_REPOSITORY_OWNER_ID:-64756523}"' scripts/bootstrap-staging-wif.sh
+          grep -Fq 'GITHUB_ENVIRONMENT="${GITHUB_ENVIRONMENT:-staging}"' scripts/bootstrap-staging-wif.sh
+          grep -Fq "assertion.repository_id=='\${GITHUB_REPOSITORY_ID}'" scripts/bootstrap-staging-wif.sh
+          grep -Fq "assertion.repository_owner_id=='\${GITHUB_REPOSITORY_OWNER_ID}'" scripts/bootstrap-staging-wif.sh
+          grep -Fq "assertion.environment=='\${GITHUB_ENVIRONMENT}'" scripts/bootstrap-staging-wif.sh
+
+          if grep -Eq 'service-accounts keys (create|upload)|iam service-accounts keys create' scripts/bootstrap-staging-wif.sh; then
+            echo 'Service-account key creation is forbidden for this bootstrap.' >&2
+            exit 1
+          fi

--- a/.github/workflows/ops-wif-ci.yml
+++ b/.github/workflows/ops-wif-ci.yml
@@ -7,11 +7,13 @@ on:
     paths:
       - scripts/bootstrap-staging-wif.sh
       - scripts/verify-staging-wif.sh
+      - scripts/configure-github-staging-vars.sh
       - .github/workflows/ops-wif-ci.yml
   pull_request:
     paths:
       - scripts/bootstrap-staging-wif.sh
       - scripts/verify-staging-wif.sh
+      - scripts/configure-github-staging-vars.sh
       - .github/workflows/ops-wif-ci.yml
 
 permissions:
@@ -25,7 +27,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Validate Bash syntax
-        run: bash -n scripts/bootstrap-staging-wif.sh scripts/verify-staging-wif.sh
+        run: |
+          bash -n \
+            scripts/bootstrap-staging-wif.sh \
+            scripts/verify-staging-wif.sh \
+            scripts/configure-github-staging-vars.sh
 
       - name: Enforce keyless and scoped trust guardrails
         shell: bash
@@ -38,7 +44,8 @@ jobs:
           grep -Fq "assertion.repository_owner_id=='\${GITHUB_REPOSITORY_OWNER_ID}'" scripts/bootstrap-staging-wif.sh
           grep -Fq "assertion.environment=='\${GITHUB_ENVIRONMENT}'" scripts/bootstrap-staging-wif.sh
 
-          if grep -Eq 'service-accounts keys (create|upload)|iam service-accounts keys create' scripts/bootstrap-staging-wif.sh; then
+          if grep -Eq 'service-accounts keys (create|upload)|iam service-accounts keys create' \
+            scripts/bootstrap-staging-wif.sh scripts/verify-staging-wif.sh scripts/configure-github-staging-vars.sh; then
             echo 'Service-account key creation is forbidden for this bootstrap.' >&2
             exit 1
           fi

--- a/docs/POST_E2E_REALTIME_BILLS_SYNC.md
+++ b/docs/POST_E2E_REALTIME_BILLS_SYNC.md
@@ -1,0 +1,84 @@
+# Post-E2E: authoritative realtime Bills sync
+
+Status: queued for Stream A **after** locked staging E2E correction cycle #2. Do not move the locked Stream A baseline to implement this before that validation.
+
+## Problem
+
+The backend Gmail realtime path updates Firestore / Financial Agent and sends an FCM notification. The Android Bills screen is Room-backed. `ClickAndSaveMessagingService` displays notifications but does not refresh Room, and normal authenticated app startup only triggers a full Gmail scan when a parser upgrade is required.
+
+Result: Financial Home/opportunities can be current while the local Bills list lags until another scan.
+
+## Required architecture
+
+Firestore remains authoritative for normalized Gmail-observed bills. Do **not** run the six-month Gmail scan on every app open.
+
+Add a secure callable, tentatively `getObservedBills`, that returns a bounded recent snapshot derived from backend-owned `users/{uid}/gmailInvoices` state.
+
+Suggested response shape:
+
+```text
+{
+  bills: [
+    {
+      sourceMessageId,
+      providerName,
+      category,
+      monthlyCost,
+      receivedDate,
+      verificationStatus
+    }
+  ],
+  sourceIds: [...],
+  generatedAt
+}
+```
+
+Rules:
+
+- App Check + Firebase Auth required.
+- No raw subject/body/snippet/PDF text.
+- No account number, address, payment instrument or hidden commercial terms.
+- Bounded result size; newest-first.
+- Backend normalized sources only.
+- `sourceMessageId` remains an internal synchronization key and must not be shown in customer UI.
+
+## Android reconciliation
+
+Add a repository method that:
+
+1. fetches `getObservedBills`;
+2. upserts each returned Gmail source into Room;
+3. removes stale Gmail-only Room rows that are no longer present in the authoritative bounded synchronization set according to a safe reconciliation rule;
+4. never deletes manually entered local bills;
+5. never changes local user-action state unless the source itself was removed and replacement lineage is explicitly known.
+
+Trigger a lightweight authoritative refresh:
+
+- after authenticated app startup/resume with reasonable throttling;
+- after an FCM event indicating `NEW_INVOICE` where practical;
+- after parser-upgrade/full Gmail scan.
+
+## Truthfulness / performance gates
+
+- no local invoice-count fallback for recurring-service count;
+- no local arithmetic that creates savings claims;
+- no six-month Gmail scan as a normal refresh mechanism;
+- one backend bill must map to one current Room source;
+- body->PDF source migrations must remain duplicate-safe;
+- failure to refresh Bills must not make a valid Gmail connection appear disconnected.
+
+## Tests
+
+Backend:
+- auth/App Check boundary;
+- response contains normalized minimum fields only;
+- bounded newest-first list;
+- no raw Gmail content;
+- stale source not returned after parser reconciliation.
+
+Android:
+- new backend bill appears once in Room;
+- existing source is updated, not duplicated;
+- manual local bill survives authoritative Gmail reconciliation;
+- stale Gmail source is removed safely;
+- transient refresh failure preserves current UI data and connection state.

--- a/docs/STAGING_WIF_BOOTSTRAP.md
+++ b/docs/STAGING_WIF_BOOTSTRAP.md
@@ -1,0 +1,111 @@
+# One-time staging WIF bootstrap
+
+This runbook removes the only current blocker preventing the locked Click&SaveAI Stream A backend from deploying to `clickandsaveai-staging`.
+
+The setup is intentionally keyless. It uses GitHub Actions OIDC -> Google Cloud Workload Identity Federation -> a dedicated staging deploy service account. Do not create or download a JSON service-account key.
+
+## Security boundary
+
+The provider created by this runbook accepts GitHub tokens only when all three immutable/context claims match:
+
+- GitHub repository ID: `1314210715`
+- GitHub repository owner ID: `64756523`
+- GitHub environment: `staging`
+
+The deploy identity is `clickandsaveai-github-deployer@clickandsaveai-staging.iam.gserviceaccount.com` unless overridden deliberately.
+
+## 1. Use a trusted Google Cloud administrator shell
+
+Google Cloud Shell is a good fit because `gcloud` is already installed. The active account must be allowed to create service accounts, Workload Identity Federation resources and IAM bindings in `clickandsaveai-staging`.
+
+Clone the repository and switch to the isolated ops branch:
+
+```bash
+git clone https://github.com/vhanukaev1981/ClickAndSaveAI.git
+cd ClickAndSaveAI
+git checkout ops/bootstrap-staging-wif
+```
+
+## 2. Create/converge WIF and deploy IAM
+
+```bash
+bash scripts/bootstrap-staging-wif.sh
+```
+
+The script is idempotent. Re-running it converges the same pool/provider/service account instead of creating a new identity.
+
+It dynamically resolves:
+
+- the Google Cloud numeric project number;
+- the default Cloud Run functions runtime service account;
+- the project's actual Cloud Build default service account.
+
+It grants the deploy service account only the product roles needed by the current Firebase deployment path, plus `Service Account User` on the runtime/Cloud Build identities. It also ensures the Cloud Build identity has `roles/cloudbuild.builds.builder`.
+
+## 3. Verify before touching GitHub variables
+
+```bash
+bash scripts/verify-staging-wif.sh
+```
+
+Do not continue unless the script ends with:
+
+```text
+WIF verification PASSED. No service-account key is required.
+```
+
+## 4. Set the two GitHub `staging` environment variables
+
+If GitHub CLI is installed and authenticated with repository-admin permission:
+
+```bash
+bash scripts/configure-github-staging-vars.sh
+```
+
+It sets and reads back:
+
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`
+- `GCP_DEPLOY_SERVICE_ACCOUNT`
+
+If `gh` is unavailable, the bootstrap/verify scripts print the exact two non-secret values. Set those values in:
+
+`GitHub repository -> Settings -> Environments -> staging -> Environment variables`
+
+Do not store a Google service-account key as a GitHub secret.
+
+## 5. Retry only the locked staging deployment
+
+Current immutable E2E correction baseline:
+
+```text
+ac2105098d698df06159f929f41595f91505c855
+```
+
+The one-time deployment probe is intentionally pinned to this SHA and to project `clickandsaveai-staging`. The first probe run (`31293189685`) failed before checkout/auth/deploy because the two WIF variables were empty. No partial Firebase deployment occurred.
+
+After the two variables are configured, rerun that locked deployment workflow. Do not move the Stream A branch or install a different APK in between.
+
+## 6. Device E2E artifact paired with the locked backend
+
+Only after the locked backend deploy succeeds, install the signed staging artifact produced by CI run `31292701315`:
+
+- GitHub artifact ID: `9032000365`
+- artifact digest: `sha256:cfc918d75b1a10a61867e48fad1646541972a7eb4442797912eebf67fa77628e`
+- extracted APK SHA-256: `cbd841ed22f51f7fc1216ee1dd23148fb468965659e9ff3d5aa1831736adfd0a`
+
+Then run E2E correction cycle #2 against the same backend/code tree.
+
+## IAM notes
+
+The bootstrap currently grants the deploy service account:
+
+- `roles/firebase.viewer`
+- `roles/cloudfunctions.admin`
+- `roles/firebaserules.admin`
+- `roles/datastore.indexAdmin`
+- `roles/cloudscheduler.admin`
+- `roles/secretmanager.viewer`
+
+It grants `roles/iam.serviceAccountUser` only on the function runtime and Cloud Build service accounts, rather than at project scope.
+
+If a future authenticated deployment reports a specific additional missing permission, add the narrow role required by that resource. Do not solve a missing permission by granting `Owner` or `Editor`.

--- a/docs/STAGING_WIF_BOOTSTRAP.md
+++ b/docs/STAGING_WIF_BOOTSTRAP.md
@@ -109,3 +109,7 @@ The bootstrap currently grants the deploy service account:
 It grants `roles/iam.serviceAccountUser` only on the function runtime and Cloud Build service accounts, rather than at project scope.
 
 If a future authenticated deployment reports a specific additional missing permission, add the narrow role required by that resource. Do not solve a missing permission by granting `Owner` or `Editor`.
+
+## Queued immediately after E2E #2
+
+The next Stream A item is the authoritative realtime Bills/Room synchronization design documented in `docs/POST_E2E_REALTIME_BILLS_SYNC.md`. It must not move the locked E2E baseline before device validation.

--- a/scripts/bootstrap-staging-wif.sh
+++ b/scripts/bootstrap-staging-wif.sh
@@ -14,6 +14,8 @@ DEPLOY_SA_ID="${DEPLOY_SA_ID:-clickandsaveai-github-deployer}"
 GITHUB_REPOSITORY_ID="${GITHUB_REPOSITORY_ID:-1314210715}"
 GITHUB_REPOSITORY_OWNER_ID="${GITHUB_REPOSITORY_OWNER_ID:-64756523}"
 GITHUB_ENVIRONMENT="${GITHUB_ENVIRONMENT:-staging}"
+GITHUB_REF="${GITHUB_REF:-refs/heads/main}"
+GITHUB_JOB_WORKFLOW_REF="${GITHUB_JOB_WORKFLOW_REF:-vhanukaev1981/ClickAndSaveAI/.github/workflows/deploy-staging.yml@refs/heads/main}"
 GITHUB_OIDC_ISSUER="https://token.actions.githubusercontent.com"
 
 log() {
@@ -66,9 +68,9 @@ if ! gcloud iam workload-identity-pools describe "$POOL_ID" \
 fi
 
 ATTRIBUTE_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.repository_owner_id=assertion.repository_owner_id,attribute.environment=assertion.environment"
-ATTRIBUTE_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && assertion.environment=='${GITHUB_ENVIRONMENT}'"
+ATTRIBUTE_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && assertion.environment=='${GITHUB_ENVIRONMENT}' && assertion.ref=='${GITHUB_REF}' && assertion.job_workflow_ref=='${GITHUB_JOB_WORKFLOW_REF}'"
 
-log "Ensuring OIDC provider exists and converges to the locked repository/environment policy"
+log "Ensuring OIDC provider exists and converges to the locked repository/workflow/environment policy"
 if gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
   --project="$PROJECT_ID" \
   --location="global" \
@@ -90,7 +92,7 @@ else
     --attribute-mapping="$ATTRIBUTE_MAPPING" \
     --attribute-condition="$ATTRIBUTE_CONDITION" \
     --display-name="Click&SaveAI GitHub" \
-    --description="Trust only the immutable Click&SaveAI repo/owner IDs in the staging GitHub environment"
+    --description="Trust only Click&SaveAI main deploy-staging workflow in the staging environment"
 fi
 
 WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
@@ -168,6 +170,8 @@ Security boundary applied at the Google provider:
   repository_id       = ${GITHUB_REPOSITORY_ID}
   repository_owner_id = ${GITHUB_REPOSITORY_OWNER_ID}
   environment         = ${GITHUB_ENVIRONMENT}
+  ref                 = ${GITHUB_REF}
+  job_workflow_ref    = ${GITHUB_JOB_WORKFLOW_REF}
 
 No service-account key was created.
 EOF

--- a/scripts/bootstrap-staging-wif.sh
+++ b/scripts/bootstrap-staging-wif.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Click&SaveAI staging GitHub Actions -> Google Cloud Workload Identity Federation bootstrap.
+#
+# Run this once from a trusted administrator shell that has gcloud installed and an
+# active account allowed to create IAM service accounts, WIF pools/providers and
+# project IAM bindings. The script never creates or downloads a service-account key.
+
+PROJECT_ID="${PROJECT_ID:-clickandsaveai-staging}"
+POOL_ID="${POOL_ID:-github-actions}"
+PROVIDER_ID="${PROVIDER_ID:-clickandsaveai}"
+DEPLOY_SA_ID="${DEPLOY_SA_ID:-clickandsaveai-github-deployer}"
+GITHUB_REPOSITORY_ID="${GITHUB_REPOSITORY_ID:-1314210715}"
+GITHUB_REPOSITORY_OWNER_ID="${GITHUB_REPOSITORY_OWNER_ID:-64756523}"
+GITHUB_ENVIRONMENT="${GITHUB_ENVIRONMENT:-staging}"
+GITHUB_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v gcloud >/dev/null 2>&1 || fail "gcloud is required. Run this from Google Cloud Shell or another trusted admin shell."
+
+ACTIVE_ACCOUNT="$(gcloud auth list --filter='status:ACTIVE' --format='value(account)' | head -n 1)"
+[[ -n "$ACTIVE_ACCOUNT" ]] || fail "No active gcloud account. Authenticate an administrator first."
+
+log "Validating Google Cloud project $PROJECT_ID as $ACTIVE_ACCOUNT"
+gcloud projects describe "$PROJECT_ID" --format='value(projectId)' >/dev/null
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+[[ "$PROJECT_NUMBER" =~ ^[0-9]+$ ]] || fail "Could not resolve the numeric project number for $PROJECT_ID."
+
+DEPLOY_SA_EMAIL="${DEPLOY_SA_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+RUNTIME_SA_EMAIL="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+
+log "Enabling APIs required for keyless federation and deployment"
+gcloud services enable \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com \
+  sts.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  --project="$PROJECT_ID"
+
+log "Ensuring deploy service account exists: $DEPLOY_SA_EMAIL"
+if ! gcloud iam service-accounts describe "$DEPLOY_SA_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  gcloud iam service-accounts create "$DEPLOY_SA_ID" \
+    --project="$PROJECT_ID" \
+    --display-name="Click&SaveAI GitHub staging deployer" \
+    --description="Keyless GitHub Actions deploy identity for Click&SaveAI staging only"
+fi
+
+log "Ensuring Workload Identity Pool exists: $POOL_ID"
+if ! gcloud iam workload-identity-pools describe "$POOL_ID" \
+  --project="$PROJECT_ID" \
+  --location="global" >/dev/null 2>&1; then
+  gcloud iam workload-identity-pools create "$POOL_ID" \
+    --project="$PROJECT_ID" \
+    --location="global" \
+    --display-name="GitHub Actions" \
+    --description="Keyless GitHub Actions identities for Click&SaveAI"
+fi
+
+ATTRIBUTE_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.repository_owner_id=assertion.repository_owner_id,attribute.environment=assertion.environment"
+ATTRIBUTE_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && assertion.environment=='${GITHUB_ENVIRONMENT}'"
+
+log "Ensuring OIDC provider exists and converges to the locked repository/environment policy"
+if gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+  --project="$PROJECT_ID" \
+  --location="global" \
+  --workload-identity-pool="$POOL_ID" >/dev/null 2>&1; then
+  gcloud iam workload-identity-pools providers update-oidc "$PROVIDER_ID" \
+    --project="$PROJECT_ID" \
+    --location="global" \
+    --workload-identity-pool="$POOL_ID" \
+    --issuer-uri="$GITHUB_OIDC_ISSUER" \
+    --attribute-mapping="$ATTRIBUTE_MAPPING" \
+    --attribute-condition="$ATTRIBUTE_CONDITION" \
+    --display-name="Click&SaveAI GitHub"
+else
+  gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_ID" \
+    --project="$PROJECT_ID" \
+    --location="global" \
+    --workload-identity-pool="$POOL_ID" \
+    --issuer-uri="$GITHUB_OIDC_ISSUER" \
+    --attribute-mapping="$ATTRIBUTE_MAPPING" \
+    --attribute-condition="$ATTRIBUTE_CONDITION" \
+    --display-name="Click&SaveAI GitHub" \
+    --description="Trust only the immutable Click&SaveAI repo/owner IDs in the staging GitHub environment"
+fi
+
+WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
+
+log "Allowing only the trusted federated repository principal set to impersonate the deploy service account"
+gcloud iam service-accounts add-iam-policy-binding "$DEPLOY_SA_EMAIL" \
+  --project="$PROJECT_ID" \
+  --member="$WIF_MEMBER" \
+  --role="roles/iam.workloadIdentityUser" \
+  --condition=None >/dev/null
+
+# Product-specific deployment roles. Firebase Viewer supplies the read-only Firebase
+# project metadata permissions that the CLI needs; write access remains scoped to the
+# services actually deployed by deploy-staging.yml.
+PROJECT_ROLES=(
+  roles/firebase.viewer
+  roles/cloudfunctions.admin
+  roles/firebaserules.admin
+  roles/datastore.indexAdmin
+  roles/cloudscheduler.admin
+  roles/secretmanager.viewer
+)
+
+log "Granting least-privilege project deployment roles to $DEPLOY_SA_EMAIL"
+for role in "${PROJECT_ROLES[@]}"; do
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
+    --role="$role" \
+    --condition=None \
+    --quiet >/dev/null
+done
+
+log "Granting Service Account User on the Cloud Run functions runtime service account"
+gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA_EMAIL" \
+  --project="$PROJECT_ID" \
+  --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
+  --role="roles/iam.serviceAccountUser" \
+  --condition=None >/dev/null
+
+log "Resolving the project's actual Cloud Build default service account"
+CLOUD_BUILD_SA_EMAIL="$(gcloud builds get-default-service-account --project="$PROJECT_ID" --format='value(serviceAccountEmail)' 2>/dev/null || true)"
+if [[ -z "$CLOUD_BUILD_SA_EMAIL" ]]; then
+  # Some gcloud versions return the email as plain output instead of a structured field.
+  CLOUD_BUILD_SA_EMAIL="$(gcloud builds get-default-service-account --project="$PROJECT_ID" 2>/dev/null | tail -n 1 | tr -d '[:space:]')"
+fi
+[[ "$CLOUD_BUILD_SA_EMAIL" == *@*.gserviceaccount.com ]] || fail "Could not resolve the Cloud Build default service account."
+
+log "Granting deployer Service Account User on Cloud Build account: $CLOUD_BUILD_SA_EMAIL"
+gcloud iam service-accounts add-iam-policy-binding "$CLOUD_BUILD_SA_EMAIL" \
+  --project="$PROJECT_ID" \
+  --member="serviceAccount:${DEPLOY_SA_EMAIL}" \
+  --role="roles/iam.serviceAccountUser" \
+  --condition=None >/dev/null
+
+log "Ensuring the Cloud Build service account can execute builds"
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${CLOUD_BUILD_SA_EMAIL}" \
+  --role="roles/cloudbuild.builds.builder" \
+  --condition=None \
+  --quiet >/dev/null
+
+WIF_PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
+
+log "Bootstrap complete"
+cat <<EOF
+
+Set these two GitHub Environment variables on:
+  Repository: vhanukaev1981/ClickAndSaveAI
+  Environment: staging
+
+GCP_WORKLOAD_IDENTITY_PROVIDER=${WIF_PROVIDER_RESOURCE}
+GCP_DEPLOY_SERVICE_ACCOUNT=${DEPLOY_SA_EMAIL}
+
+Security boundary applied at the Google provider:
+  repository_id       = ${GITHUB_REPOSITORY_ID}
+  repository_owner_id = ${GITHUB_REPOSITORY_OWNER_ID}
+  environment         = ${GITHUB_ENVIRONMENT}
+
+No service-account key was created.
+EOF

--- a/scripts/configure-github-staging-vars.sh
+++ b/scripts/configure-github-staging-vars.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-clickandsaveai-staging}"
+POOL_ID="${POOL_ID:-github-actions}"
+PROVIDER_ID="${PROVIDER_ID:-clickandsaveai}"
+DEPLOY_SA_ID="${DEPLOY_SA_ID:-clickandsaveai-github-deployer}"
+GITHUB_REPO="${GITHUB_REPO:-vhanukaev1981/ClickAndSaveAI}"
+GITHUB_ENVIRONMENT="${GITHUB_ENVIRONMENT:-staging}"
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v gcloud >/dev/null 2>&1 || fail "gcloud is required to resolve the numeric project number."
+command -v gh >/dev/null 2>&1 || fail "GitHub CLI (gh) is required. Install/authenticate gh or set the two variables in the GitHub UI."
+
+gh auth status >/dev/null 2>&1 || fail "GitHub CLI is not authenticated. Run: gh auth login"
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+[[ "$PROJECT_NUMBER" =~ ^[0-9]+$ ]] || fail "Could not resolve project number for $PROJECT_ID."
+
+DEPLOY_SA_EMAIL="${DEPLOY_SA_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+WIF_PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
+
+printf 'Setting keyless staging deployment variables on %s / environment %s...\n' "$GITHUB_REPO" "$GITHUB_ENVIRONMENT"
+
+gh variable set GCP_WORKLOAD_IDENTITY_PROVIDER \
+  --repo "$GITHUB_REPO" \
+  --env "$GITHUB_ENVIRONMENT" \
+  --body "$WIF_PROVIDER_RESOURCE"
+
+gh variable set GCP_DEPLOY_SERVICE_ACCOUNT \
+  --repo "$GITHUB_REPO" \
+  --env "$GITHUB_ENVIRONMENT" \
+  --body "$DEPLOY_SA_EMAIL"
+
+ACTUAL_PROVIDER="$(gh variable get GCP_WORKLOAD_IDENTITY_PROVIDER --repo "$GITHUB_REPO" --env "$GITHUB_ENVIRONMENT" 2>/dev/null || true)"
+ACTUAL_SA="$(gh variable get GCP_DEPLOY_SERVICE_ACCOUNT --repo "$GITHUB_REPO" --env "$GITHUB_ENVIRONMENT" 2>/dev/null || true)"
+
+[[ "$ACTUAL_PROVIDER" == "$WIF_PROVIDER_RESOURCE" ]] || fail "GitHub provider variable verification failed."
+[[ "$ACTUAL_SA" == "$DEPLOY_SA_EMAIL" ]] || fail "GitHub deploy service-account variable verification failed."
+
+cat <<EOF
+PASS: GitHub staging variables configured and verified.
+GCP_WORKLOAD_IDENTITY_PROVIDER=${WIF_PROVIDER_RESOURCE}
+GCP_DEPLOY_SERVICE_ACCOUNT=${DEPLOY_SA_EMAIL}
+EOF

--- a/scripts/verify-staging-wif.sh
+++ b/scripts/verify-staging-wif.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-clickandsaveai-staging}"
+POOL_ID="${POOL_ID:-github-actions}"
+PROVIDER_ID="${PROVIDER_ID:-clickandsaveai}"
+DEPLOY_SA_ID="${DEPLOY_SA_ID:-clickandsaveai-github-deployer}"
+GITHUB_REPOSITORY_ID="${GITHUB_REPOSITORY_ID:-1314210715}"
+GITHUB_REPOSITORY_OWNER_ID="${GITHUB_REPOSITORY_OWNER_ID:-64756523}"
+GITHUB_ENVIRONMENT="${GITHUB_ENVIRONMENT:-staging}"
+
+pass() { printf 'PASS  %s\n' "$*"; }
+fail() { printf 'FAIL  %s\n' "$*" >&2; FAILED=1; }
+
+command -v gcloud >/dev/null 2>&1 || { echo "gcloud is required" >&2; exit 1; }
+FAILED=0
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)' 2>/dev/null || true)"
+if [[ "$PROJECT_NUMBER" =~ ^[0-9]+$ ]]; then
+  pass "project $PROJECT_ID -> $PROJECT_NUMBER"
+else
+  fail "cannot resolve project number for $PROJECT_ID"
+  exit 1
+fi
+
+DEPLOY_SA_EMAIL="${DEPLOY_SA_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+RUNTIME_SA_EMAIL="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+WIF_PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
+WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
+EXPECTED_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && assertion.environment=='${GITHUB_ENVIRONMENT}'"
+
+if gcloud iam service-accounts describe "$DEPLOY_SA_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
+  pass "deploy service account exists"
+else
+  fail "deploy service account missing: $DEPLOY_SA_EMAIL"
+fi
+
+if gcloud iam workload-identity-pools describe "$POOL_ID" \
+  --project="$PROJECT_ID" --location=global >/dev/null 2>&1; then
+  pass "workload identity pool exists"
+else
+  fail "workload identity pool missing: $POOL_ID"
+fi
+
+if gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+  --project="$PROJECT_ID" --location=global --workload-identity-pool="$POOL_ID" >/dev/null 2>&1; then
+  pass "OIDC provider exists"
+  ACTUAL_CONDITION="$(gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+    --project="$PROJECT_ID" --location=global --workload-identity-pool="$POOL_ID" \
+    --format='value(attributeCondition)')"
+  if [[ "$ACTUAL_CONDITION" == "$EXPECTED_CONDITION" ]]; then
+    pass "provider condition locks repo ID, owner ID and staging environment"
+  else
+    fail "provider condition differs from expected secure condition"
+    printf '      expected: %s\n      actual:   %s\n' "$EXPECTED_CONDITION" "$ACTUAL_CONDITION" >&2
+  fi
+else
+  fail "OIDC provider missing: $PROVIDER_ID"
+fi
+
+if gcloud iam service-accounts get-iam-policy "$DEPLOY_SA_EMAIL" \
+  --project="$PROJECT_ID" \
+  --flatten='bindings[].members' \
+  --filter="bindings.role=roles/iam.workloadIdentityUser AND bindings.members=${WIF_MEMBER}" \
+  --format='value(bindings.role)' | grep -Fxq 'roles/iam.workloadIdentityUser'; then
+  pass "federated repository principal can impersonate deploy service account"
+else
+  fail "roles/iam.workloadIdentityUser binding missing on deploy service account"
+fi
+
+PROJECT_ROLES=(
+  roles/firebase.viewer
+  roles/cloudfunctions.admin
+  roles/firebaserules.admin
+  roles/datastore.indexAdmin
+  roles/cloudscheduler.admin
+  roles/secretmanager.viewer
+)
+
+for role in "${PROJECT_ROLES[@]}"; do
+  if gcloud projects get-iam-policy "$PROJECT_ID" \
+    --flatten='bindings[].members' \
+    --filter="bindings.role=${role} AND bindings.members=serviceAccount:${DEPLOY_SA_EMAIL}" \
+    --format='value(bindings.role)' | grep -Fxq "$role"; then
+    pass "$DEPLOY_SA_EMAIL has $role"
+  else
+    fail "$DEPLOY_SA_EMAIL is missing $role"
+  fi
+done
+
+if gcloud iam service-accounts get-iam-policy "$RUNTIME_SA_EMAIL" \
+  --project="$PROJECT_ID" \
+  --flatten='bindings[].members' \
+  --filter="bindings.role=roles/iam.serviceAccountUser AND bindings.members=serviceAccount:${DEPLOY_SA_EMAIL}" \
+  --format='value(bindings.role)' | grep -Fxq 'roles/iam.serviceAccountUser'; then
+  pass "deployer can act as Cloud Run functions runtime service account"
+else
+  fail "deployer cannot act as runtime service account $RUNTIME_SA_EMAIL"
+fi
+
+CLOUD_BUILD_SA_EMAIL="$(gcloud builds get-default-service-account --project="$PROJECT_ID" --format='value(serviceAccountEmail)' 2>/dev/null || true)"
+if [[ -z "$CLOUD_BUILD_SA_EMAIL" ]]; then
+  CLOUD_BUILD_SA_EMAIL="$(gcloud builds get-default-service-account --project="$PROJECT_ID" 2>/dev/null | tail -n 1 | tr -d '[:space:]')"
+fi
+
+if [[ "$CLOUD_BUILD_SA_EMAIL" == *@*.gserviceaccount.com ]]; then
+  pass "Cloud Build default service account resolved: $CLOUD_BUILD_SA_EMAIL"
+
+  if gcloud iam service-accounts get-iam-policy "$CLOUD_BUILD_SA_EMAIL" \
+    --project="$PROJECT_ID" \
+    --flatten='bindings[].members' \
+    --filter="bindings.role=roles/iam.serviceAccountUser AND bindings.members=serviceAccount:${DEPLOY_SA_EMAIL}" \
+    --format='value(bindings.role)' | grep -Fxq 'roles/iam.serviceAccountUser'; then
+    pass "deployer can act as Cloud Build service account"
+  else
+    fail "deployer cannot act as Cloud Build service account"
+  fi
+
+  if gcloud projects get-iam-policy "$PROJECT_ID" \
+    --flatten='bindings[].members' \
+    --filter="bindings.role=roles/cloudbuild.builds.builder AND bindings.members=serviceAccount:${CLOUD_BUILD_SA_EMAIL}" \
+    --format='value(bindings.role)' | grep -Fxq 'roles/cloudbuild.builds.builder'; then
+    pass "Cloud Build service account has roles/cloudbuild.builds.builder"
+  else
+    fail "Cloud Build service account is missing roles/cloudbuild.builds.builder"
+  fi
+else
+  fail "could not resolve Cloud Build default service account"
+fi
+
+printf '\nGitHub staging environment variables should be:\n'
+printf 'GCP_WORKLOAD_IDENTITY_PROVIDER=%s\n' "$WIF_PROVIDER_RESOURCE"
+printf 'GCP_DEPLOY_SERVICE_ACCOUNT=%s\n' "$DEPLOY_SA_EMAIL"
+
+if (( FAILED != 0 )); then
+  printf '\nWIF verification FAILED. Fix the items above before retrying staging deploy.\n' >&2
+  exit 1
+fi
+
+printf '\nWIF verification PASSED. No service-account key is required.\n'

--- a/scripts/verify-staging-wif.sh
+++ b/scripts/verify-staging-wif.sh
@@ -8,6 +8,8 @@ DEPLOY_SA_ID="${DEPLOY_SA_ID:-clickandsaveai-github-deployer}"
 GITHUB_REPOSITORY_ID="${GITHUB_REPOSITORY_ID:-1314210715}"
 GITHUB_REPOSITORY_OWNER_ID="${GITHUB_REPOSITORY_OWNER_ID:-64756523}"
 GITHUB_ENVIRONMENT="${GITHUB_ENVIRONMENT:-staging}"
+GITHUB_REF="${GITHUB_REF:-refs/heads/main}"
+GITHUB_JOB_WORKFLOW_REF="${GITHUB_JOB_WORKFLOW_REF:-vhanukaev1981/ClickAndSaveAI/.github/workflows/deploy-staging.yml@refs/heads/main}"
 
 pass() { printf 'PASS  %s\n' "$*"; }
 fail() { printf 'FAIL  %s\n' "$*" >&2; FAILED=1; }
@@ -27,7 +29,7 @@ DEPLOY_SA_EMAIL="${DEPLOY_SA_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
 RUNTIME_SA_EMAIL="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
 WIF_PROVIDER_RESOURCE="projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/providers/${PROVIDER_ID}"
 WIF_MEMBER="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
-EXPECTED_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && assertion.environment=='${GITHUB_ENVIRONMENT}'"
+EXPECTED_CONDITION="assertion.repository_id=='${GITHUB_REPOSITORY_ID}' && assertion.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && assertion.environment=='${GITHUB_ENVIRONMENT}' && assertion.ref=='${GITHUB_REF}' && assertion.job_workflow_ref=='${GITHUB_JOB_WORKFLOW_REF}'"
 
 if gcloud iam service-accounts describe "$DEPLOY_SA_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
   pass "deploy service account exists"
@@ -49,7 +51,7 @@ if gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
     --project="$PROJECT_ID" --location=global --workload-identity-pool="$POOL_ID" \
     --format='value(attributeCondition)')"
   if [[ "$ACTUAL_CONDITION" == "$EXPECTED_CONDITION" ]]; then
-    pass "provider condition locks repo ID, owner ID and staging environment"
+    pass "provider condition locks repo ID, owner ID, staging environment, main ref and deploy workflow"
   else
     fail "provider condition differs from expected secure condition"
     printf '      expected: %s\n      actual:   %s\n' "$EXPECTED_CONDITION" "$ACTUAL_CONDITION" >&2


### PR DESCRIPTION
## Goal
Remove the current staging deployment blocker without touching locked Stream A application code.

## Adds
- idempotent `scripts/bootstrap-staging-wif.sh`
- `scripts/verify-staging-wif.sh`
- optional authenticated `scripts/configure-github-staging-vars.sh`
- focused Ops CI
- WIF/bootstrap runbook
- queued post-E2E authoritative Bills sync design
- hardened `deploy-staging.yml` that deploys an exact 40-character Stream A commit SHA instead of a mutable branch

## Security
- no service-account JSON key is created/downloaded
- Google OIDC trust is restricted to immutable GitHub repository ID `1314210715`, owner ID `64756523`, environment `staging`, `refs/heads/main`, and `vhanukaev1981/ClickAndSaveAI/.github/workflows/deploy-staging.yml@refs/heads/main`
- deploy workflow checks exact checkout SHA and verifies the SHA belongs to Stream A lineage
- staging project is hard-pinned to `clickandsaveai-staging`
- deploy identity is separate from runtime/build identities
- `roles/iam.serviceAccountUser` is scoped to required runtime/Cloud Build service accounts rather than project-wide
- no Owner/Editor role

## Locked application baseline
This PR does not move Stream A. The application E2E correction baseline remains `ac2105098d698df06159f929f41595f91505c855` with full-green CI run `31292701315`.

## Validation
Latest Ops CI run `31301238199` is green on head `4133aa1e392352024a0a4a584b2580296370c1f2`, including immutable-deployment and keyless/scoped-trust guards.

After merge, the only external dependency is one Google Cloud administrator execution of the bootstrap/verify scripts plus setting the two non-secret `staging` environment variables. The main deployment workflow can then deploy the exact locked Stream A SHA.