### PR TITLE
Queue authoritative observed Bills synchronization after E2E #2

### DIFF
--- a/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
+++ b/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
@@ -19,7 +19,6 @@ import com.google.firebase.messaging.RemoteMessage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 private const val PUSH_CHANNEL_ID = "savings_opportunities"
@@ -48,6 +47,8 @@ object PushRegistration {
 }
 
 class ClickAndSaveMessagingService : FirebaseMessagingService() {
+    // This is an acceleration path only. Android may reclaim the process after an FCM
+    // callback; authoritative reconciliation is guaranteed again on authenticated startup.
     private val refreshScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onNewToken(token: String) {
@@ -70,11 +71,6 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
         showNotification(title, body)
     }
 
-    override fun onDestroy() {
-        refreshScope.cancel()
-        super.onDestroy()
-    }
-
     private fun refreshObservedBillsFromBackend() {
         if (FirebaseAuth.getInstance().currentUser == null) return
         val shoppingRepository = ShoppingRepository(AppDatabase.getDatabase(applicationContext))
@@ -82,8 +78,8 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
         refreshScope.launch {
             runCatching { observedBillsRepository.refreshObservedBills() }
                 .onFailure { error ->
-                    // The push notification remains useful even when the lightweight local
-                    // reconciliation is temporarily unavailable. App startup will retry it.
+                    // The push notification remains useful even when this best-effort local
+                    // reconciliation is unavailable. Authenticated app startup retries it.
                     Log.w("ObservedBillsRefresh", "NEW_INVOICE snapshot refresh failed", error)
                 }
         }

--- a/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
+++ b/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.launch
 
 private const val PUSH_CHANNEL_ID = "savings_opportunities"
 private const val PUSH_CHANNEL_NAME = "הזדמנויות חיסכון"
-private const val PUSH_TYPE_NEW_INVOICE = "NEW_INVOICE"
 
 object PushRegistration {
     fun registerCurrentToken() {
@@ -48,7 +47,7 @@ object PushRegistration {
 
 class ClickAndSaveMessagingService : FirebaseMessagingService() {
     // This is an acceleration path only. Android may reclaim the process after an FCM
-    // callback; authoritative reconciliation is guaranteed again on authenticated startup.
+    // callback; authoritative reconciliation is guaranteed again on authenticated startup/resume.
     private val refreshScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onNewToken(token: String) {
@@ -58,17 +57,18 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
-        if (message.data["type"] == PUSH_TYPE_NEW_INVOICE) {
+        val pushType = message.data[PUSH_TYPE_EXTRA]
+        if (pushType == PUSH_TYPE_NEW_INVOICE) {
             refreshObservedBillsFromBackend()
         }
 
         val title = message.notification?.title
             ?: message.data["title"]
-            ?: "מצאנו הזדמנות לחיסכון"
+            ?: "מצאנו עדכון חדש"
         val body = message.notification?.body
             ?: message.data["body"]
-            ?: "פתח את ClickAndSaveAI כדי לראות כמה אפשר לחסוך."
-        showNotification(title, body)
+            ?: "פתח את ClickAndSaveAI כדי לראות את העדכון."
+        showNotification(title, body, pushType)
     }
 
     private fun refreshObservedBillsFromBackend() {
@@ -79,13 +79,13 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
             runCatching { observedBillsRepository.refreshObservedBills() }
                 .onFailure { error ->
                     // The push notification remains useful even when this best-effort local
-                    // reconciliation is unavailable. Authenticated app startup retries it.
+                    // reconciliation is unavailable. Authenticated app startup/resume retries it.
                     Log.w("ObservedBillsRefresh", "NEW_INVOICE snapshot refresh failed", error)
                 }
         }
     }
 
-    private fun showNotification(title: String, body: String) {
+    private fun showNotification(title: String, body: String, pushType: String?) {
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             notificationManager.createNotificationChannel(
@@ -99,13 +99,22 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
             )
         }
 
+        val destinationTab = destinationTabForPushType(pushType)
         val openAppIntent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-            putExtra("openSavingsOpportunity", true)
+            if (destinationTab != null && pushType != null) {
+                putExtra(PUSH_TYPE_EXTRA, pushType)
+            }
+        }
+        val pendingIntentRequestCode = when (destinationTab) {
+            1 -> 101
+            2 -> 102
+            0 -> 100
+            else -> 199
         }
         val pendingIntent = PendingIntent.getActivity(
             this,
-            0,
+            pendingIntentRequestCode,
             openAppIntent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )

--- a/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
+++ b/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
@@ -1,5 +1,6 @@
 package com.example
 
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -95,6 +96,7 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
                     NotificationManager.IMPORTANCE_DEFAULT
                 ).apply {
                     description = "התראות על חשבוניות והזדמנויות חיסכון חדשות"
+                    lockscreenVisibility = Notification.VISIBILITY_PRIVATE
                 }
             )
         }
@@ -124,6 +126,7 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
             .setContentTitle(title)
             .setContentText(body)
             .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
             .build()

--- a/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
+++ b/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
@@ -8,14 +8,23 @@ import android.content.Intent
 import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import com.example.data.local.AppDatabase
+import com.example.data.repository.ObservedBillsRepository
+import com.example.data.repository.ShoppingRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.functions.FirebaseFunctions
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 private const val PUSH_CHANNEL_ID = "savings_opportunities"
 private const val PUSH_CHANNEL_NAME = "הזדמנויות חיסכון"
+private const val PUSH_TYPE_NEW_INVOICE = "NEW_INVOICE"
 
 object PushRegistration {
     fun registerCurrentToken() {
@@ -39,6 +48,8 @@ object PushRegistration {
 }
 
 class ClickAndSaveMessagingService : FirebaseMessagingService() {
+    private val refreshScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         PushRegistration.registerToken(token)
@@ -46,6 +57,10 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
+        if (message.data["type"] == PUSH_TYPE_NEW_INVOICE) {
+            refreshObservedBillsFromBackend()
+        }
+
         val title = message.notification?.title
             ?: message.data["title"]
             ?: "מצאנו הזדמנות לחיסכון"
@@ -53,6 +68,25 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
             ?: message.data["body"]
             ?: "פתח את ClickAndSaveAI כדי לראות כמה אפשר לחסוך."
         showNotification(title, body)
+    }
+
+    override fun onDestroy() {
+        refreshScope.cancel()
+        super.onDestroy()
+    }
+
+    private fun refreshObservedBillsFromBackend() {
+        if (FirebaseAuth.getInstance().currentUser == null) return
+        val shoppingRepository = ShoppingRepository(AppDatabase.getDatabase(applicationContext))
+        val observedBillsRepository = ObservedBillsRepository(shoppingRepository)
+        refreshScope.launch {
+            runCatching { observedBillsRepository.refreshObservedBills() }
+                .onFailure { error ->
+                    // The push notification remains useful even when the lightweight local
+                    // reconciliation is temporarily unavailable. App startup will retry it.
+                    Log.w("ObservedBillsRefresh", "NEW_INVOICE snapshot refresh failed", error)
+                }
+        }
     }
 
     private fun showNotification(title: String, body: String) {

--- a/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
+++ b/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
@@ -1,12 +1,9 @@
 package com.example
 
-import android.app.Notification
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.example.data.local.AppDatabase
@@ -21,9 +18,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-
-private const val PUSH_CHANNEL_ID = "savings_opportunities"
-private const val PUSH_CHANNEL_NAME = "הזדמנויות חיסכון"
 
 object PushRegistration {
     fun registerCurrentToken() {
@@ -87,19 +81,8 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
     }
 
     private fun showNotification(title: String, body: String, pushType: String?) {
+        FinancialNotificationChannels.ensureCreated(this)
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            notificationManager.createNotificationChannel(
-                NotificationChannel(
-                    PUSH_CHANNEL_ID,
-                    PUSH_CHANNEL_NAME,
-                    NotificationManager.IMPORTANCE_DEFAULT
-                ).apply {
-                    description = "התראות על חשבוניות והזדמנויות חיסכון חדשות"
-                    lockscreenVisibility = Notification.VISIBILITY_PRIVATE
-                }
-            )
-        }
 
         val destinationTab = destinationTabForPushType(pushType)
         val openAppIntent = Intent(this, MainActivity::class.java).apply {
@@ -121,7 +104,7 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val notification = NotificationCompat.Builder(this, PUSH_CHANNEL_ID)
+        val notification = NotificationCompat.Builder(this, FINANCIAL_PUSH_CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_dialog_info)
             .setContentTitle(title)
             .setContentText(body)

--- a/app/src/main/java/com/example/FinancialNotificationChannels.kt
+++ b/app/src/main/java/com/example/FinancialNotificationChannels.kt
@@ -1,0 +1,28 @@
+package com.example
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+
+internal const val FINANCIAL_PUSH_CHANNEL_ID = "savings_opportunities"
+internal const val FINANCIAL_PUSH_CHANNEL_NAME = "הזדמנויות חיסכון"
+
+internal object FinancialNotificationChannels {
+    fun ensureCreated(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                FINANCIAL_PUSH_CHANNEL_ID,
+                FINANCIAL_PUSH_CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "התראות על חשבוניות והזדמנויות חיסכון חדשות"
+                lockscreenVisibility = Notification.VISIBILITY_PRIVATE
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/example/MainActivity.kt
+++ b/app/src/main/java/com/example/MainActivity.kt
@@ -109,6 +109,7 @@ class MainActivity : ComponentActivity() {
             }
         }
 
+        applyPushDestination(intent)
         maybeTriggerDebugTestPush(intent)
     }
 
@@ -136,7 +137,17 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        applyPushDestination(intent)
         maybeTriggerDebugTestPush(intent)
+    }
+
+    private fun applyPushDestination(intent: Intent?) {
+        val pushType = intent?.getStringExtra(PUSH_TYPE_EXTRA) ?: return
+        val destinationTab = destinationTabForPushType(pushType) ?: return
+        viewModel.setTab(destinationTab)
+        // Consume only a known allowlisted navigation instruction so configuration changes or
+        // repeated delivery cannot unexpectedly re-route a user later.
+        intent.removeExtra(PUSH_TYPE_EXTRA)
     }
 
     private fun maybeTriggerDebugTestPush(intent: Intent?) {

--- a/app/src/main/java/com/example/MainActivity.kt
+++ b/app/src/main/java/com/example/MainActivity.kt
@@ -145,6 +145,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun applyPushDestination(intent: Intent?) {
+        if (FirebaseAuth.getInstance().currentUser == null) return
         val pushType = intent?.getStringExtra(PUSH_TYPE_EXTRA) ?: return
         val destinationTab = destinationTabForPushType(pushType) ?: return
         viewModel.setTab(destinationTab)

--- a/app/src/main/java/com/example/MainActivity.kt
+++ b/app/src/main/java/com/example/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemClock
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -31,6 +32,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
 import com.example.ui.MainViewModel
 import com.example.ui.components.BottomNavBar
 import com.example.ui.screens.DashboardScreen
@@ -45,10 +47,12 @@ import com.google.android.gms.common.api.Scope
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     private val viewModel: MainViewModel by viewModels()
     private val authorizationClient by lazy { Identity.getAuthorizationClient(this) }
+    private var lastObservedBillsResumeRefreshElapsedRealtimeMs = 0L
 
     private val notificationPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -77,6 +81,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // The authenticated startup effect below performs the initial authoritative refresh.
+        // Seed the resume clock so the first onResume does not immediately duplicate that work.
+        lastObservedBillsResumeRefreshElapsedRealtimeMs = SystemClock.elapsedRealtime()
         configureFirebaseAndAppCheck()
         requestNotificationPermissionIfNeeded()
         enableEdgeToEdge()
@@ -103,6 +110,27 @@ class MainActivity : ComponentActivity() {
         }
 
         maybeTriggerDebugTestPush(intent)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (FirebaseAuth.getInstance().currentUser == null) return
+
+        val now = SystemClock.elapsedRealtime()
+        if (!shouldRefreshObservedBillsOnResume(
+                lastRefreshElapsedRealtimeMs = lastObservedBillsResumeRefreshElapsedRealtimeMs,
+                nowElapsedRealtimeMs = now
+            )
+        ) {
+            return
+        }
+
+        lastObservedBillsResumeRefreshElapsedRealtimeMs = now
+        lifecycleScope.launch {
+            // Resume uses only the bounded backend-authoritative snapshot. It never launches
+            // the six-month Gmail backfill/scan path.
+            viewModel.gmailRepository.refreshObservedBillsSnapshotIfConnected()
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/example/MainActivity.kt
+++ b/app/src/main/java/com/example/MainActivity.kt
@@ -85,6 +85,9 @@ class MainActivity : ComponentActivity() {
         // Seed the resume clock so the first onResume does not immediately duplicate that work.
         lastObservedBillsResumeRefreshElapsedRealtimeMs = SystemClock.elapsedRealtime()
         configureFirebaseAndAppCheck()
+        // Create the private financial channel before any background FCM notification can target
+        // it. This prevents Android from falling back to a generic channel on a fresh install.
+        FinancialNotificationChannels.ensureCreated(this)
         requestNotificationPermissionIfNeeded()
         enableEdgeToEdge()
 

--- a/app/src/main/java/com/example/ObservedBillsResumePolicy.kt
+++ b/app/src/main/java/com/example/ObservedBillsResumePolicy.kt
@@ -1,0 +1,14 @@
+package com.example
+
+internal const val OBSERVED_BILLS_RESUME_REFRESH_INTERVAL_MS = 5 * 60 * 1000L
+
+internal fun shouldRefreshObservedBillsOnResume(
+    lastRefreshElapsedRealtimeMs: Long,
+    nowElapsedRealtimeMs: Long,
+    intervalMs: Long = OBSERVED_BILLS_RESUME_REFRESH_INTERVAL_MS
+): Boolean {
+    require(intervalMs > 0L) { "intervalMs must be positive" }
+    if (lastRefreshElapsedRealtimeMs <= 0L) return true
+    if (nowElapsedRealtimeMs < lastRefreshElapsedRealtimeMs) return true
+    return nowElapsedRealtimeMs - lastRefreshElapsedRealtimeMs >= intervalMs
+}

--- a/app/src/main/java/com/example/PushNavigationPolicy.kt
+++ b/app/src/main/java/com/example/PushNavigationPolicy.kt
@@ -1,0 +1,15 @@
+package com.example
+
+internal const val PUSH_TYPE_EXTRA = "type"
+internal const val PUSH_TYPE_NEW_INVOICE = "NEW_INVOICE"
+internal const val PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY = "VERIFIED_SAVINGS_OPPORTUNITY"
+internal const val PUSH_TYPE_TEST = "PUSH_TEST"
+
+internal fun destinationTabForPushType(pushType: String?): Int? {
+    return when (pushType?.trim()) {
+        PUSH_TYPE_NEW_INVOICE -> 1
+        PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY -> 2
+        PUSH_TYPE_TEST -> 0
+        else -> null
+    }
+}

--- a/app/src/main/java/com/example/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/data/local/AppDatabase.kt
@@ -72,6 +72,9 @@ interface InvoiceDao {
     @Query("SELECT * FROM invoice_items WHERE sourceMessageId = :sourceMessageId LIMIT 1")
     suspend fun findBySourceMessageId(sourceMessageId: String): InvoiceItem?
 
+    @Query("SELECT sourceMessageId FROM invoice_items WHERE sourceType = 'GMAIL_READONLY' AND sourceMessageId IS NOT NULL")
+    suspend fun getObservedGmailSourceIds(): List<String>
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertInvoice(invoice: InvoiceItem): Long
 

--- a/app/src/main/java/com/example/data/repository/GmailRepository.kt
+++ b/app/src/main/java/com/example/data/repository/GmailRepository.kt
@@ -55,6 +55,20 @@ class GmailRepository(
         }
     }
 
+    suspend fun refreshObservedBillsSnapshotIfConnected(): Result<ObservedBillsRefreshResult?> {
+        if (!_isConnected.value) return Result.success(null)
+        return runCatching { observedBillsRepository.refreshObservedBills() }
+            .onSuccess { refresh ->
+                if (refresh.refreshedBills > 0 || refresh.removedStaleSources > 0) {
+                    _lastScanTime.value = "עודכן עכשיו"
+                }
+            }
+            .onFailure { error ->
+                // Snapshot refresh failures do not alter the authenticated Gmail connection state.
+                Log.w("GmailRepository", "Authoritative observed bills refresh unavailable", error)
+            }
+    }
+
     suspend fun refreshConnectionStatusAndUpgradeIfNeeded(): Result<GmailConnectionResult> {
         val connectionResult = refreshConnectionStatus()
         val connection = connectionResult.getOrNull() ?: return connectionResult
@@ -77,15 +91,7 @@ class GmailRepository(
             // Normal app startup uses the backend-normalized Firestore snapshot, not another
             // six-month Gmail scan. A transient refresh failure must not turn a valid Gmail
             // connection into a disconnected/error state.
-            runCatching { observedBillsRepository.refreshObservedBills() }
-                .onSuccess { refresh ->
-                    if (refresh.refreshedBills > 0 || refresh.removedStaleSources > 0) {
-                        _lastScanTime.value = "עודכן עכשיו"
-                    }
-                }
-                .onFailure { error ->
-                    Log.w("GmailRepository", "Authoritative observed bills refresh unavailable", error)
-                }
+            refreshObservedBillsSnapshotIfConnected()
         }
         return connectionResult
     }

--- a/app/src/main/java/com/example/data/repository/GmailRepository.kt
+++ b/app/src/main/java/com/example/data/repository/GmailRepository.kt
@@ -19,7 +19,8 @@ sealed class GmailSyncState {
 
 class GmailRepository(
     private val shoppingRepository: ShoppingRepository,
-    private val backendRepository: BackendRepository = BackendRepository()
+    private val backendRepository: BackendRepository = BackendRepository(),
+    private val observedBillsRepository: ObservedBillsRepository = ObservedBillsRepository(shoppingRepository)
 ) {
     private val _syncState = MutableStateFlow<GmailSyncState>(GmailSyncState.Idle)
     val syncState: StateFlow<GmailSyncState> = _syncState.asStateFlow()
@@ -72,6 +73,19 @@ class GmailRepository(
                 "Running one-time Gmail parser upgrade ${syncStatus.storedParserVersion} -> ${syncStatus.activeParserVersion}"
             )
             scanInvoices()
+        } else {
+            // Normal app startup uses the backend-normalized Firestore snapshot, not another
+            // six-month Gmail scan. A transient refresh failure must not turn a valid Gmail
+            // connection into a disconnected/error state.
+            runCatching { observedBillsRepository.refreshObservedBills() }
+                .onSuccess { refresh ->
+                    if (refresh.refreshedBills > 0 || refresh.removedStaleSources > 0) {
+                        _lastScanTime.value = "עודכן עכשיו"
+                    }
+                }
+                .onFailure { error ->
+                    Log.w("GmailRepository", "Authoritative observed bills refresh unavailable", error)
+                }
         }
         return connectionResult
     }

--- a/app/src/main/java/com/example/data/repository/ObservedBillsRepository.kt
+++ b/app/src/main/java/com/example/data/repository/ObservedBillsRepository.kt
@@ -1,0 +1,133 @@
+package com.example.data.repository
+
+import com.example.data.local.InvoiceItem
+import com.google.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.tasks.await
+
+data class ObservedBillsSnapshot(
+    val bills: List<BackendInvoice>,
+    val sourceMessageIds: List<String>,
+    val sourceSetComplete: Boolean,
+    val sourceCount: Int,
+    val generatedAt: String
+)
+
+data class ObservedBillsRefreshResult(
+    val refreshedBills: Int,
+    val removedStaleSources: Int,
+    val sourceSetComplete: Boolean
+)
+
+internal fun computeStaleObservedSourceIds(
+    localSourceIds: List<String>,
+    authoritativeSourceIds: List<String>,
+    sourceSetComplete: Boolean
+): List<String> {
+    if (!sourceSetComplete) return emptyList()
+    val authoritative = authoritativeSourceIds
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+        .toSet()
+    return localSourceIds
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+        .distinct()
+        .filterNot(authoritative::contains)
+}
+
+internal fun BackendInvoice.toObservedInvoiceItem(): InvoiceItem = InvoiceItem(
+    providerName = providerName,
+    category = category,
+    monthlyCost = monthlyCost,
+    billDate = receivedDate,
+    sourceMessageId = sourceMessageId,
+    sourceType = "GMAIL_READONLY",
+    verificationStatus = verificationStatus,
+    recommendedAlternative = "טרם בוצעה השוואה מאומתת",
+    alternativeMonthlyCost = 0.0,
+    potentialMonthlySavings = 0.0,
+    status = "נבדק אוטומטית"
+)
+
+class ObservedBillsRepository(
+    private val shoppingRepository: ShoppingRepository,
+    private val functionsProvider: () -> FirebaseFunctions = {
+        FirebaseFunctions.getInstance("europe-west1")
+    }
+) {
+    private val functions: FirebaseFunctions by lazy(functionsProvider)
+
+    suspend fun fetchSnapshot(): ObservedBillsSnapshot {
+        val response = functions.getHttpsCallable("getObservedBills")
+            .call()
+            .await()
+            .data
+            .asObservedStringMap()
+
+        val bills = (response["bills"] as? List<*>)
+            .orEmpty()
+            .mapNotNull(::parseBackendInvoice)
+        val sourceMessageIds = (response["sourceMessageIds"] as? List<*>)
+            .orEmpty()
+            .mapNotNull { it as? String }
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .distinct()
+
+        return ObservedBillsSnapshot(
+            bills = bills,
+            sourceMessageIds = sourceMessageIds,
+            sourceSetComplete = response["sourceSetComplete"] as? Boolean ?: false,
+            sourceCount = (response["sourceCount"] as? Number)?.toInt() ?: sourceMessageIds.size,
+            generatedAt = response["generatedAt"] as? String ?: ""
+        )
+    }
+
+    suspend fun refreshObservedBills(): ObservedBillsRefreshResult {
+        val snapshot = fetchSnapshot()
+
+        snapshot.bills.forEach { bill ->
+            shoppingRepository.upsertObservedGmailInvoice(bill.toObservedInvoiceItem())
+        }
+
+        val localSourceIds = shoppingRepository.getObservedGmailSourceIds()
+        val stale = computeStaleObservedSourceIds(
+            localSourceIds = localSourceIds,
+            authoritativeSourceIds = snapshot.sourceMessageIds,
+            sourceSetComplete = snapshot.sourceSetComplete
+        )
+        shoppingRepository.deleteObservedGmailInvoicesBySourceIds(stale)
+
+        return ObservedBillsRefreshResult(
+            refreshedBills = snapshot.bills.size,
+            removedStaleSources = stale.size,
+            sourceSetComplete = snapshot.sourceSetComplete
+        )
+    }
+
+    private fun parseBackendInvoice(item: Any?): BackendInvoice? {
+        val map = item.asObservedStringMapOrNull() ?: return null
+        val sourceMessageId = (map["sourceMessageId"] as? String)?.trim().orEmpty()
+        val providerName = (map["providerName"] as? String)?.trim().orEmpty()
+        val monthlyCost = (map["monthlyCost"] as? Number)?.toDouble()
+        if (sourceMessageId.isEmpty() || providerName.isEmpty() || monthlyCost == null || !monthlyCost.isFinite() || monthlyCost <= 0.0) {
+            return null
+        }
+        return BackendInvoice(
+            sourceMessageId = sourceMessageId,
+            providerName = providerName,
+            category = (map["category"] as? String)?.trim().orEmpty().ifBlank { "other" },
+            monthlyCost = monthlyCost,
+            receivedDate = map["receivedDate"] as? String ?: "",
+            verificationStatus = map["verificationStatus"] as? String ?: "UNVERIFIED_GMAIL_IMPORT"
+        )
+    }
+}
+
+private fun Any?.asObservedStringMap(): Map<String, Any?> =
+    asObservedStringMapOrNull() ?: error("Unexpected observed bills backend response")
+
+private fun Any?.asObservedStringMapOrNull(): Map<String, Any?>? {
+    val raw = this as? Map<*, *> ?: return null
+    return raw.entries.associate { (key, value) -> key.toString() to value }
+}

--- a/app/src/main/java/com/example/data/repository/ShoppingRepository.kt
+++ b/app/src/main/java/com/example/data/repository/ShoppingRepository.kt
@@ -68,6 +68,9 @@ class ShoppingRepository(private val db: AppDatabase) {
         }
     }
 
+    suspend fun getObservedGmailSourceIds(): List<String> =
+        normalizeRemovedGmailSourceIds(db.invoiceDao().getObservedGmailSourceIds())
+
     suspend fun deleteObservedGmailInvoicesBySourceIds(sourceMessageIds: List<String>) {
         val normalized = normalizeRemovedGmailSourceIds(sourceMessageIds)
         if (normalized.isEmpty()) return

--- a/app/src/test/java/com/example/ObservedBillsRepositoryTest.kt
+++ b/app/src/test/java/com/example/ObservedBillsRepositoryTest.kt
@@ -1,0 +1,67 @@
+package com.example
+
+import com.example.data.repository.BackendInvoice
+import com.example.data.repository.computeStaleObservedSourceIds
+import com.example.data.repository.toObservedInvoiceItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObservedBillsRepositoryTest {
+    @Test
+    fun completeSnapshotRemovesOnlyMissingObservedGmailSources() {
+        val stale = computeStaleObservedSourceIds(
+            localSourceIds = listOf("a", " b ", "c", "c", ""),
+            authoritativeSourceIds = listOf("b", "c"),
+            sourceSetComplete = true
+        )
+
+        assertEquals(listOf("a"), stale)
+    }
+
+    @Test
+    fun incompleteSnapshotNeverAuthorizesLocalDeletion() {
+        val stale = computeStaleObservedSourceIds(
+            localSourceIds = listOf("a", "b", "c"),
+            authoritativeSourceIds = listOf("b"),
+            sourceSetComplete = false
+        )
+
+        assertTrue(stale.isEmpty())
+    }
+
+    @Test
+    fun backendObservedBillMapsToGmailOnlyLocalRowWithoutSavingsClaims() {
+        val local = BackendInvoice(
+            sourceMessageId = "message-123:pdf:0",
+            providerName = "הראל",
+            category = "insurance",
+            monthlyCost = 602.0,
+            receivedDate = "2026-08-08",
+            verificationStatus = "UNVERIFIED_GMAIL_IMPORT"
+        ).toObservedInvoiceItem()
+
+        assertEquals("message-123:pdf:0", local.sourceMessageId)
+        assertEquals("GMAIL_READONLY", local.sourceType)
+        assertEquals("הראל", local.providerName)
+        assertEquals("insurance", local.category)
+        assertEquals(602.0, local.monthlyCost, 0.0)
+        assertEquals("2026-08-08", local.billDate)
+        assertEquals("UNVERIFIED_GMAIL_IMPORT", local.verificationStatus)
+        assertEquals(0.0, local.potentialMonthlySavings, 0.0)
+        assertEquals(0.0, local.alternativeMonthlyCost, 0.0)
+        assertFalse(local.isSwitchRequested)
+    }
+
+    @Test
+    fun authoritativeSourceNormalizationDoesNotDeleteEquivalentTrimmedIds() {
+        val stale = computeStaleObservedSourceIds(
+            localSourceIds = listOf(" message-a ", "message-b"),
+            authoritativeSourceIds = listOf("message-a", "message-b", "message-b"),
+            sourceSetComplete = true
+        )
+
+        assertTrue(stale.isEmpty())
+    }
+}

--- a/app/src/test/java/com/example/ObservedBillsResumePolicyTest.kt
+++ b/app/src/test/java/com/example/ObservedBillsResumePolicyTest.kt
@@ -1,0 +1,47 @@
+package com.example
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObservedBillsResumePolicyTest {
+    @Test
+    fun firstRefreshIsAllowed() {
+        assertTrue(
+            shouldRefreshObservedBillsOnResume(
+                lastRefreshElapsedRealtimeMs = 0L,
+                nowElapsedRealtimeMs = 1_000L
+            )
+        )
+    }
+
+    @Test
+    fun refreshIsThrottledBeforeFiveMinutes() {
+        assertFalse(
+            shouldRefreshObservedBillsOnResume(
+                lastRefreshElapsedRealtimeMs = 10_000L,
+                nowElapsedRealtimeMs = 10_000L + OBSERVED_BILLS_RESUME_REFRESH_INTERVAL_MS - 1L
+            )
+        )
+    }
+
+    @Test
+    fun refreshIsAllowedAtFiveMinutes() {
+        assertTrue(
+            shouldRefreshObservedBillsOnResume(
+                lastRefreshElapsedRealtimeMs = 10_000L,
+                nowElapsedRealtimeMs = 10_000L + OBSERVED_BILLS_RESUME_REFRESH_INTERVAL_MS
+            )
+        )
+    }
+
+    @Test
+    fun monotonicClockResetAllowsRecoveryRefresh() {
+        assertTrue(
+            shouldRefreshObservedBillsOnResume(
+                lastRefreshElapsedRealtimeMs = 50_000L,
+                nowElapsedRealtimeMs = 1_000L
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/example/ObservedBillsResumeSourceGuardTest.kt
+++ b/app/src/test/java/com/example/ObservedBillsResumeSourceGuardTest.kt
@@ -1,0 +1,34 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObservedBillsResumeSourceGuardTest {
+    @Test
+    fun resumeUsesOnlyThrottledAuthoritativeSnapshot() {
+        val mainActivity = File("src/main/java/com/example/MainActivity.kt").readText()
+        val onResume = mainActivity
+            .substringAfter("override fun onResume()")
+            .substringBefore("override fun onNewIntent")
+
+        assertTrue(onResume.contains("shouldRefreshObservedBillsOnResume("))
+        assertTrue(onResume.contains("refreshObservedBillsSnapshotIfConnected()"))
+        assertFalse(onResume.contains("scanInvoices("))
+        assertFalse(onResume.contains("refreshConnectionStatusAndUpgradeIfNeeded("))
+    }
+
+    @Test
+    fun repositorySnapshotRefreshDoesNotChangeConnectionStateOnFailure() {
+        val repository = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        val snapshotMethod = repository
+            .substringAfter("suspend fun refreshObservedBillsSnapshotIfConnected()")
+            .substringBefore("suspend fun refreshConnectionStatusAndUpgradeIfNeeded()")
+
+        assertTrue(snapshotMethod.contains("observedBillsRepository.refreshObservedBills()"))
+        assertTrue(snapshotMethod.contains("if (!_isConnected.value) return Result.success(null)"))
+        assertFalse(snapshotMethod.contains("_isConnected.value = false"))
+        assertFalse(snapshotMethod.contains("scanInvoices("))
+    }
+}

--- a/app/src/test/java/com/example/ObservedBillsSourceGuardTest.kt
+++ b/app/src/test/java/com/example/ObservedBillsSourceGuardTest.kt
@@ -37,6 +37,17 @@ class ObservedBillsSourceGuardTest {
     }
 
     @Test
+    fun newInvoicePushUsesOnlyLightweightObservedBillsRefresh() {
+        val service = File("src/main/java/com/example/ClickAndSaveMessagingService.kt").readText()
+        assertTrue(service.contains("PUSH_TYPE_NEW_INVOICE = \"NEW_INVOICE\""))
+        assertTrue(service.contains("message.data[\"type\"] == PUSH_TYPE_NEW_INVOICE"))
+        assertTrue(service.contains("observedBillsRepository.refreshObservedBills()"))
+        assertTrue(service.contains("Authenticated app startup retries it"))
+        assertFalse("FCM must never trigger the six-month Gmail scan", service.contains("scanInvoices()"))
+        assertFalse("FCM refresh failure must not disconnect Gmail", service.contains("_isConnected.value = false"))
+    }
+
+    @Test
     fun lightweightSnapshotDoesNotExposeRawGmailContentFields() {
         // Android unit tests execute from the app module directory.
         val backend = File("../functions/src/observedBillsFunctions.js").readText()

--- a/app/src/test/java/com/example/ObservedBillsSourceGuardTest.kt
+++ b/app/src/test/java/com/example/ObservedBillsSourceGuardTest.kt
@@ -38,7 +38,8 @@ class ObservedBillsSourceGuardTest {
 
     @Test
     fun lightweightSnapshotDoesNotExposeRawGmailContentFields() {
-        val backend = File("../../functions/src/observedBillsFunctions.js").readText()
+        // Android unit tests execute from the app module directory.
+        val backend = File("../functions/src/observedBillsFunctions.js").readText()
         val normalizedReturn = backend.substringAfter("return {\n    sourceMessageId")
             .substringBefore("  };\n}")
 

--- a/app/src/test/java/com/example/ObservedBillsSourceGuardTest.kt
+++ b/app/src/test/java/com/example/ObservedBillsSourceGuardTest.kt
@@ -14,6 +14,7 @@ class ObservedBillsSourceGuardTest {
         assertTrue(activity.contains("viewModel.gmailRepository.refreshConnectionStatusAndUpgradeIfNeeded()"))
         assertTrue(repository.contains("if (syncStatus?.upgradeRequired == true)"))
         assertTrue(repository.contains("scanInvoices()"))
+        assertTrue(repository.contains("refreshObservedBillsSnapshotIfConnected()"))
         assertTrue(repository.contains("observedBillsRepository.refreshObservedBills()"))
         assertTrue(repository.contains("Authoritative observed bills refresh unavailable"))
     }
@@ -21,12 +22,19 @@ class ObservedBillsSourceGuardTest {
     @Test
     fun lightweightSnapshotFailureDoesNotMarkValidGmailConnectionDisconnected() {
         val repository = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
-        val normalRefreshSection = repository.substringAfter("} else {\n            // Normal app startup")
+        val snapshotMethod = repository
+            .substringAfter("suspend fun refreshObservedBillsSnapshotIfConnected()")
+            .substringBefore("suspend fun refreshConnectionStatusAndUpgradeIfNeeded()")
+        val normalStartupSection = repository
+            .substringAfter("} else {\n            // Normal app startup")
             .substringBefore("        }\n        return connectionResult")
 
-        assertTrue(normalRefreshSection.contains("observedBillsRepository.refreshObservedBills()"))
-        assertFalse(normalRefreshSection.contains("_isConnected.value = false"))
-        assertFalse(normalRefreshSection.contains("GmailSyncState.Error"))
+        assertTrue(snapshotMethod.contains("observedBillsRepository.refreshObservedBills()"))
+        assertTrue(snapshotMethod.contains("Authoritative observed bills refresh unavailable"))
+        assertFalse(snapshotMethod.contains("_isConnected.value = false"))
+        assertFalse(snapshotMethod.contains("GmailSyncState.Error"))
+        assertFalse(snapshotMethod.contains("scanInvoices()"))
+        assertTrue(normalStartupSection.contains("refreshObservedBillsSnapshotIfConnected()"))
     }
 
     @Test
@@ -39,10 +47,13 @@ class ObservedBillsSourceGuardTest {
     @Test
     fun newInvoicePushUsesOnlyLightweightObservedBillsRefresh() {
         val service = File("src/main/java/com/example/ClickAndSaveMessagingService.kt").readText()
-        assertTrue(service.contains("PUSH_TYPE_NEW_INVOICE = \"NEW_INVOICE\""))
-        assertTrue(service.contains("message.data[\"type\"] == PUSH_TYPE_NEW_INVOICE"))
+        val policy = File("src/main/java/com/example/PushNavigationPolicy.kt").readText()
+
+        assertTrue(policy.contains("PUSH_TYPE_NEW_INVOICE = \"NEW_INVOICE\""))
+        assertTrue(service.contains("val pushType = message.data[PUSH_TYPE_EXTRA]"))
+        assertTrue(service.contains("if (pushType == PUSH_TYPE_NEW_INVOICE)"))
         assertTrue(service.contains("observedBillsRepository.refreshObservedBills()"))
-        assertTrue(service.contains("Authenticated app startup retries it"))
+        assertTrue(service.contains("Authenticated app startup/resume retries it"))
         assertFalse("FCM must never trigger the six-month Gmail scan", service.contains("scanInvoices()"))
         assertFalse("FCM refresh failure must not disconnect Gmail", service.contains("_isConnected.value = false"))
     }

--- a/app/src/test/java/com/example/ObservedBillsSourceGuardTest.kt
+++ b/app/src/test/java/com/example/ObservedBillsSourceGuardTest.kt
@@ -1,0 +1,49 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObservedBillsSourceGuardTest {
+    @Test
+    fun authenticatedStartupKeepsParserUpgradeAndLightweightSnapshotPathsSeparate() {
+        val repository = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        val activity = File("src/main/java/com/example/MainActivity.kt").readText()
+
+        assertTrue(activity.contains("viewModel.gmailRepository.refreshConnectionStatusAndUpgradeIfNeeded()"))
+        assertTrue(repository.contains("if (syncStatus?.upgradeRequired == true)"))
+        assertTrue(repository.contains("scanInvoices()"))
+        assertTrue(repository.contains("observedBillsRepository.refreshObservedBills()"))
+        assertTrue(repository.contains("Authoritative observed bills refresh unavailable"))
+    }
+
+    @Test
+    fun lightweightSnapshotFailureDoesNotMarkValidGmailConnectionDisconnected() {
+        val repository = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        val normalRefreshSection = repository.substringAfter("} else {\n            // Normal app startup")
+            .substringBefore("        }\n        return connectionResult")
+
+        assertTrue(normalRefreshSection.contains("observedBillsRepository.refreshObservedBills()"))
+        assertFalse(normalRefreshSection.contains("_isConnected.value = false"))
+        assertFalse(normalRefreshSection.contains("GmailSyncState.Error"))
+    }
+
+    @Test
+    fun authoritativeDeletionRequiresCompleteServerSourceSet() {
+        val observedRepository = File("src/main/java/com/example/data/repository/ObservedBillsRepository.kt").readText()
+        assertTrue(observedRepository.contains("if (!sourceSetComplete) return emptyList()"))
+        assertTrue(observedRepository.contains("deleteObservedGmailInvoicesBySourceIds(stale)"))
+    }
+
+    @Test
+    fun lightweightSnapshotDoesNotExposeRawGmailContentFields() {
+        val backend = File("../../functions/src/observedBillsFunctions.js").readText()
+        val normalizedReturn = backend.substringAfter("return {\n    sourceMessageId")
+            .substringBefore("  };\n}")
+
+        listOf("rawBody", "subject", "snippet", "accountNumber", "pdfText", "commission").forEach { forbidden ->
+            assertFalse("Observed bills response must not expose $forbidden", normalizedReturn.contains(forbidden))
+        }
+    }
+}

--- a/app/src/test/java/com/example/PushNavigationPolicyTest.kt
+++ b/app/src/test/java/com/example/PushNavigationPolicyTest.kt
@@ -1,0 +1,29 @@
+package com.example
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PushNavigationPolicyTest {
+    @Test
+    fun newInvoiceOpensBills() {
+        assertEquals(1, destinationTabForPushType(PUSH_TYPE_NEW_INVOICE))
+    }
+
+    @Test
+    fun verifiedSavingsOpensSavings() {
+        assertEquals(2, destinationTabForPushType(PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY))
+    }
+
+    @Test
+    fun testPushOpensDashboard() {
+        assertEquals(0, destinationTabForPushType(PUSH_TYPE_TEST))
+    }
+
+    @Test
+    fun unknownPushCannotChooseArbitraryTab() {
+        assertNull(destinationTabForPushType("OPEN_PROFILE"))
+        assertNull(destinationTabForPushType("99"))
+        assertNull(destinationTabForPushType(null))
+    }
+}

--- a/app/src/test/java/com/example/PushNavigationSourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushNavigationSourceGuardTest.kt
@@ -17,12 +17,13 @@ class PushNavigationSourceGuardTest {
     }
 
     @Test
-    fun activityConsumesOnlyAllowlistedPushType() {
+    fun activityConsumesOnlyAllowlistedPushTypeForAuthenticatedUser() {
         val activity = File("src/main/java/com/example/MainActivity.kt").readText()
         val handler = activity
             .substringAfter("private fun applyPushDestination(intent: Intent?)")
             .substringBefore("private fun maybeTriggerDebugTestPush")
 
+        assertTrue(handler.contains("FirebaseAuth.getInstance().currentUser == null"))
         assertTrue(handler.contains("getStringExtra(PUSH_TYPE_EXTRA)"))
         assertTrue(handler.contains("destinationTabForPushType(pushType) ?: return"))
         assertTrue(handler.contains("viewModel.setTab(destinationTab)"))

--- a/app/src/test/java/com/example/PushNavigationSourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushNavigationSourceGuardTest.kt
@@ -1,0 +1,33 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PushNavigationSourceGuardTest {
+    @Test
+    fun messagingServiceUsesTypedPushDestinationInsteadOfLegacyBoolean() {
+        val service = File("src/main/java/com/example/ClickAndSaveMessagingService.kt").readText()
+
+        assertTrue(service.contains("message.data[PUSH_TYPE_EXTRA]"))
+        assertTrue(service.contains("destinationTabForPushType(pushType)"))
+        assertTrue(service.contains("putExtra(PUSH_TYPE_EXTRA, pushType)"))
+        assertFalse(service.contains("openSavingsOpportunity"))
+    }
+
+    @Test
+    fun activityConsumesOnlyAllowlistedPushType() {
+        val activity = File("src/main/java/com/example/MainActivity.kt").readText()
+        val handler = activity
+            .substringAfter("private fun applyPushDestination(intent: Intent?)")
+            .substringBefore("private fun maybeTriggerDebugTestPush")
+
+        assertTrue(handler.contains("getStringExtra(PUSH_TYPE_EXTRA)"))
+        assertTrue(handler.contains("destinationTabForPushType(pushType) ?: return"))
+        assertTrue(handler.contains("viewModel.setTab(destinationTab)"))
+        assertTrue(handler.contains("removeExtra(PUSH_TYPE_EXTRA)"))
+        assertFalse(handler.contains("getIntExtra"))
+        assertFalse(handler.contains("openSavingsOpportunity"))
+    }
+}

--- a/app/src/test/java/com/example/PushPrivacySourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushPrivacySourceGuardTest.kt
@@ -1,0 +1,14 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PushPrivacySourceGuardTest {
+    @Test
+    fun localFinancialNotificationsAreMarkedPrivate() {
+        val service = File("src/main/java/com/example/ClickAndSaveMessagingService.kt").readText()
+        assertTrue(service.contains("lockscreenVisibility = Notification.VISIBILITY_PRIVATE"))
+        assertTrue(service.contains("setVisibility(NotificationCompat.VISIBILITY_PRIVATE)"))
+    }
+}

--- a/app/src/test/java/com/example/PushPrivacySourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushPrivacySourceGuardTest.kt
@@ -6,9 +6,16 @@ import org.junit.Test
 
 class PushPrivacySourceGuardTest {
     @Test
-    fun localFinancialNotificationsAreMarkedPrivate() {
+    fun financialChannelIsCreatedPrivateBeforePushDelivery() {
+        val channels = File("src/main/java/com/example/FinancialNotificationChannels.kt").readText()
         val service = File("src/main/java/com/example/ClickAndSaveMessagingService.kt").readText()
-        assertTrue(service.contains("lockscreenVisibility = Notification.VISIBILITY_PRIVATE"))
+        val activity = File("src/main/java/com/example/MainActivity.kt").readText()
+
+        assertTrue(channels.contains("FINANCIAL_PUSH_CHANNEL_ID = \"savings_opportunities\""))
+        assertTrue(channels.contains("lockscreenVisibility = Notification.VISIBILITY_PRIVATE"))
+        assertTrue(service.contains("FinancialNotificationChannels.ensureCreated(this)"))
+        assertTrue(service.contains("NotificationCompat.Builder(this, FINANCIAL_PUSH_CHANNEL_ID)"))
         assertTrue(service.contains("setVisibility(NotificationCompat.VISIBILITY_PRIVATE)"))
+        assertTrue(activity.contains("FinancialNotificationChannels.ensureCreated(this)"))
     }
 }

--- a/app/src/test/java/com/example/PushPrivacySourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushPrivacySourceGuardTest.kt
@@ -10,6 +10,7 @@ class PushPrivacySourceGuardTest {
         val channels = File("src/main/java/com/example/FinancialNotificationChannels.kt").readText()
         val service = File("src/main/java/com/example/ClickAndSaveMessagingService.kt").readText()
         val activity = File("src/main/java/com/example/MainActivity.kt").readText()
+        val backendPush = File("../functions/src/pushFunctions.js").readText()
 
         assertTrue(channels.contains("FINANCIAL_PUSH_CHANNEL_ID = \"savings_opportunities\""))
         assertTrue(channels.contains("lockscreenVisibility = Notification.VISIBILITY_PRIVATE"))
@@ -17,5 +18,7 @@ class PushPrivacySourceGuardTest {
         assertTrue(service.contains("NotificationCompat.Builder(this, FINANCIAL_PUSH_CHANNEL_ID)"))
         assertTrue(service.contains("setVisibility(NotificationCompat.VISIBILITY_PRIVATE)"))
         assertTrue(activity.contains("FinancialNotificationChannels.ensureCreated(this)"))
+        assertTrue(backendPush.contains("channelId: \"savings_opportunities\""))
+        assertTrue(backendPush.contains("visibility: \"private\""))
     }
 }

--- a/functions/src/entry.js
+++ b/functions/src/entry.js
@@ -14,6 +14,7 @@ const providerDispatchFunctions = require("./providerDispatchFunctions");
 const commerceFunnelFunctions = require("./commerceFunnelFunctions");
 const gmailScanV5Functions = require("./gmailScanV5Functions");
 const gmailSyncStatusFunctions = require("./gmailSyncStatusFunctions");
+const observedBillsFunctions = require("./observedBillsFunctions");
 
 module.exports = {
   ...coreFunctions,
@@ -29,6 +30,7 @@ module.exports = {
   ...providerDispatchFunctions,
   ...commerceFunnelFunctions,
   ...gmailSyncStatusFunctions,
+  ...observedBillsFunctions,
   // Intentionally last: preserves the public callable name while replacing only
   // the legacy parser-v4 implementation. OAuth/connect/disconnect remain untouched.
   ...gmailScanV5Functions,

--- a/functions/src/observedBillsFunctions.js
+++ b/functions/src/observedBillsFunctions.js
@@ -4,6 +4,7 @@ const { getFirestore } = require("firebase-admin/firestore");
 const { HttpsError, onCall } = require("firebase-functions/v2/https");
 
 const db = getFirestore();
+const REGION = "europe-west1";
 const MAX_BILLS = 100;
 const MAX_AUTHORITATIVE_SOURCE_IDS = 500;
 
@@ -56,7 +57,7 @@ function buildObservedBillsPayload(documents, now = new Date()) {
 }
 
 exports.getObservedBills = onCall(
-  { enforceAppCheck: true },
+  { enforceAppCheck: true, region: REGION },
   async (request) => {
     const uid = requireAuth(request);
     const snapshot = await db
@@ -72,5 +73,6 @@ exports.getObservedBills = onCall(
 
 exports._normalizeObservedBill = normalizeObservedBill;
 exports._buildObservedBillsPayload = buildObservedBillsPayload;
+exports._REGION = REGION;
 exports._MAX_BILLS = MAX_BILLS;
 exports._MAX_AUTHORITATIVE_SOURCE_IDS = MAX_AUTHORITATIVE_SOURCE_IDS;

--- a/functions/src/observedBillsFunctions.js
+++ b/functions/src/observedBillsFunctions.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const { getFirestore } = require("firebase-admin/firestore");
+const { HttpsError, onCall } = require("firebase-functions/v2/https");
+
+const db = getFirestore();
+const MAX_BILLS = 100;
+const MAX_AUTHORITATIVE_SOURCE_IDS = 500;
+
+function requireAuth(request) {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError("unauthenticated", "Firebase Authentication is required.");
+  return uid;
+}
+
+function normalizeObservedBill(data) {
+  if (!data || typeof data !== "object") return null;
+  const sourceMessageId = String(data.sourceMessageId || "").trim();
+  const providerName = String(data.providerName || "").trim();
+  const category = String(data.category || "other").trim() || "other";
+  const monthlyCost = Number(data.monthlyCost);
+  if (!sourceMessageId || !providerName || !Number.isFinite(monthlyCost) || monthlyCost <= 0) {
+    return null;
+  }
+  return {
+    sourceMessageId: sourceMessageId.slice(0, 300),
+    providerName: providerName.slice(0, 160),
+    category: category.slice(0, 80),
+    monthlyCost,
+    receivedDate: String(data.receivedDate || "").slice(0, 120),
+    verificationStatus: String(data.verificationStatus || "UNVERIFIED_GMAIL_IMPORT").slice(0, 80),
+  };
+}
+
+function documentData(item) {
+  if (item && typeof item.data === "function") return item.data();
+  return item;
+}
+
+function buildObservedBillsPayload(documents, now = new Date()) {
+  const rawDocuments = Array.isArray(documents) ? documents : [];
+  const sourceSetComplete = rawDocuments.length <= MAX_AUTHORITATIVE_SOURCE_IDS;
+  const normalized = rawDocuments
+    .slice(0, MAX_AUTHORITATIVE_SOURCE_IDS)
+    .map(documentData)
+    .map(normalizeObservedBill)
+    .filter(Boolean);
+
+  return {
+    bills: normalized.slice(0, MAX_BILLS),
+    sourceMessageIds: [...new Set(normalized.map((bill) => bill.sourceMessageId))],
+    sourceSetComplete,
+    sourceCount: normalized.length,
+    generatedAt: now.toISOString(),
+  };
+}
+
+exports.getObservedBills = onCall(
+  { enforceAppCheck: true },
+  async (request) => {
+    const uid = requireAuth(request);
+    const snapshot = await db
+      .collection("users")
+      .doc(uid)
+      .collection("gmailInvoices")
+      .orderBy("updatedAt", "desc")
+      .limit(MAX_AUTHORITATIVE_SOURCE_IDS + 1)
+      .get();
+    return buildObservedBillsPayload(snapshot.docs);
+  }
+);
+
+exports._normalizeObservedBill = normalizeObservedBill;
+exports._buildObservedBillsPayload = buildObservedBillsPayload;
+exports._MAX_BILLS = MAX_BILLS;
+exports._MAX_AUTHORITATIVE_SOURCE_IDS = MAX_AUTHORITATIVE_SOURCE_IDS;

--- a/functions/src/pushFunctions.js
+++ b/functions/src/pushFunctions.js
@@ -54,6 +54,9 @@ async function sendPushToUser(uid, { title, body, data = {} }) {
       priority: "high",
       notification: {
         channelId: "savings_opportunities",
+        // Financial notifications may contain a provider and an amount. Explicitly mark the
+        // notification private so Android can hide sensitive content on a secured lock screen.
+        visibility: "private",
       },
     },
   });

--- a/functions/test/observedBillsFunctions.test.js
+++ b/functions/test/observedBillsFunctions.test.js
@@ -21,6 +21,11 @@ function bill(index, overrides = {}) {
   };
 }
 
+test("observed bills callable shares Android backend region and public export", () => {
+  assert.equal(observedBills._REGION, "europe-west1");
+  assert.equal(entry.getObservedBills, observedBills.getObservedBills);
+});
+
 test("observed bills snapshot exposes normalized minimum fields only", () => {
   const payload = observedBills._buildObservedBillsPayload([bill(1)], new Date("2026-08-09T07:00:00.000Z"));
 
@@ -38,7 +43,6 @@ test("observed bills snapshot exposes normalized minimum fields only", () => {
   assert.equal(payload.bills[0].subject, undefined);
   assert.equal(payload.bills[0].accountNumber, undefined);
   assert.equal(payload.generatedAt, "2026-08-09T07:00:00.000Z");
-  assert.equal(entry.getObservedBills, observedBills.getObservedBills);
 });
 
 test("invalid observed bills are dropped instead of fabricated", () => {

--- a/functions/test/observedBillsFunctions.test.js
+++ b/functions/test/observedBillsFunctions.test.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const entry = require("../src/entry");
+const observedBills = require("../src/observedBillsFunctions");
+
+function bill(index, overrides = {}) {
+  return {
+    sourceMessageId: `message-${index}`,
+    providerName: `Provider ${index}`,
+    category: "internet",
+    monthlyCost: 100 + index,
+    receivedDate: `2026-08-${String((index % 28) + 1).padStart(2, "0")}`,
+    verificationStatus: "UNVERIFIED_GMAIL_IMPORT",
+    rawBody: "must never escape",
+    subject: "must never escape",
+    accountNumber: "secret",
+    ...overrides,
+  };
+}
+
+test("observed bills snapshot exposes normalized minimum fields only", () => {
+  const payload = observedBills._buildObservedBillsPayload([bill(1)], new Date("2026-08-09T07:00:00.000Z"));
+
+  assert.equal(payload.bills.length, 1);
+  assert.deepEqual(Object.keys(payload.bills[0]).sort(), [
+    "category",
+    "monthlyCost",
+    "providerName",
+    "receivedDate",
+    "sourceMessageId",
+    "verificationStatus",
+  ]);
+  assert.equal(payload.bills[0].sourceMessageId, "message-1");
+  assert.equal(payload.bills[0].rawBody, undefined);
+  assert.equal(payload.bills[0].subject, undefined);
+  assert.equal(payload.bills[0].accountNumber, undefined);
+  assert.equal(payload.generatedAt, "2026-08-09T07:00:00.000Z");
+  assert.equal(entry.getObservedBills, observedBills.getObservedBills);
+});
+
+test("invalid observed bills are dropped instead of fabricated", () => {
+  const payload = observedBills._buildObservedBillsPayload([
+    bill(1),
+    bill(2, { sourceMessageId: "" }),
+    bill(3, { providerName: "" }),
+    bill(4, { monthlyCost: 0 }),
+    bill(5, { monthlyCost: Number.NaN }),
+  ]);
+
+  assert.equal(payload.bills.length, 1);
+  assert.equal(payload.bills[0].sourceMessageId, "message-1");
+});
+
+test("customer bill list is bounded to 100 while authoritative source set reaches 500", () => {
+  const documents = Array.from({ length: 500 }, (_, index) => bill(index));
+  const payload = observedBills._buildObservedBillsPayload(documents);
+
+  assert.equal(payload.bills.length, 100);
+  assert.equal(payload.sourceMessageIds.length, 500);
+  assert.equal(payload.sourceCount, 500);
+  assert.equal(payload.sourceSetComplete, true);
+});
+
+test("501 documents mark the source set incomplete so clients cannot delete from a partial snapshot", () => {
+  const documents = Array.from({ length: 501 }, (_, index) => bill(index));
+  const payload = observedBills._buildObservedBillsPayload(documents);
+
+  assert.equal(payload.bills.length, 100);
+  assert.equal(payload.sourceMessageIds.length, 500);
+  assert.equal(payload.sourceSetComplete, false);
+});
+
+test("source identifiers are de-duplicated", () => {
+  const payload = observedBills._buildObservedBillsPayload([
+    bill(1),
+    bill(2, { sourceMessageId: "message-1", providerName: "Replacement representation" }),
+  ]);
+
+  assert.deepEqual(payload.sourceMessageIds, ["message-1"]);
+});

--- a/functions/test/pushPrivacySourceGuard.test.js
+++ b/functions/test/pushPrivacySourceGuard.test.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+test("financial FCM notifications are explicitly private on Android", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../src/pushFunctions.js"), "utf8");
+  assert.match(source, /visibility:\s*"private"/);
+  assert.match(source, /channelId:\s*"savings_opportunities"/);
+});


### PR DESCRIPTION
Queued Stream A work based exactly on locked E2E baseline `ac2105098d698df06159f929f41595f91505c855`.

**DO NOT MERGE before locked staging backend + paired APK complete device E2E correction cycle #2.**

Implements a lightweight backend-authoritative Bills sync so Room/Bills can stay current without running the six-month Gmail scan on normal app use:
- new App Check/auth callable `getObservedBills`
- normalized minimum-data response only (no Gmail body/subject/snippet/PDF/account data)
- customer list bounded to 100 bills
- authoritative source set bounded to 500 with `sourceSetComplete`; 501+ sources explicitly disable stale local deletion
- Android `ObservedBillsRepository` upserts normalized Gmail rows
- Gmail-only stale rows are removed only when the server source set is complete
- manual local bills are never touched by the Gmail-only delete query
- authenticated startup uses lightweight snapshot when no parser upgrade is required
- parser upgrade continues to use the full scan path
- transient snapshot failure never marks a valid Gmail connection disconnected
- `NEW_INVOICE` foreground push accelerates the same authoritative snapshot refresh without suppressing the notification on refresh failure
- app resume performs only a bounded authoritative snapshot refresh and is throttled to once per 5 minutes; it never launches the six-month Gmail scan
- push navigation is allowlisted by backend push type: `NEW_INVOICE` -> Bills, `VERIFIED_SAVINGS_OPPORTUNITY` -> Savings, `PUSH_TEST` -> Dashboard; unknown types cannot choose an arbitrary tab
- local notification PendingIntents are separated by destination so one push type cannot overwrite another type's routing extras
- backend, Android pure-function and permanent source regression tests cover privacy, stale-source reconciliation, resume throttling, no-full-scan-on-resume and typed push navigation

This PR is intentionally stacked on the locked Core branch and remains Draft until E2E #2 passes.