### PR TITLE
Queue current-device push revocation on sign-out

### DIFF
--- a/app/src/main/java/com/example/PushTokenLifecycle.kt
+++ b/app/src/main/java/com/example/PushTokenLifecycle.kt
@@ -55,6 +55,7 @@ object PushTokenLifecycle {
             Log.w(TAG, "Local FCM token deletion failed during sign-out", error)
         }
 
-        return firstFailure?.let(Result.Companion::failure) ?: Result.success(Unit)
+        val failure = firstFailure
+        return if (failure != null) Result.failure(failure) else Result.success(Unit)
     }
 }

--- a/app/src/main/java/com/example/PushTokenLifecycle.kt
+++ b/app/src/main/java/com/example/PushTokenLifecycle.kt
@@ -1,0 +1,56 @@
+package com.example
+
+import android.util.Log
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.functions.FirebaseFunctions
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Owns privacy-sensitive lifecycle handling for the current device's FCM registration.
+ *
+ * Registration remains handled by [PushRegistration]. Sign-out calls this object while the
+ * Firebase user is still authenticated so the backend can delete the exact current token. The
+ * local FCM token is then deleted as a second line of defense so a stale backend registration
+ * cannot continue representing the signed-out device indefinitely.
+ */
+object PushTokenLifecycle {
+    private const val TAG = "PushTokenLifecycle"
+
+    suspend fun revokeCurrentDeviceBeforeSignOut(): Result<Unit> {
+        val messaging = FirebaseMessaging.getInstance()
+        val authenticated = FirebaseAuth.getInstance().currentUser != null
+
+        var firstFailure: Throwable? = null
+        val token = runCatching { messaging.token.await().trim() }
+            .onFailure { error ->
+                firstFailure = error
+                Log.w(TAG, "Unable to resolve current FCM token before sign-out", error)
+            }
+            .getOrNull()
+            .orEmpty()
+
+        if (authenticated && token.isNotEmpty()) {
+            runCatching {
+                FirebaseFunctions.getInstance("europe-west1")
+                    .getHttpsCallable("unregisterPushToken")
+                    .call(mapOf("token" to token))
+                    .await()
+            }.onFailure { error ->
+                if (firstFailure == null) firstFailure = error
+                Log.w(TAG, "Backend FCM token revocation failed before sign-out", error)
+            }
+        }
+
+        // Always try to delete the local token even when the authenticated backend revocation
+        // fails. Firebase will mint a fresh token on a later authenticated session, while the
+        // server delivery path already deletes registrations that FCM reports as invalid.
+        runCatching { messaging.deleteToken().await() }
+            .onFailure { error ->
+                if (firstFailure == null) firstFailure = error
+                Log.w(TAG, "Local FCM token deletion failed during sign-out", error)
+            }
+
+        return firstFailure?.let(Result.Companion::failure) ?: Result.success(Unit)
+    }
+}

