### PR TITLE
Ops: add locked staging device preflight

### DIFF
--- a/.github/workflows/ops-device-preflight-ci.yml
+++ b/.github/workflows/ops-device-preflight-ci.yml
@@ -1,0 +1,61 @@
+name: Validate Staging Device Preflight
+
+on:
+  push:
+    branches:
+      - ops/staging-device-preflight
+    paths:
+      - scripts/staging-device-preflight.ps1
+      - .github/workflows/ops-device-preflight-ci.yml
+  pull_request:
+    paths:
+      - scripts/staging-device-preflight.ps1
+      - .github/workflows/ops-device-preflight-ci.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Parse PowerShell script
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path scripts/staging-device-preflight.ps1),
+            [ref]$tokens,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }
+
+      - name: Enforce locked E2E artifact and package guards
+        shell: bash
+        run: |
+          set -euo pipefail
+          SCRIPT=scripts/staging-device-preflight.ps1
+          grep -Fq 'cbd841ed22f51f7fc1216ee1dd23148fb468965659e9ff3d5aa1831736adfd0a' "$SCRIPT"
+          grep -Fq 'com.aistudio.clickandsaveai.app' "$SCRIPT"
+          grep -Fq 'com.example.MainActivity' "$SCRIPT"
+          grep -Fq 'adb.exe' "$SCRIPT"
+          grep -Fq 'install -r' "$SCRIPT"
+          grep -Fq 'Get-FileHash -Algorithm SHA256' "$SCRIPT"
+          grep -Fq 'logcat -c' "$SCRIPT"
+          grep -Fq 'force-stop' "$SCRIPT"
+
+          if grep -Fq 'uninstall' "$SCRIPT"; then
+            echo 'Device preflight must not uninstall the app or destroy local E2E state.' >&2
+            exit 1
+          fi
+          if grep -Fq '?.' "$SCRIPT" || grep -Fq '??' "$SCRIPT"; then
+            echo 'Keep the helper compatible with Windows PowerShell 5.1 syntax.' >&2
+            exit 1
+          fi

--- a/scripts/staging-device-preflight.ps1
+++ b/scripts/staging-device-preflight.ps1
@@ -1,0 +1,70 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ApkPath
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$ExpectedApkSha256 = "cbd841ed22f51f7fc1216ee1dd23148fb468965659e9ff3d5aa1831736adfd0a"
+$PackageName = "com.aistudio.clickandsaveai.app"
+$ActivityName = "com.example.MainActivity"
+$Adb = Join-Path $env:LOCALAPPDATA "Android\Sdk\platform-tools\adb.exe"
+
+function Assert-LastExitCode([string]$Step) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Step failed with exit code $LASTEXITCODE"
+    }
+}
+
+$ResolvedApk = (Resolve-Path $ApkPath).Path
+if (-not (Test-Path $ResolvedApk)) {
+    throw "APK not found: $ApkPath"
+}
+
+if (-not (Test-Path $Adb)) {
+    throw "adb.exe was not found at $Adb"
+}
+
+Write-Host "[1/6] Verifying locked staging APK SHA-256..."
+$ActualHash = (Get-FileHash -Algorithm SHA256 $ResolvedApk).Hash.ToLowerInvariant()
+if ($ActualHash -ne $ExpectedApkSha256) {
+    throw "APK hash mismatch. Expected $ExpectedApkSha256 but got $ActualHash. Do not install this APK for locked E2E #2."
+}
+
+Write-Host "[2/6] Verifying one Android device is connected..."
+$DeviceLines = @(& $Adb devices) | Where-Object { $_ -match "`tdevice$" }
+Assert-LastExitCode "adb devices"
+if ($DeviceLines.Count -ne 1) {
+    throw "Expected exactly one authorized Android device, found $($DeviceLines.Count)."
+}
+
+Write-Host "[3/6] Installing locked staging APK..."
+& $Adb install -r $ResolvedApk
+Assert-LastExitCode "adb install"
+
+Write-Host "[4/6] Verifying installed package..."
+$PackagePath = @(& $Adb shell pm path $PackageName)
+Assert-LastExitCode "adb shell pm path"
+if (-not ($PackagePath -join "`n").Contains("package:")) {
+    throw "Package $PackageName is not installed after adb install."
+}
+
+Write-Host "[5/6] Starting ClickAndSaveAI with a clean log buffer..."
+& $Adb logcat -c
+Assert-LastExitCode "adb logcat -c"
+& $Adb shell am force-stop $PackageName
+Assert-LastExitCode "adb force-stop"
+& $Adb shell am start -n "$PackageName/$ActivityName"
+Assert-LastExitCode "adb start"
+Start-Sleep -Seconds 5
+
+Write-Host "[6/6] Capturing focused E2E startup logs..."
+$FocusedLogs = & $Adb logcat -d | Select-String "AppCheck|DebugAppCheckProvider|FirebaseAppCheck|MainActivity|PushRegistration|ObservedBills|GmailRepository|TestPush|ClickAndSave"
+Assert-LastExitCode "adb logcat -d"
+$FocusedLogs | ForEach-Object { $_.Line }
+
+Write-Host ""
+Write-Host "PASS: locked staging APK installed and started on the connected device." -ForegroundColor Green
+Write-Host "APK SHA-256: $ActualHash"
+Write-Host "Package: $PackageName"


### PR DESCRIPTION
Adds a Windows PowerShell staging-device preflight for E2E correction cycle #2. No application runtime code changes.

The helper:
- requires an explicit APK path;
- verifies the exact SHA-256 of the locked `ac210509…` staging APK before installation;
- requires exactly one authorized Android device;
- uses `adb install -r` and never uninstalls the app;
- verifies package `com.aistudio.clickandsaveai.app`;
- clears logcat, force-stops, starts `com.example.MainActivity`, then prints only focused App Check/Gmail/Push/ObservedBills startup logs;
- remains Windows PowerShell 5.1 compatible.

Dedicated Ops CI parses the script and locks the expected artifact/package/ADB guardrails.

This is intentionally independent of Stream A and can merge to `main` without moving the E2E application baseline.