### PR TITLE
Ops: redact credentials from E2E startup logs

### DIFF
--- a/.github/workflows/ops-device-preflight-ci.yml
+++ b/.github/workflows/ops-device-preflight-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - ops/staging-device-preflight
+      - ops/redact-e2e-secrets
     paths:
       - scripts/staging-device-preflight.ps1
       - .github/workflows/ops-device-preflight-ci.yml
@@ -37,7 +38,7 @@ jobs:
             exit 1
           }
 
-      - name: Enforce locked E2E artifact and package guards
+      - name: Enforce locked E2E artifact, privacy and package guards
         shell: bash
         run: |
           set -euo pipefail
@@ -50,6 +51,11 @@ jobs:
           grep -Fq 'Get-FileHash -Algorithm SHA256' "$SCRIPT"
           grep -Fq 'logcat -c' "$SCRIPT"
           grep -Fq 'force-stop' "$SCRIPT"
+          grep -Fq 'Redact-SensitiveLogLine' "$SCRIPT"
+          grep -Fq '[REDACTED_APP_CHECK_SECRET]' "$SCRIPT"
+          grep -Fq '[REDACTED_TOKEN]' "$SCRIPT"
+          grep -Fq '[REDACTED_JWT]' "$SCRIPT"
+          grep -Fq 'credentials redacted' "$SCRIPT"
 
           if grep -Fq 'uninstall' "$SCRIPT"; then
             echo 'Device preflight must not uninstall the app or destroy local E2E state.' >&2

--- a/scripts/staging-device-preflight.ps1
+++ b/scripts/staging-device-preflight.ps1
@@ -17,6 +17,39 @@ function Assert-LastExitCode([string]$Step) {
     }
 }
 
+function Redact-SensitiveLogLine([string]$Line) {
+    if (-not $Line) { return $Line }
+
+    $Redacted = $Line
+
+    # Firebase App Check debug builds can print a UUID-like debug secret. Never echo it from
+    # an evidence helper that may later be pasted into an issue or chat.
+    if ($Redacted -match '(?i)AppCheck|DebugAppCheckProvider') {
+        $Redacted = [regex]::Replace(
+            $Redacted,
+            '\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b',
+            '[REDACTED_APP_CHECK_SECRET]'
+        )
+    }
+
+    # Protect FCM/auth-like token values if a library or future diagnostic line starts printing
+    # them. Keep the field name for debugging while removing the credential value.
+    $Redacted = [regex]::Replace(
+        $Redacted,
+        '(?i)(\b(?:fcm[_ -]?token|registration[_ -]?token|auth[_ -]?token|access[_ -]?token|refresh[_ -]?token|debug[_ -]?token|token)\b\s*[:=]\s*)[^\s,;]+',
+        '$1[REDACTED_TOKEN]'
+    )
+
+    # JWT-shaped values are credentials even when a log line forgot to label them as a token.
+    $Redacted = [regex]::Replace(
+        $Redacted,
+        '\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b',
+        '[REDACTED_JWT]'
+    )
+
+    return $Redacted
+}
+
 $ResolvedApk = (Resolve-Path $ApkPath).Path
 if (-not (Test-Path $ResolvedApk)) {
     throw "APK not found: $ApkPath"
@@ -59,10 +92,10 @@ Assert-LastExitCode "adb force-stop"
 Assert-LastExitCode "adb start"
 Start-Sleep -Seconds 5
 
-Write-Host "[6/6] Capturing focused E2E startup logs..."
+Write-Host "[6/6] Capturing focused E2E startup logs (credentials redacted)..."
 $FocusedLogs = & $Adb logcat -d | Select-String "AppCheck|DebugAppCheckProvider|FirebaseAppCheck|MainActivity|PushRegistration|ObservedBills|GmailRepository|TestPush|ClickAndSave"
 Assert-LastExitCode "adb logcat -d"
-$FocusedLogs | ForEach-Object { $_.Line }
+$FocusedLogs | ForEach-Object { Redact-SensitiveLogLine $_.Line }
 
 Write-Host ""
 Write-Host "PASS: locked staging APK installed and started on the connected device." -ForegroundColor Green


### PR DESCRIPTION
Security hotfix for the locked staging device preflight. No application runtime code changes.

The preflight intentionally filters App Check/Push startup logs, but Firebase debug builds may print the App Check debug secret. This PR redacts before output:
- UUID-shaped App Check debug secrets on AppCheck lines
- labeled FCM/registration/auth/access/refresh/debug token values
- JWT-shaped credentials

The helper still shows useful status/log context but no longer emits credential values that could be pasted into an issue or chat.

Ops CI now requires the redaction function/markers in addition to the existing exact APK hash, package, adb, no-uninstall and PowerShell 5.1 guards.