### PR TITLE
Ops: add immutable local staging deploy fallback

### DIFF
--- a/.github/workflows/ops-local-deploy-ci.yml
+++ b/.github/workflows/ops-local-deploy-ci.yml
@@ -1,0 +1,64 @@
+name: Validate Local Locked Staging Deploy
+
+on:
+  push:
+    branches:
+      - ops/local-locked-staging-deploy
+    paths:
+      - scripts/deploy-locked-staging.ps1
+      - .github/workflows/ops-local-deploy-ci.yml
+  pull_request:
+    paths:
+      - scripts/deploy-locked-staging.ps1
+      - .github/workflows/ops-local-deploy-ci.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Parse PowerShell script
+        shell: pwsh
+        run: |
+          $errors = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path scripts/deploy-locked-staging.ps1),
+            [ref]$null,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }
+
+      - name: Enforce immutable staging guards
+        shell: bash
+        run: |
+          set -euo pipefail
+          SCRIPT=scripts/deploy-locked-staging.ps1
+          grep -Fq 'ac2105098d698df06159f929f41595f91505c855' "$SCRIPT"
+          grep -Fq '$ProjectId = "clickandsaveai-staging"' "$SCRIPT"
+          grep -Fq '$ExpectedStreamBranch = "origin/agent/ai-native-financial-core"' "$SCRIPT"
+          grep -Fq 'git merge-base --is-ancestor' "$SCRIPT"
+          grep -Fq 'git worktree add --detach' "$SCRIPT"
+          grep -Fq 'firebase.cmd' "$SCRIPT"
+          grep -Fq -- '--only "firestore:rules,firestore:indexes,functions"' "$SCRIPT"
+          grep -Fq -- '--non-interactive' "$SCRIPT"
+
+          if grep -Eq 'git[[:space:]]+(switch|checkout)[[:space:]]' "$SCRIPT"; then
+            echo 'Local staging deploy must not mutate the current checkout.' >&2
+            exit 1
+          fi
+          if grep -Fq 'firebase.ps1' "$SCRIPT"; then
+            echo 'PowerShell execution-policy-sensitive firebase.ps1 is forbidden.' >&2
+            exit 1
+          fi
+          if grep -Fq '?.' "$SCRIPT" || grep -Fq '??' "$SCRIPT"; then
+            echo 'Keep the helper compatible with Windows PowerShell 5.1 syntax.' >&2
+            exit 1
+          fi

--- a/scripts/deploy-locked-staging.ps1
+++ b/scripts/deploy-locked-staging.ps1
@@ -9,7 +9,11 @@ $ProjectId = "clickandsaveai-staging"
 $ExpectedStreamBranch = "origin/agent/ai-native-financial-core"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $FirebaseCmd = Join-Path $env:APPDATA "npm\firebase.cmd"
-$NpmCmd = (Get-Command npm.cmd -ErrorAction SilentlyContinue)?.Source
+$NpmCommand = Get-Command npm.cmd -ErrorAction SilentlyContinue
+$NpmCmd = $null
+if ($NpmCommand) {
+    $NpmCmd = $NpmCommand.Source
+}
 $WorktreeRoot = Join-Path $env:TEMP ("ClickAndSaveAI-staging-" + $SourceSha.Substring(0, [Math]::Min(8, $SourceSha.Length)))
 $LocalStagingEnv = Join-Path $RepoRoot "functions\.env.clickandsaveai-staging"
 

