### PR TITLE
Queue Gmail one-time backfill and 4h History reconciliation v2

### DIFF
--- a/functions/src/entry.js
+++ b/functions/src/entry.js
@@ -4,6 +4,7 @@ const coreFunctions = require("./index");
 const pushFunctions = require("./pushFunctions");
 const gmailWatchFunctions = require("./gmailWatchFunctions");
 const gmailWatchRenewal = require("./gmailWatchRenewal");
+const gmailIncrementalReconciliation = require("./gmailIncrementalReconciliation");
 const financialAgentFunctions = require("./financialAgentFunctions");
 const opportunityNotificationFunctions = require("./opportunityNotificationFunctions");
 const opportunityActionFunctions = require("./opportunityActionFunctions");
@@ -13,6 +14,7 @@ const providerOfferCatalogFunctions = require("./providerOfferCatalogFunctions")
 const providerDispatchFunctions = require("./providerDispatchFunctions");
 const commerceFunnelFunctions = require("./commerceFunnelFunctions");
 const gmailScanV5Functions = require("./gmailScanV5Functions");
+const gmailReliableScanFunctions = require("./gmailReliableScanFunctions");
 const gmailSyncStatusFunctions = require("./gmailSyncStatusFunctions");
 const observedBillsFunctions = require("./observedBillsFunctions");
 
