### PR TITLE
Integrate Stream B truthfulness and attributed savings guardrails

### DIFF
--- a/app/src/main/java/com/example/ui/CustomerPresentationPolicy.kt
+++ b/app/src/main/java/com/example/ui/CustomerPresentationPolicy.kt
@@ -21,8 +21,12 @@ object CustomerPresentationPolicy {
 
     fun verifiedSavingsLabel(monthlySaving: Double?, annualSaving: Double?): String? {
         val monthly = monthlySaving?.takeIf { it.isFinite() && it > 0.0 } ?: return null
-        val annual = annualSaving?.takeIf { it.isFinite() && it > 0.0 } ?: (monthly * 12.0)
-        return "אפשר לחסוך ${money(monthly)} בחודש • ${money(annual)} בשנה"
+        val annual = annualSaving?.takeIf { it.isFinite() && it > 0.0 }
+        return if (annual != null) {
+            "אפשר לחסוך ${money(monthly)} בחודש • ${money(annual)} בשנה"
+        } else {
+            "אפשר לחסוך ${money(monthly)} בחודש"
+        }
     }
 
     fun safeStatus(rawStatus: String?): String {

--- a/app/src/main/java/com/example/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/example/ui/screens/DashboardScreen.kt
@@ -93,14 +93,33 @@ fun DashboardScreen(
         (it.potentialMonthlySaving ?: 0.0) > 0.0 && it.matchedOffer != null
     }
     val verifiedMonthlySavings = verifiedOpportunities.sumOf { it.potentialMonthlySaving ?: 0.0 }
-    val verifiedAnnualSavings = verifiedOpportunities.sumOf {
-        it.potentialAnnualSaving?.takeIf { annual -> annual > 0.0 }
-            ?: ((it.potentialMonthlySaving ?: 0.0) * 12.0)
+    val verifiedAnnualValues = verifiedOpportunities.mapNotNull {
+        it.potentialAnnualSaving?.takeIf { annual -> annual.isFinite() && annual > 0.0 }
     }
-    val observedMonthlySpend = financialHome?.context?.observedRecurringMonthlySpend
-        ?.takeIf { it > 0.0 }
-        ?: localTotalMonthlyCost
-    val recurringServiceCount = financialHome?.context?.recurringServiceCount ?: invoices.size
+    val verifiedAnnualSavings = if (
+        verifiedOpportunities.isNotEmpty() && verifiedAnnualValues.size == verifiedOpportunities.size
+    ) {
+        verifiedAnnualValues.sum()
+    } else {
+        null
+    }
+
+    val authoritativeRecurringSpend = financialHome?.context?.observedRecurringMonthlySpend
+        ?.takeIf { it.isFinite() && it > 0.0 }
+    val localObservedSpend = localTotalMonthlyCost.takeIf { it.isFinite() && it > 0.0 }
+    val displayedMonthlySpend = authoritativeRecurringSpend ?: localObservedSpend
+    val recurringServiceCount = financialHome?.context?.recurringServiceCount
+    val spendTitle = if (authoritativeRecurringSpend != null) {
+        "הוצאה חודשית חוזרת"
+    } else {
+        "חיובים חודשיים שנצפו"
+    }
+    val spendSupporting = when {
+        authoritativeRecurringSpend != null -> "שירותים חוזרים שאומתו"
+        localObservedSpend != null -> "מהחשבונות שנקלטו; לא בהכרח חיוב חוזר"
+        else -> "ממתינים לנתונים"
+    }
+
     val categoryTotals = invoices
         .groupBy { it.category.ifBlank { "אחר" } }
         .mapValues { (_, items) -> items.sumOf { it.monthlyCost } }
@@ -169,15 +188,15 @@ fun DashboardScreen(
             ) {
                 MetricCard(
                     modifier = Modifier.weight(1f),
-                    title = "הוצאה חודשית",
-                    value = money(observedMonthlySpend),
-                    supporting = "חיובים חוזרים שזוהו"
+                    title = spendTitle,
+                    value = displayedMonthlySpend?.let(::money) ?: "—",
+                    supporting = spendSupporting
                 )
                 MetricCard(
                     modifier = Modifier.weight(1f),
-                    title = "שירותים במעקב",
-                    value = recurringServiceCount.toString(),
-                    supporting = "נבדקים אוטומטית"
+                    title = "שירותים חוזרים",
+                    value = recurringServiceCount?.toString() ?: "—",
+                    supporting = if (recurringServiceCount == null) "ממתינים לניתוח" else "שאומתו כחוזרים"
                 )
             }
         }
@@ -366,11 +385,7 @@ fun DashboardScreen(
 
 @Composable
 private fun SectionTitle(text: String) {
-    Text(
-        text,
-        style = MaterialTheme.typography.titleMedium,
-        fontWeight = FontWeight.Bold
-    )
+    Text(text, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
 }
 
 @Composable
@@ -382,11 +397,7 @@ private fun CategorySnapshotCard(category: String, amount: Double) {
         ) {
             Text(category, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
             Text(money(amount), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
-            Text(
-                "לחודש",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Text("לחודש", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
@@ -403,18 +414,13 @@ private fun ProactiveOpportunityCard(
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
             verticalAlignment = Alignment.Top
         ) {
             Icon(Icons.Default.AutoAwesome, contentDescription = null, tint = TechBluePrimary)
             Spacer(modifier = Modifier.size(10.dp))
             Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(
-                    "${opportunity.providerName} • ${opportunity.category}",
-                    fontWeight = FontWeight.Bold
-                )
+                Text("${opportunity.providerName} • ${opportunity.category}", fontWeight = FontWeight.Bold)
                 val matchedOffer = opportunity.matchedOffer
                 val verifiedLabel = if (matchedOffer != null) {
                     CustomerPresentationPolicy.verifiedSavingsLabel(
@@ -466,10 +472,7 @@ private fun InitialGmailOnboardingCard(
         shape = RoundedCornerShape(22.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
     ) {
-        Column(
-            modifier = Modifier.padding(18.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
+        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Email, contentDescription = null, tint = TechBluePrimary)
                 Spacer(modifier = Modifier.size(9.dp))
@@ -482,14 +485,9 @@ private fun InitialGmailOnboardingCard(
             Button(
                 onClick = if (authenticated) onConnectGmail else onGoogleSignIn,
                 enabled = !syncing,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("dashboard_connect_account")
+                modifier = Modifier.fillMaxWidth().testTag("dashboard_connect_account")
             ) {
-                Icon(
-                    if (authenticated) Icons.Default.Security else Icons.Default.Login,
-                    contentDescription = null
-                )
+                Icon(if (authenticated) Icons.Default.Security else Icons.Default.Login, contentDescription = null)
                 Spacer(modifier = Modifier.size(7.dp))
                 Text(if (authenticated) "חבר את החשבון" else "התחבר כדי להתחיל")
             }
@@ -499,43 +497,40 @@ private fun InitialGmailOnboardingCard(
 
 @Composable
 private fun SavingsHeroCard(
-    annualSavings: Double,
+    annualSavings: Double?,
     monthlySavings: Double,
     opportunities: Int,
     onOpenSavings: () -> Unit
 ) {
     val verified = opportunities > 0 && monthlySavings > 0.0
-    val displayAnnual = annualSavings.takeIf { it > 0.0 } ?: (monthlySavings * 12.0)
+    val verifiedAnnual = annualSavings?.takeIf { it.isFinite() && it > 0.0 }
     Card(
         onClick = onOpenSavings,
         modifier = Modifier.testTag("dashboard_savings_hero"),
         shape = RoundedCornerShape(24.dp),
         colors = CardDefaults.cardColors(containerColor = TechBluePrimary)
     ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(7.dp)
-        ) {
+        Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(7.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Savings, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary)
                 Spacer(modifier = Modifier.size(8.dp))
-                Text(
-                    "החיסכון שמצאנו עבורך",
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    fontWeight = FontWeight.Bold
-                )
+                Text("החיסכון שמצאנו עבורך", color = MaterialTheme.colorScheme.onPrimary, fontWeight = FontWeight.Bold)
             }
             Text(
-                if (verified) money(displayAnnual) else "עדיין בבדיקה",
+                when {
+                    !verified -> "עדיין בבדיקה"
+                    verifiedAnnual != null -> money(verifiedAnnual)
+                    else -> money(monthlySavings)
+                },
                 style = MaterialTheme.typography.displaySmall,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onPrimary
             )
             Text(
-                if (verified) {
-                    "בשנה • ${money(monthlySavings)} בחודש"
-                } else {
-                    "נציג כאן סכום רק אחרי שנמצא ונאמת חיסכון אמיתי"
+                when {
+                    !verified -> "נציג כאן סכום רק אחרי שנמצא ונאמת חיסכון אמיתי"
+                    verifiedAnnual != null -> "בשנה • ${money(monthlySavings)} בחודש"
+                    else -> "בחודש • חיסכון שנתי יוצג רק לאחר אימות"
                 },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onPrimary
@@ -598,11 +593,7 @@ private fun MetricCard(
         Column(modifier = Modifier.padding(15.dp), verticalArrangement = Arrangement.spacedBy(3.dp)) {
             Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
             Text(title, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
-            Text(
-                supporting,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            Text(supporting, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
@@ -617,34 +608,17 @@ private fun DashboardActionButton(
 ) {
     Card(
         onClick = onClick,
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag(testTag),
+        modifier = Modifier.fillMaxWidth().testTag(testTag),
         shape = RoundedCornerShape(18.dp)
     ) {
-        Row(
-            modifier = Modifier.padding(15.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Surface(
-                color = MaterialTheme.colorScheme.secondaryContainer,
-                shape = RoundedCornerShape(13.dp)
-            ) {
-                Icon(
-                    icon,
-                    contentDescription = null,
-                    modifier = Modifier.padding(9.dp),
-                    tint = TechBluePrimary
-                )
+        Row(modifier = Modifier.padding(15.dp), verticalAlignment = Alignment.CenterVertically) {
+            Surface(color = MaterialTheme.colorScheme.secondaryContainer, shape = RoundedCornerShape(13.dp)) {
+                Icon(icon, contentDescription = null, modifier = Modifier.padding(9.dp), tint = TechBluePrimary)
             }
             Spacer(modifier = Modifier.size(12.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(text, fontWeight = FontWeight.Bold)
-                Text(
-                    subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
     }

--- a/app/src/main/java/com/example/ui/screens/ProvidersScreen.kt
+++ b/app/src/main/java/com/example/ui/screens/ProvidersScreen.kt
@@ -68,6 +68,7 @@ fun ProvidersScreen(viewModel: MainViewModel) {
     val scope = rememberCoroutineScope()
     var financialHome by remember { mutableStateOf<FinancialHomeResult?>(null) }
     var loading by remember { mutableStateOf(false) }
+    var actionIntentStarting by remember { mutableStateOf(false) }
     var actionSubmitting by remember { mutableStateOf(false) }
     var hasError by remember { mutableStateOf(false) }
     var selectedOpportunity by remember { mutableStateOf<FinancialOpportunity?>(null) }
@@ -162,10 +163,34 @@ fun ProvidersScreen(viewModel: MainViewModel) {
                     items(opportunities, key = { it.id }) { opportunity ->
                         OpportunityCard(
                             opportunity = opportunity,
-                            actionEnabled = !actionSubmitting,
+                            actionEnabled = !actionIntentStarting && !actionSubmitting,
                             onAccept = {
-                                if (!actionSubmitting && opportunity.actionMode == IN_APP_PROVIDER_REQUEST) {
-                                    selectedOpportunity = opportunity
+                                if (
+                                    !actionIntentStarting &&
+                                    !actionSubmitting &&
+                                    opportunity.actionMode == IN_APP_PROVIDER_REQUEST
+                                ) {
+                                    val displayedOfferId = opportunity.matchedOffer?.offerId.orEmpty()
+                                    if (displayedOfferId.isBlank()) {
+                                        hasError = true
+                                    } else {
+                                        actionIntentStarting = true
+                                        actionMessage = ""
+                                        hasError = false
+                                        scope.launch {
+                                            runCatching {
+                                                actionRepository.recordSavingsActionStarted(
+                                                    opportunityId = opportunity.id,
+                                                    expectedOfferId = displayedOfferId
+                                                )
+                                            }.onSuccess {
+                                                selectedOpportunity = opportunity
+                                            }.onFailure {
+                                                hasError = true
+                                            }
+                                            actionIntentStarting = false
+                                        }
+                                    }
                                 }
                             }
                         )
@@ -173,6 +198,16 @@ fun ProvidersScreen(viewModel: MainViewModel) {
                 }
             }
 
+            if (actionIntentStarting) {
+                item {
+                    MessageCard(
+                        title = "בודקים שההצעה עדיין זמינה",
+                        body = "מאמתים את ההצעה שבחרת לפני שנבקש ממך אישור להעברת פרטי קשר.",
+                        testTag = "savings_action_starting",
+                        showProgress = true
+                    )
+                }
+            }
             if (actionSubmitting) {
                 item {
                     MessageCard(
@@ -208,7 +243,7 @@ fun ProvidersScreen(viewModel: MainViewModel) {
                                 financialHome = null
                                 refreshKey += 1
                             },
-                            enabled = !actionSubmitting,
+                            enabled = !actionIntentStarting && !actionSubmitting,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .testTag("savings_retry_refresh")
@@ -231,6 +266,11 @@ fun ProvidersScreen(viewModel: MainViewModel) {
                 onSubmit = { name, phone, email ->
                     if (actionSubmitting) return@SavingsActionDialog
                     val displayedOfferId = opportunity.matchedOffer?.offerId.orEmpty()
+                    if (displayedOfferId.isBlank()) {
+                        selectedOpportunity = null
+                        hasError = true
+                        return@SavingsActionDialog
+                    }
                     selectedOpportunity = null
                     actionMessage = ""
                     hasError = false
@@ -247,7 +287,7 @@ fun ProvidersScreen(viewModel: MainViewModel) {
                         }.onSuccess { result ->
                             val savingLabel = CustomerPresentationPolicy.verifiedSavingsLabel(
                                 result.potentialMonthlySaving,
-                                result.potentialMonthlySaving * 12.0
+                                result.potentialAnnualSaving
                             ) ?: "הבקשה נשמרה וההצעה תיבדק שוב לפני המשך הטיפול."
                             actionMessage = "הבקשה להצעה של ${opportunity.matchedOffer?.providerName.orEmpty()} נקלטה. $savingLabel"
                             hasError = false
@@ -363,7 +403,7 @@ private fun OpportunityCard(
                                 .fillMaxWidth()
                                 .testTag("accept_savings_${opportunity.id}")
                         ) {
-                            Text(if (actionEnabled) "אני רוצה לחסוך ${money(monthlySaving)} בחודש" else "הבקשה נשלחת…")
+                            Text(if (actionEnabled) "אני רוצה לחסוך ${money(monthlySaving)} בחודש" else "הבקשה נבדקת…")
                         }
                     }
                     else -> {

--- a/app/src/test/java/com/example/CustomerPresentationPolicyTest.kt
+++ b/app/src/test/java/com/example/CustomerPresentationPolicyTest.kt
@@ -16,16 +16,23 @@ class CustomerPresentationPolicyTest {
     }
 
     @Test
-    fun positiveMonthlySavingProducesCustomerFacingLabel() {
+    fun positiveMonthlyAndAnnualSavingProduceCustomerFacingLabel() {
         val label = CustomerPresentationPolicy.verifiedSavingsLabel(25.0, 300.0)
         assertTrue(label.orEmpty().contains("₪25.00"))
         assertTrue(label.orEmpty().contains("₪300.00"))
     }
 
     @Test
-    fun annualSavingFallsBackToVerifiedMonthlyTimesTwelve() {
+    fun missingAnnualSavingShowsVerifiedMonthlyOnly() {
         val label = CustomerPresentationPolicy.verifiedSavingsLabel(25.0, null)
-        assertTrue(label.orEmpty().contains("₪300.00"))
+        assertEquals("אפשר לחסוך ₪25.00 בחודש", label)
+        assertFalse(label.orEmpty().contains("₪300.00"))
+        assertFalse(label.orEmpty().contains("בשנה"))
+    }
+
+    @Test
+    fun nonPositiveAnnualSavingIsNotInventedFromMonthlySaving() {
+        assertEquals("אפשר לחסוך ₪25.00 בחודש", CustomerPresentationPolicy.verifiedSavingsLabel(25.0, 0.0))
     }
 
     @Test

--- a/app/src/test/java/com/example/CustomerUiSourceGuardTest.kt
+++ b/app/src/test/java/com/example/CustomerUiSourceGuardTest.kt
@@ -108,6 +108,7 @@ class CustomerUiSourceGuardTest {
             "savings_under_review_state",
             "savings_error_state",
             "savings_retry_refresh",
+            "savings_action_starting",
             "savings_action_submitting",
             "accept_savings_",
             "savings_contact_consent",
@@ -154,6 +155,26 @@ class CustomerUiSourceGuardTest {
     }
 
     @Test
+    fun dashboardDoesNotInferRecurringContextOrAnnualSavings() {
+        val dashboard = File(screenPaths[0]).readText()
+        assertFalse(
+            "Invoice count is not an authoritative recurring-service count",
+            dashboard.contains("recurringServiceCount ?: invoices.size")
+        )
+        assertFalse(
+            "Dashboard must not synthesize annual savings from monthly savings",
+            dashboard.contains("potentialMonthlySaving ?: 0.0) * 12.0")
+        )
+        assertFalse(
+            "Savings hero must not synthesize annual savings",
+            dashboard.contains("monthlySavings * 12.0")
+        )
+        assertTrue(dashboard.contains("localObservedSpend"))
+        assertTrue(dashboard.contains("לא בהכרח חיוב חוזר"))
+        assertTrue(dashboard.contains("recurringServiceCount?.toString() ?: \"—\""))
+    }
+
+    @Test
     fun savingsErrorStateKeepsExplicitRetryPath() {
         val savings = File(screenPaths[2]).readText()
         assertTrue(savings.contains("savings_error_state"))
@@ -193,13 +214,27 @@ class CustomerUiSourceGuardTest {
     }
 
     @Test
-    fun savingsSubmissionExposesProgressAndBlocksDuplicateActions() {
+    fun savingsSubmissionPreservesIntentProgressAndBlocksDuplicateActions() {
         val savings = File(screenPaths[2]).readText()
+        assertTrue(savings.contains("actionIntentStarting"))
         assertTrue(savings.contains("actionSubmitting"))
+        assertTrue(savings.contains("savings_action_starting"))
         assertTrue(savings.contains("savings_action_submitting"))
-        assertTrue(savings.contains("actionEnabled = !actionSubmitting"))
+        assertTrue(savings.contains("actionEnabled = !actionIntentStarting && !actionSubmitting"))
         assertTrue(savings.contains("enabled = actionEnabled"))
         assertTrue(savings.contains("if (actionSubmitting) return@SavingsActionDialog"))
+        assertTrue(
+            "Savings action must record ACTION_STARTED before opening explicit provider consent",
+            savings.contains("recordSavingsActionStarted(")
+        )
+        assertFalse(
+            "Savings success UI must use backend annual economics, not monthly x 12",
+            savings.contains("result.potentialMonthlySaving * 12.0")
+        )
+        assertTrue(
+            "Savings success UI must preserve backend-returned annual savings",
+            savings.contains("result.potentialAnnualSaving")
+        )
     }
 
     @Test


### PR DESCRIPTION
Superseded by `review/ui-truthfulness-current`, rebuilt directly from the current Stream B head `4b10b8dab97a027685312ce891ff17f324fbe874`. The old run failed on a stale integration snapshot; do not merge this PR.