--- a/scripts/deploy-locked-staging.ps1
+++ b/scripts/deploy-locked-staging.ps1
@@ -1,0 +1,117 @@
+param(
+    [string]$SourceSha = "ac2105098d698df06159f929f41595f91505c855"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$ProjectId = "clickandsaveai-staging"
+$ExpectedStreamBranch = "origin/agent/ai-native-financial-core"
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$FirebaseCmd = Join-Path $env:APPDATA "npm\firebase.cmd"
+$NpmCmd = (Get-Command npm.cmd -ErrorAction SilentlyContinue)?.Source
+$WorktreeRoot = Join-Path $env:TEMP ("ClickAndSaveAI-staging-" + $SourceSha.Substring(0, [Math]::Min(8, $SourceSha.Length)))
+$LocalStagingEnv = Join-Path $RepoRoot "functions\.env.clickandsaveai-staging"
+
+function Assert-LastExitCode([string]$Step) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Step failed with exit code $LASTEXITCODE"
+    }
+}
+
+if ($SourceSha -notmatch '^[0-9a-f]{40}$') {
+    throw "SourceSha must be an exact lowercase 40-character Git commit SHA."
+}
+
+if (-not (Test-Path $FirebaseCmd)) {
+    throw "firebase.cmd was not found at $FirebaseCmd"
+}
+
+if (-not $NpmCmd) {
+    throw "npm.cmd was not found in PATH."
+}
+
+Push-Location $RepoRoot
+try {
+    Write-Host "[1/8] Fetching locked Stream A lineage..."
+    & git fetch origin agent/ai-native-financial-core
+    Assert-LastExitCode "git fetch"
+
+    Write-Host "[2/8] Verifying exact commit exists..."
+    & git cat-file -e "$SourceSha`^{commit}"
+    Assert-LastExitCode "git cat-file"
+
+    Write-Host "[3/8] Verifying commit belongs to Stream A..."
+    & git merge-base --is-ancestor $SourceSha $ExpectedStreamBranch
+    Assert-LastExitCode "Stream A lineage check"
+
+    if (Test-Path $WorktreeRoot) {
+        Write-Host "Removing stale temporary worktree directory $WorktreeRoot"
+        & git worktree remove --force $WorktreeRoot 2>$null
+        Remove-Item -Recurse -Force $WorktreeRoot -ErrorAction SilentlyContinue
+    }
+
+    Write-Host "[4/8] Creating detached worktree at exact SHA $SourceSha..."
+    & git worktree add --detach $WorktreeRoot $SourceSha
+    Assert-LastExitCode "git worktree add"
+
+    $ActualSha = (& git -C $WorktreeRoot rev-parse HEAD).Trim()
+    Assert-LastExitCode "git rev-parse"
+    if ($ActualSha -ne $SourceSha) {
+        throw "Worktree verification failed. Expected $SourceSha but got $ActualSha"
+    }
+
+    if (Test-Path $LocalStagingEnv) {
+        Write-Host "[5/8] Copying local staging Functions environment into isolated worktree..."
+        Copy-Item $LocalStagingEnv (Join-Path $WorktreeRoot "functions\.env.clickandsaveai-staging") -Force
+    }
+    else {
+        Write-Warning "No local functions\.env.clickandsaveai-staging found. Deployment can continue only if the deployed Functions do not require local parameter values from that file."
+    }
+
+    Write-Host "[6/8] Installing backend dependencies and running tests..."
+    Push-Location (Join-Path $WorktreeRoot "functions")
+    try {
+        & $NpmCmd install --ignore-scripts
+        Assert-LastExitCode "npm install"
+        & $NpmCmd test
+        Assert-LastExitCode "backend tests"
+    }
+    finally {
+        Pop-Location
+    }
+
+    Write-Host "[7/8] Verifying Firebase target is staging only..."
+    if ($ProjectId -ne "clickandsaveai-staging") {
+        throw "Deployment target guard failed."
+    }
+
+    Write-Host "[8/8] Deploying exact SHA $SourceSha to $ProjectId..."
+    Push-Location $WorktreeRoot
+    try {
+        & $FirebaseCmd deploy `
+            --project $ProjectId `
+            --only "firestore:rules,firestore:indexes,functions" `
+            --non-interactive
+        Assert-LastExitCode "Firebase staging deploy"
+    }
+    finally {
+        Pop-Location
+    }
+
+    Write-Host ""
+    Write-Host "PASS: deployed locked Stream A SHA $SourceSha to $ProjectId" -ForegroundColor Green
+}
+finally {
+    Pop-Location
+    if (Test-Path $WorktreeRoot) {
+        Push-Location $RepoRoot
+        try {
+            & git worktree remove --force $WorktreeRoot 2>$null
+        }
+        finally {
+            Pop-Location
+        }
+        Remove-Item -Recurse -Force $WorktreeRoot -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
Adds a Windows-safe local deployment fallback for the locked Stream A staging baseline, without touching application code.

Why:
- GitHub OIDC/WIF remains externally blocked until Google Cloud IAM is configured.
- the repository owner already has a working authenticated local Firebase CLI path.
- this helper avoids mutable-branch deployment and avoids changing the developer's current checkout.

Safety:
- default source is exact locked SHA `ac2105098d698df06159f929f41595f91505c855`
- accepts only exact lowercase 40-character commit SHAs
- verifies the SHA belongs to `origin/agent/ai-native-financial-core`
- creates a detached temporary Git worktree; never `git switch`/`checkout`s the active working tree
- hard-pins Firebase project to `clickandsaveai-staging`
- deploys only Firestore rules/indexes + Functions
- uses `firebase.cmd`, avoiding the local PowerShell execution-policy problem with `firebase.ps1`
- copies only the existing local staging Functions env file into the temporary worktree
- installs dependencies and runs backend tests before deployment
- cleans the temporary worktree afterward
- script remains compatible with Windows PowerShell 5.1 syntax

Includes dedicated Ops CI for PowerShell parsing and immutable/staging guardrails.