--- a/app/src/main/java/com/example/PushTokenLifecycle.kt
+++ b/app/src/main/java/com/example/PushTokenLifecycle.kt
@@ -5,6 +5,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.functions.FirebaseFunctions
 import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withTimeout
 
 /**
  * Owns privacy-sensitive lifecycle handling for the current device's FCM registration.
@@ -16,26 +17,28 @@ import kotlinx.coroutines.tasks.await
  */
 object PushTokenLifecycle {
     private const val TAG = "PushTokenLifecycle"
+    private const val FCM_OPERATION_TIMEOUT_MS = 5_000L
 
     suspend fun revokeCurrentDeviceBeforeSignOut(): Result<Unit> {
         val messaging = FirebaseMessaging.getInstance()
         val authenticated = FirebaseAuth.getInstance().currentUser != null
 
         var firstFailure: Throwable? = null
-        val token = runCatching { messaging.token.await().trim() }
-            .onFailure { error ->
-                firstFailure = error
-                Log.w(TAG, "Unable to resolve current FCM token before sign-out", error)
-            }
-            .getOrNull()
-            .orEmpty()
+        val token = runCatching {
+            withTimeout(FCM_OPERATION_TIMEOUT_MS) { messaging.token.await().trim() }
+        }.onFailure { error ->
+            firstFailure = error
+            Log.w(TAG, "Unable to resolve current FCM token before sign-out", error)
+        }.getOrNull().orEmpty()
 
         if (authenticated && token.isNotEmpty()) {
             runCatching {
-                FirebaseFunctions.getInstance("europe-west1")
-                    .getHttpsCallable("unregisterPushToken")
-                    .call(mapOf("token" to token))
-                    .await()
+                withTimeout(FCM_OPERATION_TIMEOUT_MS) {
+                    FirebaseFunctions.getInstance("europe-west1")
+                        .getHttpsCallable("unregisterPushToken")
+                        .call(mapOf("token" to token))
+                        .await()
+                }
             }.onFailure { error ->
                 if (firstFailure == null) firstFailure = error
                 Log.w(TAG, "Backend FCM token revocation failed before sign-out", error)
@@ -45,11 +48,12 @@ object PushTokenLifecycle {
         // Always try to delete the local token even when the authenticated backend revocation
         // fails. Firebase will mint a fresh token on a later authenticated session, while the
         // server delivery path already deletes registrations that FCM reports as invalid.
-        runCatching { messaging.deleteToken().await() }
-            .onFailure { error ->
-                if (firstFailure == null) firstFailure = error
-                Log.w(TAG, "Local FCM token deletion failed during sign-out", error)
-            }
+        runCatching {
+            withTimeout(FCM_OPERATION_TIMEOUT_MS) { messaging.deleteToken().await() }
+        }.onFailure { error ->
+            if (firstFailure == null) firstFailure = error
+            Log.w(TAG, "Local FCM token deletion failed during sign-out", error)
+        }
 
         return firstFailure?.let(Result.Companion::failure) ?: Result.success(Unit)
     }

--- a/app/src/main/java/com/example/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/data/repository/AuthRepository.kt
@@ -8,6 +8,7 @@ import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetCredentialResponse
 import androidx.credentials.exceptions.GetCredentialException
+import com.example.PushTokenLifecycle
 import com.example.data.local.AppDatabase
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
@@ -137,6 +138,12 @@ class AuthRepository(private val applicationContext: Context) {
     }
 
     suspend fun signOut() {
+        // Revoke this device while Firebase Auth is still valid. A transient revocation failure
+        // must never trap the user in a signed-in session; PushTokenLifecycle also attempts to
+        // delete the local FCM token so a later login receives a fresh registration.
+        PushTokenLifecycle.revokeCurrentDeviceBeforeSignOut()
+            .onFailure { Log.w("AuthRepository", "Push revocation incomplete during sign-out", it) }
+
         runCatching { getFirebaseAuthSafe()?.signOut() }
             .onFailure { Log.e("AuthRepository", "Sign-out failed", it) }
 

--- a/app/src/test/java/com/example/PushSignOutSourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushSignOutSourceGuardTest.kt
@@ -1,6 +1,7 @@
 package com.example
 
 import java.io.File
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -38,5 +39,28 @@ class PushSignOutSourceGuardTest {
 
         assertTrue(signOutSection.contains(".onFailure { Log.w(\"AuthRepository\", \"Push revocation incomplete during sign-out\", it) }"))
         assertTrue(signOutSection.contains("getFirebaseAuthSafe()?.signOut()"))
+    }
+
+    @Test
+    fun gmailDisconnectAloneDoesNotRevokeAccountPushRegistration() {
+        val gmailRepository = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        val disconnectSection = gmailRepository
+            .substringAfter("suspend fun disconnectGmail()")
+            .substringBeforeLast("}\n")
+
+        assertFalse(disconnectSection.contains("PushTokenLifecycle"))
+        assertFalse(disconnectSection.contains("unregisterPushToken"))
+        assertFalse(disconnectSection.contains("deleteToken()"))
+    }
+
+    @Test
+    fun pushRegistrationRequiresAuthenticatedFirebaseUser() {
+        val service = File("src/main/java/com/example/ClickAndSaveMessagingService.kt").readText()
+        val registrationSection = service
+            .substringAfter("object PushRegistration")
+            .substringBefore("class ClickAndSaveMessagingService")
+
+        assertTrue(registrationSection.contains("if (FirebaseAuth.getInstance().currentUser == null) return"))
+        assertTrue(registrationSection.contains("if (FirebaseAuth.getInstance().currentUser == null || token.isBlank()) return"))
     }
 }

--- a/app/src/test/java/com/example/PushSignOutSourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushSignOutSourceGuardTest.kt
@@ -1,0 +1,42 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PushSignOutSourceGuardTest {
+    @Test
+    fun authSignOutRevokesPushBeforeFirebaseAuthSignOut() {
+        val authRepository = File("src/main/java/com/example/data/repository/AuthRepository.kt").readText()
+        val signOutSection = authRepository
+            .substringAfter("suspend fun signOut()")
+            .substringBefore("_userSession.value = UserSession()")
+
+        val revokeIndex = signOutSection.indexOf("PushTokenLifecycle.revokeCurrentDeviceBeforeSignOut()")
+        val firebaseSignOutIndex = signOutSection.indexOf("getFirebaseAuthSafe()?.signOut()")
+
+        assertTrue("Current-device push revocation must be wired into sign-out", revokeIndex >= 0)
+        assertTrue("Push revocation must happen while Firebase Auth is still valid", firebaseSignOutIndex > revokeIndex)
+    }
+
+    @Test
+    fun pushLifecycleUsesBackendRevocationLocalDeletionAndTimeouts() {
+        val lifecycle = File("src/main/java/com/example/PushTokenLifecycle.kt").readText()
+
+        assertTrue(lifecycle.contains("getHttpsCallable(\"unregisterPushToken\")"))
+        assertTrue(lifecycle.contains("messaging.deleteToken().await()"))
+        assertTrue(lifecycle.contains("withTimeout(FCM_OPERATION_TIMEOUT_MS)"))
+        assertTrue(lifecycle.contains("FirebaseAuth.getInstance().currentUser != null"))
+    }
+
+    @Test
+    fun signOutStillCompletesWhenPushRevocationFails() {
+        val authRepository = File("src/main/java/com/example/data/repository/AuthRepository.kt").readText()
+        val signOutSection = authRepository
+            .substringAfter("suspend fun signOut()")
+            .substringBefore("_userSession.value = UserSession()")
+
+        assertTrue(signOutSection.contains(".onFailure { Log.w(\"AuthRepository\", \"Push revocation incomplete during sign-out\", it) }"))
+        assertTrue(signOutSection.contains("getFirebaseAuthSafe()?.signOut()"))
+    }
+}

--- a/functions/test/pushTokenRevocationSourceGuard.test.js
+++ b/functions/test/pushTokenRevocationSourceGuard.test.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "src", "pushFunctions.js"),
+  "utf8"
+);
+
+test("unregisterPushToken stays App Check authenticated and token-specific", () => {
+  const section = source
+    .split("exports.unregisterPushToken = onCall(")[1]
+    ?.split("exports.sendTestPush = onCall(")[0] || "";
+
+  assert.match(section, /enforceAppCheck:\s*true/);
+  assert.match(section, /const uid = requireAuth\(request\)/);
+  assert.match(section, /normalizeToken\(request\.data\?\.token\)/);
+  assert.match(section, /tokenDocumentId\(token\)/);
+  assert.match(section, /collection\("users"\)/);
+  assert.match(section, /doc\(uid\)/);
+  assert.match(section, /collection\("pushTokens"\)/);
+  assert.match(section, /doc\(tokenId\)/);
+  assert.match(section, /\.delete\(\)/);
+  assert.doesNotMatch(section, /listCollections|recursiveDelete|batch\(\)/);
+});


### PR DESCRIPTION
Stacked security follow-up on green PR #34. **Do not merge to Core before staging E2E correction cycle #2.**

Implements current-device FCM privacy lifecycle for sign-out:
- resolves the current device FCM token while Firebase Auth is still valid
- calls existing App Check/auth protected `unregisterPushToken` for the exact token
- deletes the local FCM token as a second line of defense
- bounds each FCM operation with a 5-second timeout so sign-out cannot hang indefinitely
- push revocation failure is logged but never traps the user in an authenticated session
- `AuthRepository.signOut()` performs push revocation before Firebase Auth sign-out
- exact-token backend behavior remains per-user and does not revoke other devices

Permanent regression guards verify:
- revocation occurs before Firebase Auth sign-out
- backend callable + local `deleteToken()` are both used
- operations are timeout-bounded
- backend unregister remains App Check/auth protected and token-specific

Base is PR #34 (`queued/authoritative-bills-sync`), so the locked Stream A E2E baseline remains untouched.