### PR TITLE
Ops: add one-command locked E2E2 runner

### DIFF
--- a/.github/workflows/ops-e2e2-runner-ci.yml
+++ b/.github/workflows/ops-e2e2-runner-ci.yml
@@ -1,0 +1,65 @@
+name: Validate Locked E2E2 Runner
+
+on:
+  push:
+    branches:
+      - ops/locked-e2e2-runner
+    paths:
+      - scripts/run-locked-e2e2.ps1
+      - .github/workflows/ops-e2e2-runner-ci.yml
+  pull_request:
+    paths:
+      - scripts/run-locked-e2e2.ps1
+      - .github/workflows/ops-e2e2-runner-ci.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Parse PowerShell script
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path scripts/run-locked-e2e2.ps1),
+            [ref]$tokens,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }
+
+      - name: Enforce locked sequence and staging guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          SCRIPT=scripts/run-locked-e2e2.ps1
+          grep -Fq 'ac2105098d698df06159f929f41595f91505c855' "$SCRIPT"
+          grep -Fq '[ValidateSet("clickandsaveai-staging")]' "$SCRIPT"
+          grep -Fq 'deploy-locked-staging.ps1' "$SCRIPT"
+          grep -Fq 'staging-device-preflight.ps1' "$SCRIPT"
+          grep -Fq 'Device installation was not attempted' "$SCRIPT"
+          DEPLOY_LINE=$(grep -n 'DeployScript -SourceSha' "$SCRIPT" | head -n1 | cut -d: -f1)
+          DEVICE_LINE=$(grep -n 'DevicePreflightScript -ApkPath' "$SCRIPT" | head -n1 | cut -d: -f1)
+          test "$DEPLOY_LINE" -lt "$DEVICE_LINE"
+
+          if grep -Fq 'uninstall' "$SCRIPT"; then
+            echo 'Locked E2E runner must never uninstall the app.' >&2
+            exit 1
+          fi
+          if grep -Fq 'firebase deploy' "$SCRIPT"; then
+            echo 'Wrapper must delegate deployment to the audited locked deploy helper.' >&2
+            exit 1
+          fi
+          if grep -Fq '?.' "$SCRIPT" || grep -Fq '??' "$SCRIPT"; then
+            echo 'Keep the helper compatible with Windows PowerShell 5.1 syntax.' >&2
+            exit 1
+          fi

--- a/scripts/run-locked-e2e2.ps1
+++ b/scripts/run-locked-e2e2.ps1
@@ -1,0 +1,60 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ApkPath,
+
+    [string]$SourceSha = "ac2105098d698df06159f929f41595f91505c855",
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("clickandsaveai-staging")]
+    [string]$ConfirmProject
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$DeployScript = Join-Path $RepoRoot "scripts\deploy-locked-staging.ps1"
+$DevicePreflightScript = Join-Path $RepoRoot "scripts\staging-device-preflight.ps1"
+
+if ($ConfirmProject -ne "clickandsaveai-staging") {
+    throw "E2E #2 is staging-only. ConfirmProject must be clickandsaveai-staging."
+}
+
+if ($SourceSha -notmatch '^[0-9a-f]{40}$') {
+    throw "SourceSha must be an exact lowercase 40-character Git commit SHA."
+}
+
+if (-not (Test-Path $DeployScript)) {
+    throw "Missing locked staging deploy helper: $DeployScript"
+}
+
+if (-not (Test-Path $DevicePreflightScript)) {
+    throw "Missing staging device preflight helper: $DevicePreflightScript"
+}
+
+$ResolvedApk = (Resolve-Path $ApkPath).Path
+
+Write-Host "============================================================"
+Write-Host " Click&SaveAI locked staging E2E correction cycle #2"
+Write-Host " Backend SHA: $SourceSha"
+Write-Host " Project: clickandsaveai-staging"
+Write-Host " APK: $ResolvedApk"
+Write-Host "============================================================"
+Write-Host ""
+
+Write-Host "PHASE 1/2 — deploy exact locked backend" -ForegroundColor Cyan
+& $DeployScript -SourceSha $SourceSha
+if ($LASTEXITCODE -ne 0) {
+    throw "Locked staging backend deploy failed. Device installation was not attempted."
+}
+
+Write-Host ""
+Write-Host "PHASE 2/2 — verify/install paired APK and capture focused startup logs" -ForegroundColor Cyan
+& $DevicePreflightScript -ApkPath $ResolvedApk
+if ($LASTEXITCODE -ne 0) {
+    throw "Device preflight failed after backend deployment."
+}
+
+Write-Host ""
+Write-Host "PASS: locked backend and paired APK are aligned for E2E #2." -ForegroundColor Green
+Write-Host "Continue with Google/Firebase sign-in -> Gmail readonly -> parser upgrade/backfill -> Financial Home -> Push/Savings validation."


### PR DESCRIPTION
Adds a single Windows PowerShell wrapper for the locked staging E2E correction cycle #2. No application runtime code changes.

The wrapper requires:
- paired APK path
- explicit `clickandsaveai-staging` confirmation
- defaults to locked backend SHA `ac2105098d698df06159f929f41595f91505c855`

Sequence is fixed:
1. invoke the audited `deploy-locked-staging.ps1` helper;
2. only after successful deployment invoke `staging-device-preflight.ps1`;
3. stop before device installation if deployment fails.

It therefore preserves the existing exact-SHA, staging-only, detached-worktree, APK-hash, package and no-uninstall guardrails while reducing the account-owner handoff to one command.

Dedicated Ops CI validates PowerShell parsing, staging confirmation and deploy-before-device ordering.