@@ -21,6 +23,9 @@ module.exports = {
   ...pushFunctions,
   ...gmailWatchFunctions,
   ...gmailWatchRenewal,
+  // Overrides only gmailPushNotification with the serialized/monotonic wrapper and
+  // adds the four-hour History reconciliation schedule.
+  ...gmailIncrementalReconciliation,
   ...financialAgentFunctions,
   ...opportunityNotificationFunctions,
   ...opportunityActionFunctions,
@@ -31,7 +36,8 @@ module.exports = {
   ...commerceFunnelFunctions,
   ...gmailSyncStatusFunctions,
   ...observedBillsFunctions,
-  // Intentionally last: preserves the public callable name while replacing only
-  // the legacy parser-v4 implementation. OAuth/connect/disconnect remain untouched.
+  // Keep the stable parser implementation available internally, then gate its public
+  // callable so six-month scanning can run only for first backfill/parser upgrades.
   ...gmailScanV5Functions,
+  ...gmailReliableScanFunctions,
 };

--- a/functions/src/gmailHistoryPolicy.js
+++ b/functions/src/gmailHistoryPolicy.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const { ACTIVE_GMAIL_PARSER_VERSION } = require("./gmailParserVersion");
+
+function normalizeHistoryId(value) {
+  const normalized = String(value || "").trim();
+  return /^\d+$/.test(normalized) ? normalized : "";
+}
+
+function compareHistoryIds(left, right) {
+  const a = normalizeHistoryId(left);
+  const b = normalizeHistoryId(right);
+  if (!a || !b) return null;
+  const aBig = BigInt(a);
+  const bBig = BigInt(b);
+  return aBig === bBig ? 0 : (aBig > bBig ? 1 : -1);
+}
+
+function selectMonotonicCheckpoint(currentValue, candidateValue) {
+  const current = normalizeHistoryId(currentValue);
+  const candidate = normalizeHistoryId(candidateValue);
+  if (!current) return candidate;
+  if (!candidate) return current;
+  return compareHistoryIds(current, candidate) >= 0 ? current : candidate;
+}
+
+function syncMode(connection, activeParserVersion = ACTIVE_GMAIL_PARSER_VERSION) {
+  const data = connection && typeof connection === "object" ? connection : {};
+  if (data.initialBackfillCompleted !== true) return "INITIAL_BACKFILL";
+  if (data.historyRecoveryRequired === true) return "RECOVERY_REQUIRED";
+  const storedParserVersion = Math.max(0, Number(data.parserVersion || 0));
+  if (storedParserVersion < activeParserVersion) return "PARSER_UPGRADE_BACKFILL";
+  return "INCREMENTAL";
+}
+
+module.exports = {
+  normalizeHistoryId,
+  compareHistoryIds,
+  selectMonotonicCheckpoint,
+  syncMode,
+};

--- a/functions/src/gmailIncrementalReconciliation.js
+++ b/functions/src/gmailIncrementalReconciliation.js
@@ -1,0 +1,192 @@
+"use strict";
+
+const { FieldValue, getFirestore } = require("firebase-admin/firestore");
+const { onSchedule } = require("firebase-functions/v2/scheduler");
+const { defineSecret, defineString } = require("firebase-functions/params");
+const logger = require("firebase-functions/logger");
+const { decryptToken } = require("./tokenCrypto");
+const { _processMailboxNotification: processMailboxNotification } = require("./gmailWatchFunctions");
+const { ACTIVE_GMAIL_PARSER_VERSION } = require("./gmailParserVersion");
+const {
+  compareHistoryIds,
+  normalizeHistoryId,
+  syncMode,
+} = require("./gmailHistoryPolicy");
+
+const db = getFirestore();
+const googleOAuthClientId = defineString("GOOGLE_OAUTH_CLIENT_ID");
+const googleOAuthClientSecret = defineSecret("GOOGLE_OAUTH_CLIENT_SECRET");
+const oauthTokenEncryptionKey = defineSecret("OAUTH_TOKEN_ENCRYPTION_KEY");
+const geminiApiKey = defineSecret("GEMINI_API_KEY");
+
+const MAX_CONNECTIONS_PER_SWEEP = 250;
+const MAX_CONCURRENCY = 5;
+
+async function refreshAccessToken(encryptedRefreshToken) {
+  const refreshToken = decryptToken(encryptedRefreshToken, oauthTokenEncryptionKey.value());
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: googleOAuthClientId.value(),
+      client_secret: googleOAuthClientSecret.value(),
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || !payload.access_token) {
+    throw new Error(`Google token refresh failed with ${response.status}`);
+  }
+  return String(payload.access_token);
+}
+
+async function getCurrentMailboxHistoryId(accessToken) {
+  const response = await fetch("https://gmail.googleapis.com/gmail/v1/users/me/profile", {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  const payload = await response.json().catch(() => ({}));
+  const historyId = normalizeHistoryId(payload.historyId);
+  if (!response.ok || !historyId) {
+    throw new Error(`Gmail users.getProfile failed with ${response.status}`);
+  }
+  return historyId;
+}
+
+async function reconcileConnection(doc) {
+  const data = doc.data() || {};
+  if (data.watchEnabled !== true || !data.encryptedRefreshToken) {
+    return { status: "SKIPPED_NOT_WATCHING" };
+  }
+
+  const mode = syncMode(data, ACTIVE_GMAIL_PARSER_VERSION);
+  if (mode === "INITIAL_BACKFILL") {
+    return { status: "SKIPPED_BACKFILL_INCOMPLETE" };
+  }
+  if (mode === "PARSER_UPGRADE_BACKFILL") {
+    return { status: "SKIPPED_PARSER_UPGRADE_REQUIRED" };
+  }
+  if (mode === "RECOVERY_REQUIRED") {
+    await doc.ref.set({
+      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return { status: "RECOVERY_PENDING" };
+  }
+
+  const startHistoryId = normalizeHistoryId(data.watchHistoryId);
+  if (!startHistoryId) {
+    await doc.ref.set({
+      historyRecoveryRequired: true,
+      historyRecoveryReason: "MISSING_HISTORY_BASELINE",
+      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return { status: "RECOVERY_REQUIRED" };
+  }
+
+  const accessToken = await refreshAccessToken(data.encryptedRefreshToken);
+  const currentHistoryId = await getCurrentMailboxHistoryId(accessToken);
+  const ordering = compareHistoryIds(currentHistoryId, startHistoryId);
+
+  if (ordering !== null && ordering <= 0) {
+    await doc.ref.set({
+      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+      lastReconciliationAt: FieldValue.serverTimestamp(),
+      lastReconciliationHistoryId: startHistoryId,
+      updatedAt: FieldValue.serverTimestamp(),
+    }, { merge: true });
+    return { status: "CURRENT" };
+  }
+
+  const result = await processMailboxNotification(doc, currentHistoryId);
+  await doc.ref.set({
+    lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
+    lastReconciliationAt: result?.status === "RECONCILED"
+      ? FieldValue.serverTimestamp()
+      : (data.lastReconciliationAt || FieldValue.delete()),
+    lastReconciliationHistoryId: result?.checkpoint || startHistoryId,
+    updatedAt: FieldValue.serverTimestamp(),
+  }, { merge: true });
+
+  if (result?.status === "RECOVERY_REQUIRED" || result?.status === "RECOVERY_PENDING") {
+    return { status: result.status };
+  }
+  return { status: "RECONCILED" };
+}
+
+async function runWithConcurrency(items, concurrency, worker) {
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      await worker(items[index]);
+    }
+  });
+  await Promise.all(workers);
+}
+
+exports.gmailIncrementalReconciliation = onSchedule(
+  {
+    schedule: "0 */4 * * *",
+    timeZone: "Asia/Jerusalem",
+    region: "europe-west1",
+    timeoutSeconds: 540,
+    memory: "1GiB",
+    secrets: [googleOAuthClientSecret, oauthTokenEncryptionKey, geminiApiKey],
+  },
+  async () => {
+    const snapshot = await db.collection("gmailConnections")
+      .where("watchEnabled", "==", true)
+      .limit(MAX_CONNECTIONS_PER_SWEEP)
+      .get();
+
+    const stats = {
+      candidates: snapshot.size,
+      reconciled: 0,
+      current: 0,
+      recoveryRequired: 0,
+      recoveryPending: 0,
+      skippedBackfillIncomplete: 0,
+      skippedParserUpgradeRequired: 0,
+      skippedNotWatching: 0,
+      failed: 0,
+    };
+
+    await runWithConcurrency(snapshot.docs, MAX_CONCURRENCY, async (doc) => {
+      try {
+        const result = await reconcileConnection(doc);
+        switch (result.status) {
+          case "RECONCILED": stats.reconciled += 1; break;
+          case "CURRENT": stats.current += 1; break;
+          case "RECOVERY_REQUIRED": stats.recoveryRequired += 1; break;
+          case "RECOVERY_PENDING": stats.recoveryPending += 1; break;
+          case "SKIPPED_BACKFILL_INCOMPLETE": stats.skippedBackfillIncomplete += 1; break;
+          case "SKIPPED_PARSER_UPGRADE_REQUIRED": stats.skippedParserUpgradeRequired += 1; break;
+          case "SKIPPED_NOT_WATCHING": stats.skippedNotWatching += 1; break;
+          default: break;
+        }
+      } catch (error) {
+        stats.failed += 1;
+        logger.error("Gmail incremental reconciliation failed", {
+          uid: doc.id,
+          errorName: error instanceof Error ? error.name : typeof error,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+
+    logger.info("Gmail incremental reconciliation completed", stats);
+    if (stats.failed > 0) {
+      throw new Error(`Failed to reconcile ${stats.failed} Gmail connection(s)`);
+    }
+  }
+);
+
+Object.defineProperties(module.exports, {
+  _reconcileConnection: { value: reconcileConnection, enumerable: false },
+  _getCurrentMailboxHistoryId: { value: getCurrentMailboxHistoryId, enumerable: false },
+});

--- a/functions/src/gmailIncrementalReconciliation.js
+++ b/functions/src/gmailIncrementalReconciliation.js
@@ -1,15 +1,18 @@
 "use strict";
 
+const crypto = require("node:crypto");
 const { FieldValue, getFirestore } = require("firebase-admin/firestore");
+const { onMessagePublished } = require("firebase-functions/v2/pubsub");
 const { onSchedule } = require("firebase-functions/v2/scheduler");
 const { defineSecret, defineString } = require("firebase-functions/params");
 const logger = require("firebase-functions/logger");
 const { decryptToken } = require("./tokenCrypto");
-const { _processMailboxNotification: processMailboxNotification } = require("./gmailWatchFunctions");
+const gmailWatchFunctions = require("./gmailWatchFunctions");
 const { ACTIVE_GMAIL_PARSER_VERSION } = require("./gmailParserVersion");
 const {
   compareHistoryIds,
   normalizeHistoryId,
+  selectMonotonicCheckpoint,
   syncMode,
 } = require("./gmailHistoryPolicy");
 
@@ -19,8 +22,38 @@ const googleOAuthClientSecret = defineSecret("GOOGLE_OAUTH_CLIENT_SECRET");
 const oauthTokenEncryptionKey = defineSecret("OAUTH_TOKEN_ENCRYPTION_KEY");
 const geminiApiKey = defineSecret("GEMINI_API_KEY");
 
+const GMAIL_PUBSUB_TOPIC = "gmail-notifications";
 const MAX_CONNECTIONS_PER_SWEEP = 250;
 const MAX_CONCURRENCY = 5;
+const LEASE_TTL_MS = 10 * 60 * 1000;
+
+function oldPushRunner() {
+  const handler = gmailWatchFunctions.gmailPushNotification;
+  const runner = typeof handler?.run === "function" ? handler.run.bind(handler) : handler;
+  if (typeof runner !== "function") {
+    throw new Error("Existing Gmail Pub/Sub handler is unavailable.");
+  }
+  return runner;
+}
+
+function decodePubSubPayload(event) {
+  const encoded = event?.data?.message?.data || "";
+  if (!encoded) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+    const emailAddress = String(payload.emailAddress || "").trim().toLowerCase();
+    const historyId = normalizeHistoryId(payload.historyId);
+    if (!emailAddress || !historyId) return null;
+    return { emailAddress, historyId };
+  } catch {
+    return null;
+  }
+}
+
+function syntheticPubSubEvent(emailAddress, historyId) {
+  const data = Buffer.from(JSON.stringify({ emailAddress, historyId }), "utf8").toString("base64");
+  return { data: { message: { data } } };
+}
 
 async function refreshAccessToken(encryptedRefreshToken) {
   const refreshToken = decryptToken(encryptedRefreshToken, oauthTokenEncryptionKey.value());
@@ -53,72 +86,272 @@ async function getCurrentMailboxHistoryId(accessToken) {
   return historyId;
 }
 
-async function reconcileConnection(doc) {
+async function historyCheckpointIsReadable(accessToken, startHistoryId) {
+  const params = new URLSearchParams({
+    startHistoryId: String(startHistoryId),
+    historyTypes: "messageAdded",
+    maxResults: "1",
+  });
+  const response = await fetch(
+    `https://gmail.googleapis.com/gmail/v1/users/me/history?${params.toString()}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } }
+  );
+  if (response.status === 404) return false;
+  if (!response.ok) {
+    throw new Error(`Gmail history.list preflight failed with ${response.status}`);
+  }
+  return true;
+}
+
+async function acquireMailboxLease(connectionDocs, targetHistoryId) {
+  const owner = crypto.randomUUID();
+  const nowMs = Date.now();
+  const leaseUntilMs = nowMs + LEASE_TTL_MS;
+
+  const result = await db.runTransaction(async (transaction) => {
+    const snapshots = [];
+    for (const doc of connectionDocs) {
+      snapshots.push(await transaction.get(doc.ref));
+    }
+
+    for (const snapshot of snapshots) {
+      const data = snapshot.data() || {};
+      const activeLeaseUntil = Number(data.incrementalLeaseUntilMs || 0);
+      const activeOwner = String(data.incrementalLeaseOwner || "");
+      if (activeLeaseUntil > nowMs && activeOwner && activeOwner !== owner) {
+        return { acquired: false, owner, states: [] };
+      }
+    }
+
+    const states = [];
+    for (const snapshot of snapshots) {
+      const data = snapshot.data() || {};
+      const pendingHistoryId = selectMonotonicCheckpoint(
+        data.pendingHistoryId,
+        targetHistoryId
+      );
+      transaction.set(snapshot.ref, {
+        incrementalLeaseOwner: owner,
+        incrementalLeaseUntilMs: leaseUntilMs,
+        pendingHistoryId,
+        updatedAt: FieldValue.serverTimestamp(),
+      }, { merge: true });
+      states.push({
+        ref: snapshot.ref,
+        data,
+        checkpoint: normalizeHistoryId(data.watchHistoryId),
+      });
+    }
+    return { acquired: true, owner, states };
+  });
+
+  return result;
+}
+
+async function releaseMailboxLease(states, owner) {
+  if (!states.length) return;
+  await db.runTransaction(async (transaction) => {
+    const snapshots = [];
+    for (const state of states) snapshots.push(await transaction.get(state.ref));
+    for (const snapshot of snapshots) {
+      const data = snapshot.data() || {};
+      if (String(data.incrementalLeaseOwner || "") !== owner) continue;
+      transaction.set(snapshot.ref, {
+        incrementalLeaseOwner: FieldValue.delete(),
+        incrementalLeaseUntilMs: FieldValue.delete(),
+        updatedAt: FieldValue.serverTimestamp(),
+      }, { merge: true });
+    }
+  });
+}
+
+async function markRecovery(state, owner, targetHistoryId, reason) {
+  await db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(state.ref);
+    const data = snapshot.data() || {};
+    if (String(data.incrementalLeaseOwner || "") !== owner) return;
+    const update = {
+      pendingHistoryId: selectMonotonicCheckpoint(data.pendingHistoryId, targetHistoryId),
+      historyRecoveryRequired: true,
+      historyRecoveryReason: reason,
+      historyRecoveryDetectedAt: FieldValue.serverTimestamp(),
+      incrementalLeaseOwner: FieldValue.delete(),
+      incrementalLeaseUntilMs: FieldValue.delete(),
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+    if (state.checkpoint) update.watchHistoryId = state.checkpoint;
+    transaction.set(state.ref, update, { merge: true });
+  });
+}
+
+async function finalizeMailboxLease(states, owner, targetHistoryId) {
+  let firstCheckpoint = "";
+  let recoveryRequired = false;
+
+  await db.runTransaction(async (transaction) => {
+    const snapshots = [];
+    for (const state of states) snapshots.push(await transaction.get(state.ref));
+
+    for (let index = 0; index < snapshots.length; index += 1) {
+      const snapshot = snapshots[index];
+      const state = states[index];
+      const data = snapshot.data() || {};
+      if (String(data.incrementalLeaseOwner || "") !== owner) continue;
+
+      const update = {
+        incrementalLeaseOwner: FieldValue.delete(),
+        incrementalLeaseUntilMs: FieldValue.delete(),
+        updatedAt: FieldValue.serverTimestamp(),
+      };
+
+      if (data.historyRecoveryRequired === true) {
+        recoveryRequired = true;
+        if (state.checkpoint) update.watchHistoryId = state.checkpoint;
+        update.pendingHistoryId = selectMonotonicCheckpoint(
+          data.pendingHistoryId,
+          targetHistoryId
+        );
+      } else {
+        const checkpoint = selectMonotonicCheckpoint(
+          selectMonotonicCheckpoint(state.checkpoint, data.watchHistoryId),
+          targetHistoryId
+        );
+        if (checkpoint) {
+          update.watchHistoryId = checkpoint;
+          if (!firstCheckpoint) firstCheckpoint = checkpoint;
+        }
+        const pending = normalizeHistoryId(data.pendingHistoryId);
+        const pendingOrdering = pending && checkpoint
+          ? compareHistoryIds(pending, checkpoint)
+          : null;
+        update.pendingHistoryId = pendingOrdering !== null && pendingOrdering > 0
+          ? pending
+          : FieldValue.delete();
+      }
+      transaction.set(snapshot.ref, update, { merge: true });
+    }
+  });
+
+  return {
+    status: recoveryRequired ? "RECOVERY_REQUIRED" : "RECONCILED",
+    checkpoint: firstCheckpoint || targetHistoryId,
+  };
+}
+
+async function processMailboxNotification(event) {
+  const payload = decodePubSubPayload(event);
+  if (!payload) return { status: "IGNORED" };
+
+  const matches = await db.collection("gmailConnections")
+    .where("email", "==", payload.emailAddress)
+    .limit(10)
+    .get();
+  if (matches.empty) return { status: "NO_CONNECTION" };
+
+  const lease = await acquireMailboxLease(matches.docs, payload.historyId);
+  if (!lease.acquired) {
+    throw new Error("Gmail mailbox reconciliation is already in progress.");
+  }
+
+  try {
+    let needsProcessing = false;
+    for (const state of lease.states) {
+      const data = state.data;
+      if (data.watchEnabled !== true || !data.encryptedRefreshToken) continue;
+
+      if (data.historyRecoveryRequired === true) {
+        await markRecovery(state, lease.owner, payload.historyId, String(
+          data.historyRecoveryReason || "RECOVERY_PENDING"
+        ));
+        return { status: "RECOVERY_PENDING", checkpoint: state.checkpoint };
+      }
+
+      if (!state.checkpoint) {
+        await markRecovery(state, lease.owner, payload.historyId, "MISSING_HISTORY_BASELINE");
+        return { status: "RECOVERY_REQUIRED", checkpoint: "" };
+      }
+
+      const ordering = compareHistoryIds(payload.historyId, state.checkpoint);
+      if (ordering !== null && ordering <= 0) continue;
+
+      const accessToken = await refreshAccessToken(data.encryptedRefreshToken);
+      const readable = await historyCheckpointIsReadable(accessToken, state.checkpoint);
+      if (!readable) {
+        await markRecovery(state, lease.owner, payload.historyId, "HISTORY_ID_EXPIRED");
+        logger.warn("Gmail History expired; checkpoint preserved for explicit recovery", {
+          uid: state.ref.id,
+        });
+        return { status: "RECOVERY_REQUIRED", checkpoint: state.checkpoint };
+      }
+      needsProcessing = true;
+    }
+
+    if (!needsProcessing) {
+      const finalized = await finalizeMailboxLease(lease.states, lease.owner, payload.historyId);
+      return { ...finalized, status: "CURRENT" };
+    }
+
+    await oldPushRunner()(event);
+    return await finalizeMailboxLease(lease.states, lease.owner, payload.historyId);
+  } catch (error) {
+    await releaseMailboxLease(lease.states, lease.owner).catch(() => undefined);
+    throw error;
+  }
+}
+
+exports.gmailPushNotification = onMessagePublished(
+  {
+    topic: GMAIL_PUBSUB_TOPIC,
+    region: "europe-west1",
+    retry: true,
+    timeoutSeconds: 540,
+    memory: "1GiB",
+    secrets: [googleOAuthClientSecret, oauthTokenEncryptionKey, geminiApiKey],
+  },
+  processMailboxNotification
+);
+
+async function reconcileOneConnection(doc) {
   const data = doc.data() || {};
   if (data.watchEnabled !== true || !data.encryptedRefreshToken) {
     return { status: "SKIPPED_NOT_WATCHING" };
   }
 
   const mode = syncMode(data, ACTIVE_GMAIL_PARSER_VERSION);
-  if (mode === "INITIAL_BACKFILL") {
-    return { status: "SKIPPED_BACKFILL_INCOMPLETE" };
-  }
-  if (mode === "PARSER_UPGRADE_BACKFILL") {
-    return { status: "SKIPPED_PARSER_UPGRADE_REQUIRED" };
-  }
-  if (mode === "RECOVERY_REQUIRED") {
-    await doc.ref.set({
-      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
-      updatedAt: FieldValue.serverTimestamp(),
-    }, { merge: true });
-    return { status: "RECOVERY_PENDING" };
-  }
-
-  const startHistoryId = normalizeHistoryId(data.watchHistoryId);
-  if (!startHistoryId) {
-    await doc.ref.set({
-      historyRecoveryRequired: true,
-      historyRecoveryReason: "MISSING_HISTORY_BASELINE",
-      lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
-      updatedAt: FieldValue.serverTimestamp(),
-    }, { merge: true });
-    return { status: "RECOVERY_REQUIRED" };
-  }
+  if (mode === "INITIAL_BACKFILL") return { status: "SKIPPED_BACKFILL_INCOMPLETE" };
+  if (mode === "PARSER_UPGRADE_BACKFILL") return { status: "SKIPPED_PARSER_UPGRADE_REQUIRED" };
+  if (mode === "RECOVERY_REQUIRED") return { status: "RECOVERY_PENDING" };
 
   const accessToken = await refreshAccessToken(data.encryptedRefreshToken);
   const currentHistoryId = await getCurrentMailboxHistoryId(accessToken);
-  const ordering = compareHistoryIds(currentHistoryId, startHistoryId);
-
-  if (ordering !== null && ordering <= 0) {
+  const checkpoint = normalizeHistoryId(data.watchHistoryId);
+  if (checkpoint && compareHistoryIds(currentHistoryId, checkpoint) <= 0) {
     await doc.ref.set({
       lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
       lastReconciliationAt: FieldValue.serverTimestamp(),
-      lastReconciliationHistoryId: startHistoryId,
+      lastReconciliationHistoryId: checkpoint,
       updatedAt: FieldValue.serverTimestamp(),
     }, { merge: true });
     return { status: "CURRENT" };
   }
 
-  const result = await processMailboxNotification(doc, currentHistoryId);
+  const result = await processMailboxNotification(
+    syntheticPubSubEvent(String(data.email || "").trim().toLowerCase(), currentHistoryId)
+  );
   await doc.ref.set({
     lastReconciliationAttemptAt: FieldValue.serverTimestamp(),
-    lastReconciliationAt: result?.status === "RECONCILED"
+    lastReconciliationAt: result.status === "RECONCILED" || result.status === "CURRENT"
       ? FieldValue.serverTimestamp()
       : (data.lastReconciliationAt || FieldValue.delete()),
-    lastReconciliationHistoryId: result?.checkpoint || startHistoryId,
+    lastReconciliationHistoryId: result.checkpoint || checkpoint || "",
     updatedAt: FieldValue.serverTimestamp(),
   }, { merge: true });
-
-  if (result?.status === "RECOVERY_REQUIRED" || result?.status === "RECOVERY_PENDING") {
-    return { status: result.status };
-  }
-  return { status: "RECONCILED" };
+  return result;
 }
 
 async function runWithConcurrency(items, concurrency, worker) {
   let nextIndex = 0;
-  const workerCount = Math.min(concurrency, items.length);
-  const workers = Array.from({ length: workerCount }, async () => {
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
     while (true) {
       const index = nextIndex;
       nextIndex += 1;
@@ -144,31 +377,21 @@ exports.gmailIncrementalReconciliation = onSchedule(
       .limit(MAX_CONNECTIONS_PER_SWEEP)
       .get();
 
-    const stats = {
-      candidates: snapshot.size,
-      reconciled: 0,
-      current: 0,
-      recoveryRequired: 0,
-      recoveryPending: 0,
-      skippedBackfillIncomplete: 0,
-      skippedParserUpgradeRequired: 0,
-      skippedNotWatching: 0,
-      failed: 0,
-    };
+    const seenEmails = new Set();
+    const candidates = snapshot.docs.filter((doc) => {
+      const email = String(doc.data()?.email || "").trim().toLowerCase();
+      if (!email || seenEmails.has(email)) return false;
+      seenEmails.add(email);
+      return true;
+    });
 
-    await runWithConcurrency(snapshot.docs, MAX_CONCURRENCY, async (doc) => {
+    const stats = { candidates: candidates.length, reconciled: 0, current: 0, skipped: 0, failed: 0 };
+    await runWithConcurrency(candidates, MAX_CONCURRENCY, async (doc) => {
       try {
-        const result = await reconcileConnection(doc);
-        switch (result.status) {
-          case "RECONCILED": stats.reconciled += 1; break;
-          case "CURRENT": stats.current += 1; break;
-          case "RECOVERY_REQUIRED": stats.recoveryRequired += 1; break;
-          case "RECOVERY_PENDING": stats.recoveryPending += 1; break;
-          case "SKIPPED_BACKFILL_INCOMPLETE": stats.skippedBackfillIncomplete += 1; break;
-          case "SKIPPED_PARSER_UPGRADE_REQUIRED": stats.skippedParserUpgradeRequired += 1; break;
-          case "SKIPPED_NOT_WATCHING": stats.skippedNotWatching += 1; break;
-          default: break;
-        }
+        const result = await reconcileOneConnection(doc);
+        if (result.status === "RECONCILED") stats.reconciled += 1;
+        else if (result.status === "CURRENT") stats.current += 1;
+        else stats.skipped += 1;
       } catch (error) {
         stats.failed += 1;
         logger.error("Gmail incremental reconciliation failed", {
@@ -180,13 +403,14 @@ exports.gmailIncrementalReconciliation = onSchedule(
     });
 
     logger.info("Gmail incremental reconciliation completed", stats);
-    if (stats.failed > 0) {
-      throw new Error(`Failed to reconcile ${stats.failed} Gmail connection(s)`);
-    }
+    if (stats.failed > 0) throw new Error(`Failed to reconcile ${stats.failed} Gmail mailbox(es)`);
   }
 );
 
 Object.defineProperties(module.exports, {
-  _reconcileConnection: { value: reconcileConnection, enumerable: false },
+  _processMailboxNotification: { value: processMailboxNotification, enumerable: false },
+  _reconcileOneConnection: { value: reconcileOneConnection, enumerable: false },
   _getCurrentMailboxHistoryId: { value: getCurrentMailboxHistoryId, enumerable: false },
+  _historyCheckpointIsReadable: { value: historyCheckpointIsReadable, enumerable: false },
+  _syntheticPubSubEvent: { value: syntheticPubSubEvent, enumerable: false },
 });

--- a/functions/src/gmailIncrementalReconciliation.js
+++ b/functions/src/gmailIncrementalReconciliation.js
@@ -248,7 +248,13 @@ async function processMailboxNotification(event) {
     .get();
   if (matches.empty) return { status: "NO_CONNECTION" };
 
-  const lease = await acquireMailboxLease(matches.docs, payload.historyId);
+  const activeDocs = matches.docs.filter((doc) => {
+    const data = doc.data() || {};
+    return data.watchEnabled === true && Boolean(data.encryptedRefreshToken);
+  });
+  if (activeDocs.length === 0) return { status: "NO_ACTIVE_CONNECTION" };
+
+  const lease = await acquireMailboxLease(activeDocs, payload.historyId);
   if (!lease.acquired) {
     throw new Error("Gmail mailbox reconciliation is already in progress.");
   }
@@ -257,17 +263,24 @@ async function processMailboxNotification(event) {
     let needsProcessing = false;
     for (const state of lease.states) {
       const data = state.data;
-      if (data.watchEnabled !== true || !data.encryptedRefreshToken) continue;
+      const mode = syncMode(data, ACTIVE_GMAIL_PARSER_VERSION);
+
+      if (mode === "INITIAL_BACKFILL" || mode === "PARSER_UPGRADE_BACKFILL") {
+        await releaseMailboxLease(lease.states, lease.owner);
+        return { status: "BACKFILL_PENDING", checkpoint: state.checkpoint };
+      }
 
       if (data.historyRecoveryRequired === true) {
         await markRecovery(state, lease.owner, payload.historyId, String(
           data.historyRecoveryReason || "RECOVERY_PENDING"
         ));
+        await releaseMailboxLease(lease.states, lease.owner);
         return { status: "RECOVERY_PENDING", checkpoint: state.checkpoint };
       }
 
       if (!state.checkpoint) {
         await markRecovery(state, lease.owner, payload.historyId, "MISSING_HISTORY_BASELINE");
+        await releaseMailboxLease(lease.states, lease.owner);
         return { status: "RECOVERY_REQUIRED", checkpoint: "" };
       }
 
@@ -278,6 +291,7 @@ async function processMailboxNotification(event) {
       const readable = await historyCheckpointIsReadable(accessToken, state.checkpoint);
       if (!readable) {
         await markRecovery(state, lease.owner, payload.historyId, "HISTORY_ID_EXPIRED");
+        await releaseMailboxLease(lease.states, lease.owner);
         logger.warn("Gmail History expired; checkpoint preserved for explicit recovery", {
           uid: state.ref.id,
         });
@@ -322,6 +336,9 @@ async function reconcileOneConnection(doc) {
   if (mode === "PARSER_UPGRADE_BACKFILL") return { status: "SKIPPED_PARSER_UPGRADE_REQUIRED" };
   if (mode === "RECOVERY_REQUIRED") return { status: "RECOVERY_PENDING" };
 
+  const email = String(data.email || "").trim().toLowerCase();
+  if (!email) return { status: "SKIPPED_MISSING_EMAIL" };
+
   const accessToken = await refreshAccessToken(data.encryptedRefreshToken);
   const currentHistoryId = await getCurrentMailboxHistoryId(accessToken);
   const checkpoint = normalizeHistoryId(data.watchHistoryId);
@@ -336,7 +353,7 @@ async function reconcileOneConnection(doc) {
   }
 
   const result = await processMailboxNotification(
-    syntheticPubSubEvent(String(data.email || "").trim().toLowerCase(), currentHistoryId)
+    syntheticPubSubEvent(email, currentHistoryId)
   );
   await doc.ref.set({
     lastReconciliationAttemptAt: FieldValue.serverTimestamp(),

--- a/functions/src/gmailReliableScanFunctions.js
+++ b/functions/src/gmailReliableScanFunctions.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const { FieldValue, getFirestore } = require("firebase-admin/firestore");
+const { HttpsError, onCall } = require("firebase-functions/v2/https");
+const { defineSecret } = require("firebase-functions/params");
+const stableScan = require("./gmailScanV5Functions");
+const { ACTIVE_GMAIL_PARSER_VERSION } = require("./gmailParserVersion");
+const { normalizeHistoryId, syncMode } = require("./gmailHistoryPolicy");
+
+const db = getFirestore();
+const googleOAuthClientSecret = defineSecret("GOOGLE_OAUTH_CLIENT_SECRET");
+const oauthTokenEncryptionKey = defineSecret("OAUTH_TOKEN_ENCRYPTION_KEY");
+const geminiApiKey = defineSecret("GEMINI_API_KEY");
+
+function requireAuth(request) {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError("unauthenticated", "Firebase Authentication is required.");
+  return uid;
+}
+
+function stableScanRunner() {
+  const handler = stableScan.scanGmailInvoices;
+  const runner = typeof handler?.run === "function" ? handler.run.bind(handler) : handler;
+  if (typeof runner !== "function") {
+    throw new Error("Stable Gmail scan handler is unavailable.");
+  }
+  return runner;
+}
+
+function incrementalNoScanResult(mode, connection) {
+  return {
+    invoices: [],
+    scannedMessages: 0,
+    importedCount: 0,
+    removedSourceMessageIds: [],
+    scannedPages: 0,
+    lookback: "incremental",
+    parserVersion: ACTIVE_GMAIL_PARSER_VERSION,
+    upgradedMessages: 0,
+    agentRefreshed: false,
+    initialBackfillCompleted: connection.initialBackfillCompleted === true,
+    historyRecoveryRequired: connection.historyRecoveryRequired === true,
+    syncMode: mode,
+  };
+}
+
+exports.scanGmailInvoices = onCall(
+  {
+    enforceAppCheck: true,
+    secrets: [googleOAuthClientSecret, oauthTokenEncryptionKey, geminiApiKey],
+    timeoutSeconds: 540,
+    memory: "1GiB",
+  },
+  async (request) => {
+    const uid = requireAuth(request);
+    const connectionRef = db.collection("gmailConnections").doc(uid);
+    const beforeSnapshot = await connectionRef.get();
+    if (!beforeSnapshot.exists) {
+      throw new HttpsError("failed-precondition", "Gmail is not connected.");
+    }
+    const before = beforeSnapshot.data() || {};
+    const mode = syncMode(before, ACTIVE_GMAIL_PARSER_VERSION);
+
+    if (mode === "INCREMENTAL" || mode === "RECOVERY_REQUIRED") {
+      return incrementalNoScanResult(mode, before);
+    }
+
+    const result = await stableScanRunner()(request);
+    const afterSnapshot = await connectionRef.get();
+    const after = afterSnapshot.data() || before;
+    const checkpoint = normalizeHistoryId(after.watchHistoryId || before.watchHistoryId);
+
+    const update = {
+      parserVersion: ACTIVE_GMAIL_PARSER_VERSION,
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+
+    if (mode === "INITIAL_BACKFILL") {
+      update.initialBackfillCompleted = true;
+      update.initialBackfillCompletedAt = FieldValue.serverTimestamp();
+      if (checkpoint) {
+        update.initialBackfillHistoryBaseline = checkpoint;
+        update.historyRecoveryRequired = false;
+        update.historyRecoveryReason = FieldValue.delete();
+      } else {
+        update.historyRecoveryRequired = true;
+        update.historyRecoveryReason = "MISSING_HISTORY_BASELINE";
+      }
+    }
+
+    await connectionRef.set(update, { merge: true });
+
+    return {
+      ...result,
+      initialBackfillCompleted: mode === "INITIAL_BACKFILL"
+        ? true
+        : before.initialBackfillCompleted === true,
+      historyRecoveryRequired: mode === "INITIAL_BACKFILL" && !checkpoint,
+      syncMode: mode,
+    };
+  }
+);
+
+Object.defineProperties(module.exports, {
+  _incrementalNoScanResult: { value: incrementalNoScanResult, enumerable: false },
+  _stableScanRunner: { value: stableScanRunner, enumerable: false },
+});

--- a/functions/src/gmailSyncStatusFunctions.js
+++ b/functions/src/gmailSyncStatusFunctions.js
@@ -3,6 +3,7 @@
 const { getFirestore } = require("firebase-admin/firestore");
 const { HttpsError, onCall } = require("firebase-functions/v2/https");
 const { ACTIVE_GMAIL_PARSER_VERSION } = require("./gmailParserVersion");
+const { normalizeHistoryId, syncMode } = require("./gmailHistoryPolicy");
 
 const db = getFirestore();
 const GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
@@ -20,12 +21,26 @@ function buildGmailSyncStatus(connection) {
     data.scopes.includes(GMAIL_READONLY_SCOPE) &&
     Boolean(data.encryptedRefreshToken);
   const storedParserVersion = Math.max(0, Number(data.parserVersion || 0));
+  const mode = connected ? syncMode(data, ACTIVE_GMAIL_PARSER_VERSION) : "DISCONNECTED";
+
   return {
     connected,
     storedParserVersion,
     activeParserVersion: ACTIVE_GMAIL_PARSER_VERSION,
     upgradeRequired: connected && storedParserVersion < ACTIVE_GMAIL_PARSER_VERSION,
     lookback: INITIAL_GMAIL_LOOKBACK,
+    initialBackfillCompleted: data.initialBackfillCompleted === true,
+    initialBackfillCompletedAt: data.initialBackfillCompletedAt || null,
+    initialBackfillHistoryBaseline: normalizeHistoryId(data.initialBackfillHistoryBaseline),
+    incrementalCheckpointHistoryId: normalizeHistoryId(data.watchHistoryId),
+    pendingHistoryId: normalizeHistoryId(data.pendingHistoryId),
+    historyRecoveryRequired: data.historyRecoveryRequired === true,
+    historyRecoveryReason: data.historyRecoveryRequired === true
+      ? String(data.historyRecoveryReason || "RECOVERY_REQUIRED").slice(0, 80)
+      : "",
+    lastIncrementalScanAt: data.lastIncrementalScanAt || null,
+    lastReconciliationAt: data.lastReconciliationAt || null,
+    syncMode: mode,
   };
 }
 

--- a/functions/src/gmailSyncStatusFunctions.js
+++ b/functions/src/gmailSyncStatusFunctions.js
@@ -22,14 +22,19 @@ function buildGmailSyncStatus(connection) {
     Boolean(data.encryptedRefreshToken);
   const storedParserVersion = Math.max(0, Number(data.parserVersion || 0));
   const mode = connected ? syncMode(data, ACTIVE_GMAIL_PARSER_VERSION) : "DISCONNECTED";
+  const initialBackfillCompleted = data.initialBackfillCompleted === true;
 
   return {
     connected,
     storedParserVersion,
     activeParserVersion: ACTIVE_GMAIL_PARSER_VERSION,
-    upgradeRequired: connected && storedParserVersion < ACTIVE_GMAIL_PARSER_VERSION,
+    // The Android client already uses this flag as its one-time scan gate. Keep legacy
+    // parser-v6 connections without the new completion marker on the migration path once.
+    upgradeRequired: connected && (
+      storedParserVersion < ACTIVE_GMAIL_PARSER_VERSION || !initialBackfillCompleted
+    ),
     lookback: INITIAL_GMAIL_LOOKBACK,
-    initialBackfillCompleted: data.initialBackfillCompleted === true,
+    initialBackfillCompleted,
     initialBackfillCompletedAt: data.initialBackfillCompletedAt || null,
     initialBackfillHistoryBaseline: normalizeHistoryId(data.initialBackfillHistoryBaseline),
     incrementalCheckpointHistoryId: normalizeHistoryId(data.watchHistoryId),

--- a/functions/test/gmailIncrementalReliabilityV2.test.js
+++ b/functions/test/gmailIncrementalReliabilityV2.test.js
@@ -54,6 +54,15 @@ test("public incremental processing is serialized and finalizes checkpoints tran
   assert.match(reconciliationSource, /data\.historyRecoveryRequired === true/);
 });
 
+test("PubSub does not race the first or parser-upgrade backfill and recovery releases mailbox leases", () => {
+  assert.match(reconciliationSource, /mode === "INITIAL_BACKFILL" \|\| mode === "PARSER_UPGRADE_BACKFILL"/);
+  assert.match(reconciliationSource, /status:\s*"BACKFILL_PENDING"/);
+  const recoveryBranch = reconciliationSource
+    .split("if (!readable) {")[1]
+    ?.split("return { status: \"RECOVERY_REQUIRED\"")[0] || "";
+  assert.match(recoveryBranch, /releaseMailboxLease\(lease\.states, lease\.owner\)/);
+});
+
 test("public scan persists first-backfill completion and refuses normal six-month rescans", () => {
   assert.match(reliableScanSource, /initialBackfillCompleted/);
   assert.match(reliableScanSource, /initialBackfillCompletedAt/);

--- a/functions/test/gmailIncrementalReliabilityV2.test.js
+++ b/functions/test/gmailIncrementalReliabilityV2.test.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const policy = require("../src/gmailHistoryPolicy");
+
+const watchSource = fs.readFileSync(
+  path.join(__dirname, "..", "src", "gmailWatchFunctions.js"),
+  "utf8"
+);
+const scanSource = fs.readFileSync(
+  path.join(__dirname, "..", "src", "gmailScanV5Functions.js"),
+  "utf8"
+);
+const reconciliationSource = fs.readFileSync(
+  path.join(__dirname, "..", "src", "gmailIncrementalReconciliation.js"),
+  "utf8"
+);
+
+test("Gmail sync mode permits the six-month scan only for initial or parser-upgrade backfill", () => {
+  assert.equal(policy.syncMode({}, 6), "INITIAL_BACKFILL");
+  assert.equal(policy.syncMode({ initialBackfillCompleted: true, parserVersion: 5 }, 6), "PARSER_UPGRADE_BACKFILL");
+  assert.equal(policy.syncMode({ initialBackfillCompleted: true, parserVersion: 6 }, 6), "INCREMENTAL");
+  assert.equal(policy.syncMode({
+    initialBackfillCompleted: true,
+    parserVersion: 6,
+    historyRecoveryRequired: true,
+  }, 6), "RECOVERY_REQUIRED");
+});
+
+test("history checkpoint selection is monotonic and never regresses", () => {
+  assert.equal(policy.selectMonotonicCheckpoint("100", "105"), "105");
+  assert.equal(policy.selectMonotonicCheckpoint("105", "100"), "105");
+  assert.equal(policy.selectMonotonicCheckpoint("105", "105"), "105");
+  assert.equal(policy.selectMonotonicCheckpoint("", "105"), "105");
+});
+
+test("expired Gmail History enters recovery without advancing watchHistoryId", () => {
+  const expiredBlock = watchSource
+    .split("if (history.expired) {")[1]
+    ?.split("return")[0] || "";
+
+  assert.match(expiredBlock, /pendingHistoryId:\s*notificationHistoryId/);
+  assert.match(expiredBlock, /historyRecoveryRequired:\s*true/);
+  assert.match(expiredBlock, /historyRecoveryReason:\s*"HISTORY_ID_EXPIRED"/);
+  assert.doesNotMatch(expiredBlock, /watchHistoryId\s*:/);
+});
+
+test("successful incremental processing advances checkpoint through a Firestore transaction", () => {
+  assert.match(watchSource, /db\.runTransaction/);
+  assert.match(watchSource, /selectMonotonicCheckpoint/);
+  assert.match(watchSource, /historyRecoveryRequired === true/);
+});
+
+test("initial backfill completion and history baseline are persisted by the scan itself", () => {
+  assert.match(scanSource, /initialBackfillCompleted/);
+  assert.match(scanSource, /initialBackfillCompletedAt/);
+  assert.match(scanSource, /initialBackfillHistoryBaseline/);
+  assert.match(scanSource, /syncMode\(/);
+  assert.match(scanSource, /INCREMENTAL/);
+  assert.match(scanSource, /RECOVERY_REQUIRED/);
+});
+
+test("four-hour safety reconciliation uses Gmail History only and never launches a six-month scan", () => {
+  assert.match(reconciliationSource, /schedule:\s*"0 \*\/4 \* \* \*"/);
+  assert.match(reconciliationSource, /users\/me\/profile/);
+  assert.match(reconciliationSource, /_processMailboxNotification/);
+  assert.doesNotMatch(reconciliationSource, /newer_than:/);
+  assert.doesNotMatch(reconciliationSource, /scanGmailInvoices/);
+});

--- a/functions/test/gmailIncrementalReliabilityV2.test.js
+++ b/functions/test/gmailIncrementalReliabilityV2.test.js
@@ -7,14 +7,11 @@ const assert = require("node:assert/strict");
 
 const policy = require("../src/gmailHistoryPolicy");
 const entry = require("../src/entry");
+const reconciliation = require("../src/gmailIncrementalReconciliation");
 const syncStatus = require("../src/gmailSyncStatusFunctions");
 
-const watchSource = fs.readFileSync(
-  path.join(__dirname, "..", "src", "gmailWatchFunctions.js"),
-  "utf8"
-);
-const scanSource = fs.readFileSync(
-  path.join(__dirname, "..", "src", "gmailScanV5Functions.js"),
+const reliableScanSource = fs.readFileSync(
+  path.join(__dirname, "..", "src", "gmailReliableScanFunctions.js"),
   "utf8"
 );
 const reconciliationSource = fs.readFileSync(
@@ -40,30 +37,31 @@ test("history checkpoint selection is monotonic and never regresses", () => {
   assert.equal(policy.selectMonotonicCheckpoint("", "105"), "105");
 });
 
-test("expired Gmail History enters recovery without advancing watchHistoryId", () => {
-  const expiredBlock = watchSource
-    .split("if (history.expired) {")[1]
-    ?.split("return")[0] || "";
-
-  assert.match(expiredBlock, /pendingHistoryId:\s*notificationHistoryId/);
-  assert.match(expiredBlock, /historyRecoveryRequired:\s*true/);
-  assert.match(expiredBlock, /historyRecoveryReason:\s*"HISTORY_ID_EXPIRED"/);
-  assert.doesNotMatch(expiredBlock, /watchHistoryId\s*:/);
+test("expired Gmail History enters recovery while preserving the last processed checkpoint", () => {
+  assert.match(reconciliationSource, /response\.status === 404\) return false/);
+  assert.match(reconciliationSource, /historyRecoveryRequired:\s*true/);
+  assert.match(reconciliationSource, /historyRecoveryReason:\s*reason/);
+  assert.match(reconciliationSource, /pendingHistoryId:\s*selectMonotonicCheckpoint\(data\.pendingHistoryId, targetHistoryId\)/);
+  assert.match(reconciliationSource, /if \(state\.checkpoint\) update\.watchHistoryId = state\.checkpoint/);
+  assert.doesNotMatch(reconciliationSource, /update\.watchHistoryId = targetHistoryId/);
 });
 
-test("successful incremental processing advances checkpoint through a Firestore transaction", () => {
-  assert.match(watchSource, /db\.runTransaction/);
-  assert.match(watchSource, /selectMonotonicCheckpoint/);
-  assert.match(watchSource, /historyRecoveryRequired === true/);
+test("public incremental processing is serialized and finalizes checkpoints transactionally", () => {
+  assert.equal(entry.gmailPushNotification, reconciliation.gmailPushNotification);
+  assert.match(reconciliationSource, /incrementalLeaseOwner/);
+  assert.match(reconciliationSource, /db\.runTransaction/);
+  assert.match(reconciliationSource, /selectMonotonicCheckpoint/);
+  assert.match(reconciliationSource, /data\.historyRecoveryRequired === true/);
 });
 
-test("initial backfill completion and history baseline are persisted by the scan itself", () => {
-  assert.match(scanSource, /initialBackfillCompleted/);
-  assert.match(scanSource, /initialBackfillCompletedAt/);
-  assert.match(scanSource, /initialBackfillHistoryBaseline/);
-  assert.match(scanSource, /syncMode\(/);
-  assert.match(scanSource, /INCREMENTAL/);
-  assert.match(scanSource, /RECOVERY_REQUIRED/);
+test("public scan persists first-backfill completion and refuses normal six-month rescans", () => {
+  assert.match(reliableScanSource, /initialBackfillCompleted/);
+  assert.match(reliableScanSource, /initialBackfillCompletedAt/);
+  assert.match(reliableScanSource, /initialBackfillHistoryBaseline/);
+  assert.match(reliableScanSource, /syncMode\(/);
+  assert.match(reliableScanSource, /mode === "INCREMENTAL"/);
+  assert.match(reliableScanSource, /mode === "RECOVERY_REQUIRED"/);
+  assert.match(reliableScanSource, /stableScanRunner\(\)\(request\)/);
 });
 
 test("four-hour safety reconciliation uses Gmail History only and never launches a six-month scan", () => {

--- a/functions/test/gmailIncrementalReliabilityV2.test.js
+++ b/functions/test/gmailIncrementalReliabilityV2.test.js
@@ -6,6 +6,8 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const policy = require("../src/gmailHistoryPolicy");
+const entry = require("../src/entry");
+const syncStatus = require("../src/gmailSyncStatusFunctions");
 
 const watchSource = fs.readFileSync(
   path.join(__dirname, "..", "src", "gmailWatchFunctions.js"),
@@ -65,9 +67,31 @@ test("initial backfill completion and history baseline are persisted by the scan
 });
 
 test("four-hour safety reconciliation uses Gmail History only and never launches a six-month scan", () => {
+  assert.equal(typeof entry.gmailIncrementalReconciliation, "function");
   assert.match(reconciliationSource, /schedule:\s*"0 \*\/4 \* \* \*"/);
   assert.match(reconciliationSource, /users\/me\/profile/);
   assert.match(reconciliationSource, /_processMailboxNotification/);
   assert.doesNotMatch(reconciliationSource, /newer_than:/);
   assert.doesNotMatch(reconciliationSource, /scanGmailInvoices/);
+});
+
+test("Gmail sync status exposes backfill and incremental checkpoint health without mailbox content", () => {
+  const lastIncrementalScanAt = { seconds: 123, nanoseconds: 0 };
+  const result = syncStatus._buildGmailSyncStatus({
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+    encryptedRefreshToken: "encrypted",
+    parserVersion: 6,
+    initialBackfillCompleted: true,
+    watchHistoryId: "100",
+    pendingHistoryId: "101",
+    historyRecoveryRequired: false,
+    lastIncrementalScanAt,
+  });
+
+  assert.equal(result.initialBackfillCompleted, true);
+  assert.equal(result.incrementalCheckpointHistoryId, "100");
+  assert.equal(result.pendingHistoryId, "101");
+  assert.equal(result.historyRecoveryRequired, false);
+  assert.equal(result.lastIncrementalScanAt, lastIncrementalScanAt);
+  assert.equal(result.syncMode, "INCREMENTAL");
 });

--- a/functions/test/gmailScanV5Functions.test.js
+++ b/functions/test/gmailScanV5Functions.test.js
@@ -4,15 +4,17 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 // entry.js loads the production bootstrap first; index.js initializes the default
-// Firebase Admin app. Requiring the stable scan module afterwards avoids creating
-// a second default app with a different test-only configuration.
+// Firebase Admin app. The stable parser remains testable directly, while the public
+// callable is now wrapped by the one-time-backfill reliability gate.
 const entry = require("../src/entry");
 const scan = require("../src/gmailScanV5Functions");
+const reliableScan = require("../src/gmailReliableScanFunctions");
 
-test("public scanGmailInvoices export stays on the stable scan module with active revision 6", () => {
+test("stable Gmail parser stays on active revision 6 behind the reliable public scan gate", () => {
   assert.equal(scan.GMAIL_PARSER_VERSION_ACTIVE, 6);
   assert.equal(scan.GMAIL_PARSER_VERSION_V5, 6);
-  assert.equal(entry.scanGmailInvoices, scan.scanGmailInvoices);
+  assert.equal(entry.scanGmailInvoices, reliableScan.scanGmailInvoices);
+  assert.notEqual(entry.scanGmailInvoices, scan.scanGmailInvoices);
 });
 
 test("stored invoice normalization preserves an explicit canonical service type", () => {

--- a/functions/test/gmailSyncStatusFunctions.test.js
+++ b/functions/test/gmailSyncStatusFunctions.test.js
@@ -11,6 +11,7 @@ test("Gmail sync status requires one-time upgrade below active parser revision",
     scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
     encryptedRefreshToken: "encrypted",
     parserVersion: 5,
+    initialBackfillCompleted: true,
   });
 
   assert.equal(result.connected, true);
@@ -20,14 +21,28 @@ test("Gmail sync status requires one-time upgrade below active parser revision",
   assert.equal(result.lookback, "6m");
 });
 
-test("Gmail sync status is current after revision 6 backfill", () => {
+test("legacy parser-6 connection without explicit backfill marker requests one migration backfill", () => {
   const result = status._buildGmailSyncStatus({
     scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
     encryptedRefreshToken: "encrypted",
     parserVersion: 6,
   });
 
+  assert.equal(result.initialBackfillCompleted, false);
+  assert.equal(result.syncMode, "INITIAL_BACKFILL");
+  assert.equal(result.upgradeRequired, true);
+});
+
+test("Gmail sync status is current after revision 6 backfill is explicitly complete", () => {
+  const result = status._buildGmailSyncStatus({
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"],
+    encryptedRefreshToken: "encrypted",
+    parserVersion: 6,
+    initialBackfillCompleted: true,
+  });
+
   assert.equal(result.upgradeRequired, false);
+  assert.equal(result.syncMode, "INCREMENTAL");
   assert.equal(entry.getGmailSyncStatus, status.getGmailSyncStatus);
 });
 
@@ -35,4 +50,5 @@ test("disconnected account never requests parser backfill", () => {
   const result = status._buildGmailSyncStatus({ parserVersion: 0 });
   assert.equal(result.connected, false);
   assert.equal(result.upgradeRequired, false);
+  assert.equal(result.syncMode, "DISCONNECTED");
 });


### PR DESCRIPTION
Queued Gmail reliability v2 on top of the current green queued stack. **DO NOT MERGE to Core before staging E2E correction cycle #2.**

## What this implements
- explicit Gmail sync modes: `INITIAL_BACKFILL`, `PARSER_UPGRADE_BACKFILL`, `INCREMENTAL`, `RECOVERY_REQUIRED`;
- six-month Gmail scan remains the existing stable parser/PDF engine but is exposed publicly only for first backfill or parser-version upgrade;
- first successful backfill persists `initialBackfillCompleted`, completion timestamp and History baseline;
- legacy parser-v6 connections without the new completion marker take one migration backfill;
- normal Gmail processing remains Watch + Pub/Sub + Gmail History;
- public Pub/Sub ingestion is serialized per mailbox with a Firestore lease;
- `watchHistoryId` is finalized monotonically in a transaction and cannot regress under concurrent notifications;
- History is preflighted before the existing ingestion engine runs;
- Gmail History 404 enters explicit recovery, preserves the last processed checkpoint and records the pending target instead of silently advancing across an unprocessed gap;
- Pub/Sub arriving during initial/parser-upgrade backfill is held as pending and does not race the backfill;
- a scheduled safety reconciliation runs every 4 hours in `Asia/Jerusalem`, reads the current mailbox History ID and reuses the guarded incremental path;
- the scheduled path never invokes the six-month `newer_than:` scan;
- sync-status observability exposes only operational state: backfill completion, checkpoint/pending History IDs, recovery state and reconciliation timestamps — no mailbox content.

## Existing behavior intentionally reused
The stable Gmail parser remains the single parser/PDF ingestion implementation. Existing PDF retry/idempotency/audit behavior is reused rather than duplicated.

## TDD evidence
- initial tests-only run `31351407305`: RED, 135 passed / 1 expected failure (`gmailHistoryPolicy` not yet implemented);
- edge-case run `31352021094`: RED, 142 passed / 2 expected failures (backfill/Push isolation and legacy parser-v6 migration marker);
- runtime was changed only after each failing acceptance condition was observed.

## Fresh verification checkpoint
Head: `3f9f29890ae31e857e4cad26872f9029a23c2027`
CI run: `31352143161` — **completed / success**
- backend tests: success;
- Android unit tests: success;
- lint: success;
- debug APK: success;
- staging debug signing verification: success;
- OAuth E2E-ready artifact upload: success;
- release APK: success.

Artifact:
- ID `9049419413`
- digest `sha256:734f854fd4010c25ab68bc3868f0693adc7896efac62fbee96af46a9bd0513ba`
- expires 2026-08-17.

The earlier experimental PR #39 was closed without merge because its asynchronous checkpoint-repair approach could race the realtime handler. This v2 replaces it with guarded public processing and transactional finalization.

This PR remains Draft/queued until the locked Stream A staging backend + paired APK pass E2E correction cycle #2.