### PR TITLE
Queue four-hour Gmail History reconciliation

### DIFF
--- a/functions/src/entry.js
+++ b/functions/src/entry.js
@@ -4,6 +4,7 @@ const coreFunctions = require("./index");
 const pushFunctions = require("./pushFunctions");
 const gmailWatchFunctions = require("./gmailWatchFunctions");
 const gmailWatchRenewal = require("./gmailWatchRenewal");
+const gmailIncrementalReconciliation = require("./gmailIncrementalReconciliation");
 const financialAgentFunctions = require("./financialAgentFunctions");
 const opportunityNotificationFunctions = require("./opportunityNotificationFunctions");
 const opportunityActionFunctions = require("./opportunityActionFunctions");
@@ -20,6 +21,7 @@ module.exports = {
   ...pushFunctions,
   ...gmailWatchFunctions,
   ...gmailWatchRenewal,
+  ...gmailIncrementalReconciliation,
   ...financialAgentFunctions,
   ...opportunityNotificationFunctions,
   ...opportunityActionFunctions,

--- a/functions/src/gmailIncrementalReconciliation.js
+++ b/functions/src/gmailIncrementalReconciliation.js
@@ -1,0 +1,320 @@
+"use strict";
+
+const { FieldValue, getFirestore } = require("firebase-admin/firestore");
+const { onDocumentUpdated } = require("firebase-functions/v2/firestore");
+const { onSchedule } = require("firebase-functions/v2/scheduler");
+const { defineSecret, defineString } = require("firebase-functions/params");
+const logger = require("firebase-functions/logger");
+const { decryptToken } = require("./tokenCrypto");
+const { gmailPushNotification } = require("./gmailWatchFunctions");
+const { ACTIVE_GMAIL_PARSER_VERSION } = require("./gmailParserVersion");
+
+const db = getFirestore();
+const googleOAuthClientId = defineString("GOOGLE_OAUTH_CLIENT_ID");
+const googleOAuthClientSecret = defineSecret("GOOGLE_OAUTH_CLIENT_SECRET");
+const oauthTokenEncryptionKey = defineSecret("OAUTH_TOKEN_ENCRYPTION_KEY");
+const geminiApiKey = defineSecret("GEMINI_API_KEY");
+
+const INITIAL_GMAIL_LOOKBACK = "6m";
+const MAX_CONNECTIONS_PER_SWEEP = 250;
+const MAX_CONCURRENCY = 5;
+
+function normalizeHistoryId(value) {
+  const normalized = String(value || "").trim();
+  return /^\d+$/.test(normalized) ? normalized : "";
+}
+
+function compareHistoryIds(left, right) {
+  const a = normalizeHistoryId(left);
+  const b = normalizeHistoryId(right);
+  if (!a || !b) return null;
+  const aBig = BigInt(a);
+  const bBig = BigInt(b);
+  return aBig === bBig ? 0 : (aBig > bBig ? 1 : -1);
+}
+
+async function refreshAccessToken(encryptedRefreshToken) {
+  const refreshToken = decryptToken(encryptedRefreshToken, oauthTokenEncryptionKey.value());
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: googleOAuthClientId.value(),
+      client_secret: googleOAuthClientSecret.value(),
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || !payload.access_token) {
+    throw new Error(`Google token refresh failed with ${response.status}`);
+  }
+  return String(payload.access_token);
+}
+
+async function getCurrentMailboxHistoryId(accessToken) {
+  const response = await fetch("https://gmail.googleapis.com/gmail/v1/users/me/profile", {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  const payload = await response.json().catch(() => ({}));
+  const historyId = normalizeHistoryId(payload.historyId);
+  if (!response.ok || !historyId) {
+    throw new Error(`Gmail users.getProfile failed with ${response.status}`);
+  }
+  return historyId;
+}
+
+async function historyCheckpointIsReadable(accessToken, startHistoryId) {
+  const params = new URLSearchParams({
+    startHistoryId: String(startHistoryId),
+    historyTypes: "messageAdded",
+    maxResults: "1",
+  });
+  const response = await fetch(
+    `https://gmail.googleapis.com/gmail/v1/users/me/history?${params.toString()}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } }
+  );
+  if (response.status === 404) return false;
+  if (!response.ok) {
+    throw new Error(`Gmail history.list preflight failed with ${response.status}`);
+  }
+  return true;
+}
+
+function syntheticPubSubEvent(emailAddress, historyId) {
+  const payload = Buffer.from(JSON.stringify({ emailAddress, historyId }), "utf8").toString("base64");
+  return {
+    data: {
+      message: {
+        data: payload,
+      },
+    },
+  };
+}
+
+async function invokeExistingIncrementalHandler(emailAddress, historyId) {
+  const handler = typeof gmailPushNotification.run === "function"
+    ? gmailPushNotification.run.bind(gmailPushNotification)
+    : gmailPushNotification;
+  if (typeof handler !== "function") {
+    throw new Error("Gmail Pub/Sub handler is unavailable for reconciliation reuse.");
+  }
+  await handler(syntheticPubSubEvent(emailAddress, historyId));
+}
+
+function backfillCompletionUpdate(data) {
+  if (data.initialBackfillCompleted === true) return null;
+  if (!data.lastScanAt || String(data.initialBackfillLookback || "") !== INITIAL_GMAIL_LOOKBACK) {
+    return null;
+  }
+  return {
+    initialBackfillCompleted: true,
+    initialBackfillCompletedAt: data.lastScanAt,
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+}
+
+async function markBackfillCompleteIfObserved(doc) {
+  const data = doc.data() || {};
+  const update = backfillCompletionUpdate(data);
+  if (!update) return data.initialBackfillCompleted === true;
+  await doc.ref.set(update, { merge: true });
+  return true;
+}
+
+async function reconcileConnection(doc) {
+  const data = doc.data() || {};
+  if (data.watchEnabled !== true || !data.encryptedRefreshToken) {
+    return { status: "SKIPPED_NOT_WATCHING" };
+  }
+
+  const initialBackfillCompleted = await markBackfillCompleteIfObserved(doc);
+  if (!initialBackfillCompleted) {
+    return { status: "SKIPPED_BACKFILL_INCOMPLETE" };
+  }
+
+  const startHistoryId = normalizeHistoryId(data.watchHistoryId);
+  if (!startHistoryId) {
+    await doc.ref.set({
+      historyRecoveryRequired: true,
+      historyRecoveryReason: "MISSING_HISTORY_BASELINE",
+      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return { status: "RECOVERY_REQUIRED" };
+  }
+
+  if (data.historyRecoveryRequired === true) {
+    await doc.ref.set({
+      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return { status: "RECOVERY_PENDING" };
+  }
+
+  const accessToken = await refreshAccessToken(data.encryptedRefreshToken);
+  const currentHistoryId = await getCurrentMailboxHistoryId(accessToken);
+  const ordering = compareHistoryIds(currentHistoryId, startHistoryId);
+
+  if (ordering !== null && ordering <= 0) {
+    await doc.ref.set({
+      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+      lastReconciliationAt: FieldValue.serverTimestamp(),
+      lastReconciliationHistoryId: startHistoryId,
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return { status: "CURRENT" };
+  }
+
+  const readable = await historyCheckpointIsReadable(accessToken, startHistoryId);
+  if (!readable) {
+    await doc.ref.set({
+      pendingHistoryId: currentHistoryId,
+      historyRecoveryRequired: true,
+      historyRecoveryReason: "HISTORY_ID_EXPIRED",
+      historyRecoveryDetectedAt: FieldValue.serverTimestamp(),
+      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return { status: "RECOVERY_REQUIRED" };
+  }
+
+  const emailAddress = String(data.email || "").trim().toLowerCase();
+  if (!emailAddress) {
+    throw new Error("Gmail connection is missing normalized email address.");
+  }
+
+  await invokeExistingIncrementalHandler(emailAddress, currentHistoryId);
+  await doc.ref.set({
+    lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+    lastReconciliationAt: FieldValue.serverTimestamp(),
+    lastReconciliationHistoryId: currentHistoryId,
+    parserVersion: ACTIVE_GMAIL_PARSER_VERSION,
+    updatedAt: FieldValue.serverTimestamp(),
+  }, { merge: true });
+  return { status: "RECONCILED" };
+}
+
+async function runWithConcurrency(items, concurrency, worker) {
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      await worker(items[index]);
+    }
+  });
+  await Promise.all(workers);
+}
+
+exports.gmailIncrementalReconciliation = onSchedule(
+  {
+    schedule: "0 */4 * * *",
+    timeZone: "Asia/Jerusalem",
+    region: "europe-west1",
+    timeoutSeconds: 540,
+    memory: "1GiB",
+    secrets: [googleOAuthClientSecret, oauthTokenEncryptionKey, geminiApiKey],
+  },
+  async () => {
+    const snapshot = await db.collection("gmailConnections")
+      .where("watchEnabled", "==", true)
+      .limit(MAX_CONNECTIONS_PER_SWEEP)
+      .get();
+
+    const stats = {
+      candidates: snapshot.size,
+      reconciled: 0,
+      current: 0,
+      recoveryRequired: 0,
+      recoveryPending: 0,
+      skippedBackfillIncomplete: 0,
+      skippedNotWatching: 0,
+      failed: 0,
+    };
+
+    await runWithConcurrency(snapshot.docs, MAX_CONCURRENCY, async (doc) => {
+      try {
+        const result = await reconcileConnection(doc);
+        switch (result.status) {
+          case "RECONCILED": stats.reconciled += 1; break;
+          case "CURRENT": stats.current += 1; break;
+          case "RECOVERY_REQUIRED": stats.recoveryRequired += 1; break;
+          case "RECOVERY_PENDING": stats.recoveryPending += 1; break;
+          case "SKIPPED_BACKFILL_INCOMPLETE": stats.skippedBackfillIncomplete += 1; break;
+          case "SKIPPED_NOT_WATCHING": stats.skippedNotWatching += 1; break;
+          default: break;
+        }
+      } catch (error) {
+        stats.failed += 1;
+        logger.error("Gmail incremental reconciliation failed", {
+          uid: doc.id,
+          errorName: error instanceof Error ? error.name : typeof error,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+
+    logger.info("Gmail incremental reconciliation completed", stats);
+    if (stats.failed > 0) {
+      throw new Error(`Failed to reconcile ${stats.failed} Gmail connection(s)`);
+    }
+  }
+);
+
+exports.onGmailConnectionCheckpointChanged = onDocumentUpdated(
+  {
+    document: "gmailConnections/{uid}",
+    region: "europe-west1",
+  },
+  async (event) => {
+    const before = event.data?.before?.data() || {};
+    const after = event.data?.after?.data() || {};
+    const ref = event.data?.after?.ref;
+    if (!ref) return;
+
+    const update = {};
+    const completion = backfillCompletionUpdate(after);
+    if (completion) Object.assign(update, completion);
+
+    const sameMailbox = String(before.email || "").trim().toLowerCase() ===
+      String(after.email || "").trim().toLowerCase();
+    const beforeHistoryId = normalizeHistoryId(before.watchHistoryId);
+    const afterHistoryId = normalizeHistoryId(after.watchHistoryId);
+    const ordering = sameMailbox && beforeHistoryId && afterHistoryId
+      ? compareHistoryIds(afterHistoryId, beforeHistoryId)
+      : null;
+
+    if (ordering !== null && ordering < 0) {
+      update.watchHistoryId = beforeHistoryId;
+      update.historyCheckpointProtectedAt = FieldValue.serverTimestamp();
+    }
+
+    const recoveryAdvancedCheckpoint =
+      sameMailbox &&
+      after.historyRecoveryRequired === true &&
+      beforeHistoryId &&
+      afterHistoryId &&
+      compareHistoryIds(afterHistoryId, beforeHistoryId) === 1 &&
+      normalizeHistoryId(after.pendingHistoryId) === afterHistoryId;
+
+    if (recoveryAdvancedCheckpoint) {
+      update.watchHistoryId = beforeHistoryId;
+      update.historyCheckpointProtectedAt = FieldValue.serverTimestamp();
+      update.historyRecoveryReason = String(after.historyRecoveryReason || "HISTORY_ID_EXPIRED");
+    }
+
+    if (Object.keys(update).length > 0) {
+      update.updatedAt = FieldValue.serverTimestamp();
+      await ref.set(update, { merge: true });
+    }
+  }
+);
+
+Object.defineProperties(module.exports, {
+  _normalizeHistoryId: { value: normalizeHistoryId, enumerable: false },
+  _compareHistoryIds: { value: compareHistoryIds, enumerable: false },
+  _backfillCompletionUpdate: { value: backfillCompletionUpdate, enumerable: false },
+  _syntheticPubSubEvent: { value: syntheticPubSubEvent, enumerable: false },
+});

--- a/functions/test/gmailIncrementalReconciliation.test.js
+++ b/functions/test/gmailIncrementalReconciliation.test.js
@@ -17,6 +17,7 @@ test("four-hour Gmail reconciliation is exported without replacing the public Gm
   assert.equal(typeof entry.gmailIncrementalReconciliation, "function");
   assert.equal(typeof entry.onGmailConnectionCheckpointChanged, "function");
   assert.equal(typeof entry.gmailPushNotification, "function");
+  assert.equal(typeof entry.gmailPushNotification.run, "function");
   assert.match(source, /schedule:\s*"0 \*\/4 \* \* \*"/);
   assert.match(source, /timeZone:\s*"Asia\/Jerusalem"/);
 });
@@ -70,8 +71,7 @@ test("reconciliation preflights Gmail History and enters recovery without advanc
   assert.match(source, /historyRecoveryRequired:\s*true/);
   assert.match(source, /historyRecoveryReason:\s*"HISTORY_ID_EXPIRED"/);
 
-  const expiredBlock = source
-    .substringAfter?.("if (!readable) {") || source.split("if (!readable) {")[1]?.split("\n  }")[0] || "";
+  const expiredBlock = source.split("if (!readable) {")[1]?.split("\n  }")[0] || "";
   assert.doesNotMatch(expiredBlock, /watchHistoryId\s*:/);
 });
 

--- a/functions/test/gmailIncrementalReconciliation.test.js
+++ b/functions/test/gmailIncrementalReconciliation.test.js
@@ -1,0 +1,84 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const entry = require("../src/entry");
+const reconciliation = require("../src/gmailIncrementalReconciliation");
+
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "src", "gmailIncrementalReconciliation.js"),
+  "utf8"
+);
+
+test("four-hour Gmail reconciliation is exported without replacing the public Gmail push handler", () => {
+  assert.equal(typeof entry.gmailIncrementalReconciliation, "function");
+  assert.equal(typeof entry.onGmailConnectionCheckpointChanged, "function");
+  assert.equal(typeof entry.gmailPushNotification, "function");
+  assert.match(source, /schedule:\s*"0 \*\/4 \* \* \*"/);
+  assert.match(source, /timeZone:\s*"Asia\/Jerusalem"/);
+});
+
+test("history ids are normalized and compared monotonically as integers", () => {
+  assert.equal(reconciliation._normalizeHistoryId(" 00123 "), "00123");
+  assert.equal(reconciliation._normalizeHistoryId("abc"), "");
+  assert.equal(reconciliation._compareHistoryIds("101", "100"), 1);
+  assert.equal(reconciliation._compareHistoryIds("100", "100"), 0);
+  assert.equal(reconciliation._compareHistoryIds("99", "100"), -1);
+  assert.equal(reconciliation._compareHistoryIds("bad", "100"), null);
+});
+
+test("observed six-month scan state becomes an explicit initial-backfill completion marker", () => {
+  const lastScanAt = { seconds: 123, nanoseconds: 0 };
+  const update = reconciliation._backfillCompletionUpdate({
+    initialBackfillLookback: "6m",
+    lastScanAt,
+  });
+  assert.equal(update.initialBackfillCompleted, true);
+  assert.equal(update.initialBackfillCompletedAt, lastScanAt);
+
+  assert.equal(reconciliation._backfillCompletionUpdate({
+    initialBackfillCompleted: true,
+    initialBackfillLookback: "6m",
+    lastScanAt,
+  }), null);
+  assert.equal(reconciliation._backfillCompletionUpdate({
+    initialBackfillLookback: "6m",
+  }), null);
+});
+
+test("scheduled reconciliation reuses the existing Gmail Pub/Sub ingestion path", () => {
+  const event = reconciliation._syntheticPubSubEvent("USER@example.com", "987654321");
+  const decoded = JSON.parse(Buffer.from(event.data.message.data, "base64").toString("utf8"));
+  assert.deepEqual(decoded, {
+    emailAddress: "USER@example.com",
+    historyId: "987654321",
+  });
+
+  assert.match(source, /require\("\.\/gmailWatchFunctions"\)/);
+  assert.match(source, /gmailPushNotification\.run/);
+  assert.doesNotMatch(source, /newer_than:/);
+  assert.doesNotMatch(source, /users\/me\/messages\?/);
+});
+
+test("reconciliation preflights Gmail History and enters recovery without advancing the checkpoint", () => {
+  assert.match(source, /users\/me\/profile/);
+  assert.match(source, /users\/me\/history\?/);
+  assert.match(source, /response\.status === 404/);
+  assert.match(source, /historyRecoveryRequired:\s*true/);
+  assert.match(source, /historyRecoveryReason:\s*"HISTORY_ID_EXPIRED"/);
+
+  const expiredBlock = source
+    .substringAfter?.("if (!readable) {") || source.split("if (!readable) {")[1]?.split("\n  }")[0] || "";
+  assert.doesNotMatch(expiredBlock, /watchHistoryId\s*:/);
+});
+
+test("connection update guard protects Gmail History checkpoints from regression and expired-history advance", () => {
+  assert.match(source, /ordering !== null && ordering < 0/);
+  assert.match(source, /update\.watchHistoryId = beforeHistoryId/);
+  assert.match(source, /after\.historyRecoveryRequired === true/);
+  assert.match(source, /normalizeHistoryId\(after\.pendingHistoryId\) === afterHistoryId/);
+  assert.match(source, /historyCheckpointProtectedAt/);
+});


### PR DESCRIPTION
Queued Stream A reliability work for Issue #6, based exactly on locked Core `ac2105098d698df06159f929f41595f91505c855`.

**DO NOT MERGE before staging E2E correction cycle #2.**

Adds a 4-hour Gmail incremental reconciliation path without repeating the six-month backfill:
- scheduled every 4 hours in Asia/Jerusalem
- uses Gmail `users.getProfile.historyId` as the current mailbox target
- preflights `users.history.list` from the persisted `watchHistoryId`
- reuses the existing Gmail Pub/Sub ingestion handler instead of introducing a second parser/PDF pipeline
- marks observed six-month scan state as explicit `initialBackfillCompleted`
- stores reconciliation timestamps/history IDs for operator health
- on expired History (404), sets recovery-required state and does **not** intentionally advance the checkpoint
- Firestore update guard restores backward checkpoints and protects the last valid checkpoint when the existing realtime path detects expired history
- limits each sweep to 250 watched connections with concurrency 5
- does not run `messages.list newer_than:6m` during routine reconciliation

This intentionally remains Draft/queued until the locked backend/APK E2E cycle passes. Google documents that Gmail History is read from a persisted `startHistoryId`, that an old/invalid ID typically returns 404, and that the current response/profile `historyId` is the synchronization checkpoint.

Regression tests cover schedule/export, integer History ordering, initial-backfill completion state, reuse of the existing ingestion handler, no six-month scan path, 404 recovery state and checkpoint protection.