### PR TITLE
Ops: add local-only App Check debug secret helper

### DIFF
--- a/.github/workflows/ops-appcheck-secret-ci.yml
+++ b/.github/workflows/ops-appcheck-secret-ci.yml
@@ -1,0 +1,66 @@
+name: Validate Local App Check Secret Helper
+
+on:
+  push:
+    branches:
+      - ops/local-appcheck-secret
+    paths:
+      - scripts/copy-appcheck-debug-secret.ps1
+      - .github/workflows/ops-appcheck-secret-ci.yml
+  pull_request:
+    paths:
+      - scripts/copy-appcheck-debug-secret.ps1
+      - .github/workflows/ops-appcheck-secret-ci.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Parse PowerShell script
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path scripts/copy-appcheck-debug-secret.ps1),
+            [ref]$tokens,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }
+
+      - name: Enforce local-only credential handling
+        shell: bash
+        run: |
+          set -euo pipefail
+          SCRIPT=scripts/copy-appcheck-debug-secret.ps1
+          grep -Fq 'com.aistudio.clickandsaveai.app' "$SCRIPT"
+          grep -Fq 'DebugAppCheckProvider' "$SCRIPT"
+          grep -Fq 'Set-Clipboard -Value $Secret' "$SCRIPT"
+          grep -Fq 'Do not paste the secret into chat, GitHub, logs or screenshots.' "$SCRIPT"
+          grep -Fq 'Remove-Variable Secret' "$SCRIPT"
+
+          if grep -Eq 'Write-(Host|Output|Information|Verbose|Debug).*\$Secret|echo .*\$Secret' "$SCRIPT"; then
+            echo 'The App Check helper must never print the credential.' >&2
+            exit 1
+          fi
+          if grep -Eq 'Set-Content|Out-File|Add-Content|Export-' "$SCRIPT"; then
+            echo 'The App Check helper must not persist the credential to disk.' >&2
+            exit 1
+          fi
+          if grep -Fq 'uninstall' "$SCRIPT"; then
+            echo 'The App Check helper must not mutate installed app state.' >&2
+            exit 1
+          fi
+          if grep -Fq '?.' "$SCRIPT" || grep -Fq '??' "$SCRIPT"; then
+            echo 'Keep the helper compatible with Windows PowerShell 5.1 syntax.' >&2
+            exit 1
+          fi

--- a/scripts/copy-appcheck-debug-secret.ps1
+++ b/scripts/copy-appcheck-debug-secret.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$Adb = Join-Path $env:LOCALAPPDATA "Android\Sdk\platform-tools\adb.exe"
+$PackageName = "com.aistudio.clickandsaveai.app"
+$ActivityName = "com.example.MainActivity"
+
+function Assert-LastExitCode([string]$Step) {
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Step failed with exit code $LASTEXITCODE"
+    }
+}
+
+if (-not (Test-Path $Adb)) {
+    throw "adb.exe was not found at $Adb"
+}
+
+$DeviceLines = @(& $Adb devices) | Where-Object { $_ -match "`tdevice$" }
+Assert-LastExitCode "adb devices"
+if ($DeviceLines.Count -ne 1) {
+    throw "Expected exactly one authorized Android device, found $($DeviceLines.Count)."
+}
+
+Write-Host "Starting the staging app and collecting App Check debug output locally..."
+& $Adb logcat -c
+Assert-LastExitCode "adb logcat -c"
+& $Adb shell am force-stop $PackageName
+Assert-LastExitCode "adb force-stop"
+& $Adb shell am start -n "$PackageName/$ActivityName" | Out-Null
+Assert-LastExitCode "adb start"
+Start-Sleep -Seconds 5
+
+$LogLines = @(& $Adb logcat -d)
+Assert-LastExitCode "adb logcat -d"
+
+$Candidates = New-Object System.Collections.Generic.HashSet[string]
+$UuidPattern = '\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b'
+foreach ($Line in $LogLines) {
+    if ($Line -notmatch '(?i)AppCheck|DebugAppCheckProvider') { continue }
+    foreach ($Match in [regex]::Matches($Line, $UuidPattern)) {
+        [void]$Candidates.Add($Match.Value)
+    }
+}
+
+if ($Candidates.Count -eq 0) {
+    throw "No App Check debug secret was found. Confirm this is the debug staging APK, then run the helper again."
+}
+if ($Candidates.Count -gt 1) {
+    throw "More than one App Check debug secret was found. Clear logcat and retry before registering anything."
+}
+
+$Secret = @($Candidates)[0]
+Set-Clipboard -Value $Secret
+
+# Never print the credential itself. This message is safe to paste into support/chat.
+Write-Host "PASS: one App Check debug secret was copied to the Windows clipboard." -ForegroundColor Green
+Write-Host "Paste it directly into Firebase Console -> App Check -> Android app -> Manage debug tokens."
+Write-Host "Do not paste the secret into chat, GitHub, logs or screenshots."
+
+Remove-Variable Secret -ErrorAction SilentlyContinue


### PR DESCRIPTION
Adds a local Windows helper for the one App Check step that must remain private to the device owner.

The helper:
- requires exactly one authorized Android device;
- starts the staging app with a clean log buffer;
- extracts UUID-shaped App Check debug secrets only from AppCheck/DebugAppCheckProvider lines;
- fails if zero or multiple candidates exist;
- copies the single secret directly to the Windows clipboard;
- never prints the secret and never writes it to disk;
- explicitly tells the owner to paste it only into Firebase Console App Check debug-token management.

Dedicated Ops CI parses the script and blocks printing/persisting the credential.

No application runtime code changes.