### PR TITLE
Queue exact verified-savings push destination

### DIFF
--- a/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
+++ b/app/src/main/java/com/example/ClickAndSaveMessagingService.kt
@@ -4,6 +4,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.example.data.local.AppDatabase
@@ -53,6 +54,10 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
         val pushType = message.data[PUSH_TYPE_EXTRA]
+        val opportunityId = message.data[PUSH_OPPORTUNITY_ID_EXTRA]
+        val offerId = message.data[PUSH_OFFER_ID_EXTRA]
+        val navigationTarget = navigationTargetForPush(pushType, opportunityId, offerId)
+
         if (pushType == PUSH_TYPE_NEW_INVOICE) {
             refreshObservedBillsFromBackend()
         }
@@ -63,7 +68,7 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
         val body = message.notification?.body
             ?: message.data["body"]
             ?: "פתח את ClickAndSaveAI כדי לראות את העדכון."
-        showNotification(title, body, pushType)
+        showNotification(title, body, pushType, navigationTarget)
     }
 
     private fun refreshObservedBillsFromBackend() {
@@ -80,23 +85,41 @@ class ClickAndSaveMessagingService : FirebaseMessagingService() {
         }
     }
 
-    private fun showNotification(title: String, body: String, pushType: String?) {
+    private fun showNotification(
+        title: String,
+        body: String,
+        pushType: String?,
+        navigationTarget: PushNavigationTarget?
+    ) {
         FinancialNotificationChannels.ensureCreated(this)
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        val destinationTab = destinationTabForPushType(pushType)
         val openAppIntent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-            if (destinationTab != null && pushType != null) {
+            if (pushType != null && navigationTarget != null) {
                 putExtra(PUSH_TYPE_EXTRA, pushType)
+                if (!navigationTarget.opportunityId.isNullOrBlank()) {
+                    putExtra(PUSH_OPPORTUNITY_ID_EXTRA, navigationTarget.opportunityId)
+                }
+                if (!navigationTarget.offerId.isNullOrBlank()) {
+                    putExtra(PUSH_OFFER_ID_EXTRA, navigationTarget.offerId)
+                }
+
+                // PendingIntent identity does not include extras. Give every exact savings pair
+                // a distinct data URI as well as a distinct request code so a newer notification
+                // cannot overwrite another Opportunity -> Offer route.
+                if (navigationTarget.tab == 2) {
+                    data = Uri.Builder()
+                        .scheme("clickandsave")
+                        .authority("push")
+                        .appendPath("savings")
+                        .appendPath(navigationTarget.opportunityId)
+                        .appendPath(navigationTarget.offerId)
+                        .build()
+                }
             }
         }
-        val pendingIntentRequestCode = when (destinationTab) {
-            1 -> 101
-            2 -> 102
-            0 -> 100
-            else -> 199
-        }
+        val pendingIntentRequestCode = pendingIntentRequestCodeForPushTarget(navigationTarget)
         val pendingIntent = PendingIntent.getActivity(
             this,
             pendingIntentRequestCode,

--- a/app/src/main/java/com/example/MainActivity.kt
+++ b/app/src/main/java/com/example/MainActivity.kt
@@ -149,12 +149,15 @@ class MainActivity : ComponentActivity() {
         val pushType = intent?.getStringExtra(PUSH_TYPE_EXTRA)
         val opportunityId = intent?.getStringExtra(PUSH_OPPORTUNITY_ID_EXTRA)
         val offerId = intent?.getStringExtra(PUSH_OFFER_ID_EXTRA)
-        val navigationTarget = navigationTargetForPush(pushType, opportunityId, offerId) ?: run {
-            intent?.removeExtra(PUSH_TYPE_EXTRA)
-            intent?.removeExtra(PUSH_OPPORTUNITY_ID_EXTRA)
-            intent?.removeExtra(PUSH_OFFER_ID_EXTRA)
-            return
-        }
+
+        // Read once, then consume only the allowlisted routing extras before validation. This
+        // prevents a malformed/stale push from being replayed after Activity recreation while
+        // preserving the captured local values for typed validation below.
+        intent?.removeExtra(PUSH_TYPE_EXTRA)
+        intent?.removeExtra(PUSH_OPPORTUNITY_ID_EXTRA)
+        intent?.removeExtra(PUSH_OFFER_ID_EXTRA)
+
+        val navigationTarget = navigationTargetForPush(pushType, opportunityId, offerId) ?: return
 
         if (
             navigationTarget.tab == 2 &&
@@ -167,12 +170,6 @@ class MainActivity : ComponentActivity() {
             )
         }
         viewModel.setTab(navigationTarget.tab)
-
-        // Consume only the known allowlisted routing fields so configuration changes or repeated
-        // delivery cannot unexpectedly re-route a user later.
-        intent.removeExtra(PUSH_TYPE_EXTRA)
-        intent.removeExtra(PUSH_OPPORTUNITY_ID_EXTRA)
-        intent.removeExtra(PUSH_OFFER_ID_EXTRA)
     }
 
     private fun maybeTriggerDebugTestPush(intent: Intent?) {

--- a/app/src/main/java/com/example/MainActivity.kt
+++ b/app/src/main/java/com/example/MainActivity.kt
@@ -146,12 +146,33 @@ class MainActivity : ComponentActivity() {
 
     private fun applyPushDestination(intent: Intent?) {
         if (FirebaseAuth.getInstance().currentUser == null) return
-        val pushType = intent?.getStringExtra(PUSH_TYPE_EXTRA) ?: return
-        val destinationTab = destinationTabForPushType(pushType) ?: return
-        viewModel.setTab(destinationTab)
-        // Consume only a known allowlisted navigation instruction so configuration changes or
-        // repeated delivery cannot unexpectedly re-route a user later.
+        val pushType = intent?.getStringExtra(PUSH_TYPE_EXTRA)
+        val opportunityId = intent?.getStringExtra(PUSH_OPPORTUNITY_ID_EXTRA)
+        val offerId = intent?.getStringExtra(PUSH_OFFER_ID_EXTRA)
+        val navigationTarget = navigationTargetForPush(pushType, opportunityId, offerId) ?: run {
+            intent?.removeExtra(PUSH_TYPE_EXTRA)
+            intent?.removeExtra(PUSH_OPPORTUNITY_ID_EXTRA)
+            intent?.removeExtra(PUSH_OFFER_ID_EXTRA)
+            return
+        }
+
+        if (
+            navigationTarget.tab == 2 &&
+            navigationTarget.opportunityId != null &&
+            navigationTarget.offerId != null
+        ) {
+            viewModel.setSavingsPushTarget(
+                navigationTarget.opportunityId,
+                navigationTarget.offerId
+            )
+        }
+        viewModel.setTab(navigationTarget.tab)
+
+        // Consume only the known allowlisted routing fields so configuration changes or repeated
+        // delivery cannot unexpectedly re-route a user later.
         intent.removeExtra(PUSH_TYPE_EXTRA)
+        intent.removeExtra(PUSH_OPPORTUNITY_ID_EXTRA)
+        intent.removeExtra(PUSH_OFFER_ID_EXTRA)
     }
 
     private fun maybeTriggerDebugTestPush(intent: Intent?) {

--- a/app/src/main/java/com/example/PushNavigationPolicy.kt
+++ b/app/src/main/java/com/example/PushNavigationPolicy.kt
@@ -1,15 +1,48 @@
 package com.example
 
 internal const val PUSH_TYPE_EXTRA = "type"
+internal const val PUSH_OPPORTUNITY_ID_EXTRA = "opportunityId"
+internal const val PUSH_OFFER_ID_EXTRA = "offerId"
 internal const val PUSH_TYPE_NEW_INVOICE = "NEW_INVOICE"
 internal const val PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY = "VERIFIED_SAVINGS_OPPORTUNITY"
 internal const val PUSH_TYPE_TEST = "PUSH_TEST"
+
+internal data class PushNavigationTarget(
+    val tab: Int,
+    val opportunityId: String? = null,
+    val offerId: String? = null
+)
 
 internal fun destinationTabForPushType(pushType: String?): Int? {
     return when (pushType?.trim()) {
         PUSH_TYPE_NEW_INVOICE -> 1
         PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY -> 2
         PUSH_TYPE_TEST -> 0
+        else -> null
+    }
+}
+
+internal fun navigationTargetForPush(
+    pushType: String?,
+    opportunityId: String?,
+    offerId: String?
+): PushNavigationTarget? {
+    return when (pushType?.trim()) {
+        PUSH_TYPE_NEW_INVOICE -> PushNavigationTarget(tab = 1)
+        PUSH_TYPE_TEST -> PushNavigationTarget(tab = 0)
+        PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY -> {
+            val exactOpportunityId = opportunityId?.trim().orEmpty()
+            val exactOfferId = offerId?.trim().orEmpty()
+            if (exactOpportunityId.isBlank() || exactOfferId.isBlank()) {
+                null
+            } else {
+                PushNavigationTarget(
+                    tab = 2,
+                    opportunityId = exactOpportunityId,
+                    offerId = exactOfferId
+                )
+            }
+        }
         else -> null
     }
 }

--- a/app/src/main/java/com/example/PushNavigationPolicy.kt
+++ b/app/src/main/java/com/example/PushNavigationPolicy.kt
@@ -46,3 +46,15 @@ internal fun navigationTargetForPush(
         else -> null
     }
 }
+
+internal fun pendingIntentRequestCodeForPushTarget(target: PushNavigationTarget?): Int {
+    return when (target?.tab) {
+        0 -> 100
+        1 -> 101
+        2 -> {
+            val exactPair = "${target.opportunityId.orEmpty()}\u0000${target.offerId.orEmpty()}"
+            1_000 + (exactPair.hashCode() and 0x3fffffff)
+        }
+        else -> 199
+    }
+}

--- a/app/src/main/java/com/example/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/ui/MainViewModel.kt
@@ -69,6 +69,11 @@ sealed class ProviderLeadUiState {
     data class Error(val message: String) : ProviderLeadUiState()
 }
 
+data class SavingsPushTarget(
+    val opportunityId: String,
+    val offerId: String
+)
+
 class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val db = AppDatabase.getDatabase(application)
     private val shoppingRepository = ShoppingRepository(db)
@@ -95,6 +100,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _aiErrorMessage = MutableStateFlow("")
     val aiErrorMessage: StateFlow<String> = _aiErrorMessage.asStateFlow()
+
+    private val _savingsPushTarget = MutableStateFlow<SavingsPushTarget?>(null)
+    val savingsPushTarget: StateFlow<SavingsPushTarget?> = _savingsPushTarget.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -227,6 +235,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun signOut() {
         viewModelScope.launch {
+            _savingsPushTarget.value = null
             gmailRepository.disconnectGmail()
             authRepository.signOut()
         }
@@ -351,6 +360,20 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun setTab(index: Int) {
         selectedTab.value = index.coerceIn(0, 4)
+    }
+
+    fun setSavingsPushTarget(opportunityId: String, offerId: String) {
+        val exactOpportunityId = opportunityId.trim()
+        val exactOfferId = offerId.trim()
+        if (exactOpportunityId.isBlank() || exactOfferId.isBlank()) return
+        _savingsPushTarget.value = SavingsPushTarget(
+            opportunityId = exactOpportunityId,
+            offerId = exactOfferId
+        )
+    }
+
+    fun clearSavingsPushTarget() {
+        _savingsPushTarget.value = null
     }
 
     fun setSearchQuery(query: String) {

--- a/app/src/main/java/com/example/ui/SavingsPushTargetPolicy.kt
+++ b/app/src/main/java/com/example/ui/SavingsPushTargetPolicy.kt
@@ -1,0 +1,46 @@
+package com.example.ui
+
+data class SavingsPushCandidate(
+    val opportunityId: String,
+    val offerId: String?
+)
+
+enum class SavingsPushTargetStatus {
+    NONE,
+    FOCUSED,
+    STALE
+}
+
+data class SavingsPushTargetResolution(
+    val status: SavingsPushTargetStatus,
+    val focusedOpportunityId: String? = null
+)
+
+fun resolveSavingsPushTarget(
+    target: SavingsPushTarget?,
+    candidates: List<SavingsPushCandidate>
+): SavingsPushTargetResolution {
+    if (target == null) {
+        return SavingsPushTargetResolution(status = SavingsPushTargetStatus.NONE)
+    }
+
+    val exactOpportunityId = target.opportunityId.trim()
+    val exactOfferId = target.offerId.trim()
+    if (exactOpportunityId.isBlank() || exactOfferId.isBlank()) {
+        return SavingsPushTargetResolution(status = SavingsPushTargetStatus.STALE)
+    }
+
+    val opportunity = candidates.firstOrNull {
+        it.opportunityId.trim() == exactOpportunityId
+    } ?: return SavingsPushTargetResolution(status = SavingsPushTargetStatus.STALE)
+
+    val currentOfferId = opportunity.offerId?.trim().orEmpty()
+    if (currentOfferId != exactOfferId) {
+        return SavingsPushTargetResolution(status = SavingsPushTargetStatus.STALE)
+    }
+
+    return SavingsPushTargetResolution(
+        status = SavingsPushTargetStatus.FOCUSED,
+        focusedOpportunityId = exactOpportunityId
+    )
+}

--- a/app/src/test/java/com/example/PushNavigationPolicyTest.kt
+++ b/app/src/test/java/com/example/PushNavigationPolicyTest.kt
@@ -8,16 +8,61 @@ class PushNavigationPolicyTest {
     @Test
     fun newInvoiceOpensBills() {
         assertEquals(1, destinationTabForPushType(PUSH_TYPE_NEW_INVOICE))
+        assertEquals(
+            PushNavigationTarget(tab = 1),
+            navigationTargetForPush(PUSH_TYPE_NEW_INVOICE, null, null)
+        )
     }
 
     @Test
-    fun verifiedSavingsOpensSavings() {
+    fun verifiedSavingsRequiresAndPreservesExactOpportunityAndOffer() {
         assertEquals(2, destinationTabForPushType(PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY))
+        assertEquals(
+            PushNavigationTarget(
+                tab = 2,
+                opportunityId = "opp-1",
+                offerId = "offer-1"
+            ),
+            navigationTargetForPush(
+                PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY,
+                "opp-1",
+                "offer-1"
+            )
+        )
+    }
+
+    @Test
+    fun verifiedSavingsWithoutExactIdsCannotNavigate() {
+        assertNull(
+            navigationTargetForPush(
+                PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY,
+                "",
+                "offer-1"
+            )
+        )
+        assertNull(
+            navigationTargetForPush(
+                PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY,
+                "opp-1",
+                ""
+            )
+        )
+        assertNull(
+            navigationTargetForPush(
+                PUSH_TYPE_VERIFIED_SAVINGS_OPPORTUNITY,
+                null,
+                null
+            )
+        )
     }
 
     @Test
     fun testPushOpensDashboard() {
         assertEquals(0, destinationTabForPushType(PUSH_TYPE_TEST))
+        assertEquals(
+            PushNavigationTarget(tab = 0),
+            navigationTargetForPush(PUSH_TYPE_TEST, null, null)
+        )
     }
 
     @Test
@@ -25,5 +70,8 @@ class PushNavigationPolicyTest {
         assertNull(destinationTabForPushType("OPEN_PROFILE"))
         assertNull(destinationTabForPushType("99"))
         assertNull(destinationTabForPushType(null))
+        assertNull(navigationTargetForPush("OPEN_PROFILE", "opp-1", "offer-1"))
+        assertNull(navigationTargetForPush("99", "opp-1", "offer-1"))
+        assertNull(navigationTargetForPush(null, "opp-1", "offer-1"))
     }
 }

--- a/app/src/test/java/com/example/PushNavigationPolicyTest.kt
+++ b/app/src/test/java/com/example/PushNavigationPolicyTest.kt
@@ -1,6 +1,7 @@
 package com.example
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -54,6 +55,19 @@ class PushNavigationPolicyTest {
                 null
             )
         )
+    }
+
+    @Test
+    fun exactSavingsPairsReceiveDifferentPendingIntentRequestCodes() {
+        val first = PushNavigationTarget(tab = 2, opportunityId = "opp-1", offerId = "offer-1")
+        val second = PushNavigationTarget(tab = 2, opportunityId = "opp-2", offerId = "offer-2")
+
+        assertNotEquals(
+            pendingIntentRequestCodeForPushTarget(first),
+            pendingIntentRequestCodeForPushTarget(second)
+        )
+        assertEquals(101, pendingIntentRequestCodeForPushTarget(PushNavigationTarget(tab = 1)))
+        assertEquals(100, pendingIntentRequestCodeForPushTarget(PushNavigationTarget(tab = 0)))
     }
 
     @Test

--- a/app/src/test/java/com/example/PushNavigationSourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushNavigationSourceGuardTest.kt
@@ -7,13 +7,21 @@ import org.junit.Test
 
 class PushNavigationSourceGuardTest {
     @Test
-    fun messagingServiceUsesTypedPushDestinationInsteadOfLegacyBoolean() {
+    fun messagingServicePreservesOnlyAllowlistedExactPushRoute() {
         val service = File("src/main/java/com/example/ClickAndSaveMessagingService.kt").readText()
 
         assertTrue(service.contains("message.data[PUSH_TYPE_EXTRA]"))
-        assertTrue(service.contains("destinationTabForPushType(pushType)"))
+        assertTrue(service.contains("message.data[PUSH_OPPORTUNITY_ID_EXTRA]"))
+        assertTrue(service.contains("message.data[PUSH_OFFER_ID_EXTRA]"))
+        assertTrue(service.contains("navigationTargetForPush(pushType, opportunityId, offerId)"))
         assertTrue(service.contains("putExtra(PUSH_TYPE_EXTRA, pushType)"))
+        assertTrue(service.contains("putExtra(PUSH_OPPORTUNITY_ID_EXTRA, navigationTarget.opportunityId)"))
+        assertTrue(service.contains("putExtra(PUSH_OFFER_ID_EXTRA, navigationTarget.offerId)"))
+        assertTrue(service.contains("pendingIntentRequestCodeForPushTarget(navigationTarget)"))
+        assertFalse(service.contains("destinationTabForPushType(pushType)"))
         assertFalse(service.contains("openSavingsOpportunity"))
+        assertFalse(service.contains("message.data.forEach"))
+        assertFalse(service.contains("putExtras("))
     }
 
     @Test

--- a/app/src/test/java/com/example/PushNavigationSourceGuardTest.kt
+++ b/app/src/test/java/com/example/PushNavigationSourceGuardTest.kt
@@ -25,7 +25,7 @@ class PushNavigationSourceGuardTest {
     }
 
     @Test
-    fun activityConsumesOnlyAllowlistedPushTypeForAuthenticatedUser() {
+    fun activityConsumesTypedExactPushTargetForAuthenticatedUser() {
         val activity = File("src/main/java/com/example/MainActivity.kt").readText()
         val handler = activity
             .substringAfter("private fun applyPushDestination(intent: Intent?)")
@@ -33,10 +33,30 @@ class PushNavigationSourceGuardTest {
 
         assertTrue(handler.contains("FirebaseAuth.getInstance().currentUser == null"))
         assertTrue(handler.contains("getStringExtra(PUSH_TYPE_EXTRA)"))
-        assertTrue(handler.contains("destinationTabForPushType(pushType) ?: return"))
-        assertTrue(handler.contains("viewModel.setTab(destinationTab)"))
+        assertTrue(handler.contains("getStringExtra(PUSH_OPPORTUNITY_ID_EXTRA)"))
+        assertTrue(handler.contains("getStringExtra(PUSH_OFFER_ID_EXTRA)"))
+        assertTrue(handler.contains("navigationTargetForPush(pushType, opportunityId, offerId) ?: return"))
+        assertTrue(handler.contains("viewModel.setTab(navigationTarget.tab)"))
+        assertTrue(handler.contains("viewModel.setSavingsPushTarget("))
+        assertTrue(handler.contains("navigationTarget.opportunityId"))
+        assertTrue(handler.contains("navigationTarget.offerId"))
         assertTrue(handler.contains("removeExtra(PUSH_TYPE_EXTRA)"))
+        assertTrue(handler.contains("removeExtra(PUSH_OPPORTUNITY_ID_EXTRA)"))
+        assertTrue(handler.contains("removeExtra(PUSH_OFFER_ID_EXTRA)"))
         assertFalse(handler.contains("getIntExtra"))
         assertFalse(handler.contains("openSavingsOpportunity"))
+    }
+
+    @Test
+    fun viewModelStoresSavingsPushTargetOnlyInMemoryAsOneShotState() {
+        val viewModel = File("src/main/java/com/example/ui/MainViewModel.kt").readText()
+
+        assertTrue(viewModel.contains("data class SavingsPushTarget("))
+        assertTrue(viewModel.contains("private val _savingsPushTarget = MutableStateFlow<SavingsPushTarget?>(null)"))
+        assertTrue(viewModel.contains("val savingsPushTarget: StateFlow<SavingsPushTarget?> = _savingsPushTarget.asStateFlow()"))
+        assertTrue(viewModel.contains("fun setSavingsPushTarget("))
+        assertTrue(viewModel.contains("fun clearSavingsPushTarget()"))
+        assertFalse(viewModel.contains("SharedPreferences"))
+        assertFalse(viewModel.contains("savedStateHandle"))
     }
 }

--- a/app/src/test/java/com/example/SavingsPushTargetPolicyTest.kt
+++ b/app/src/test/java/com/example/SavingsPushTargetPolicyTest.kt
@@ -1,0 +1,68 @@
+package com.example
+
+import com.example.ui.SavingsPushCandidate
+import com.example.ui.SavingsPushTarget
+import com.example.ui.SavingsPushTargetStatus
+import com.example.ui.resolveSavingsPushTarget
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SavingsPushTargetPolicyTest {
+    private val current = listOf(
+        SavingsPushCandidate(opportunityId = "opp-1", offerId = "offer-1"),
+        SavingsPushCandidate(opportunityId = "opp-2", offerId = "offer-2")
+    )
+
+    @Test
+    fun noPushTargetLeavesSavingsListUntouched() {
+        val result = resolveSavingsPushTarget(null, current)
+
+        assertEquals(SavingsPushTargetStatus.NONE, result.status)
+        assertNull(result.focusedOpportunityId)
+    }
+
+    @Test
+    fun exactCurrentOpportunityAndOfferFocusesOnlyThatOpportunity() {
+        val result = resolveSavingsPushTarget(
+            SavingsPushTarget(opportunityId = "opp-2", offerId = "offer-2"),
+            current
+        )
+
+        assertEquals(SavingsPushTargetStatus.FOCUSED, result.status)
+        assertEquals("opp-2", result.focusedOpportunityId)
+    }
+
+    @Test
+    fun sameOpportunityWithDifferentCurrentOfferIsStale() {
+        val result = resolveSavingsPushTarget(
+            SavingsPushTarget(opportunityId = "opp-1", offerId = "old-offer"),
+            current
+        )
+
+        assertEquals(SavingsPushTargetStatus.STALE, result.status)
+        assertNull(result.focusedOpportunityId)
+    }
+
+    @Test
+    fun missingOpportunityIsStaleAndNeverSubstitutesAnotherOffer() {
+        val result = resolveSavingsPushTarget(
+            SavingsPushTarget(opportunityId = "missing-opp", offerId = "offer-2"),
+            current
+        )
+
+        assertEquals(SavingsPushTargetStatus.STALE, result.status)
+        assertNull(result.focusedOpportunityId)
+    }
+
+    @Test
+    fun candidateWithoutCurrentOfferCannotSatisfyExactPushTarget() {
+        val result = resolveSavingsPushTarget(
+            SavingsPushTarget(opportunityId = "opp-3", offerId = "offer-3"),
+            current + SavingsPushCandidate(opportunityId = "opp-3", offerId = null)
+        )
+
+        assertEquals(SavingsPushTargetStatus.STALE, result.status)
+        assertNull(result.focusedOpportunityId)
+    }
+}

--- a/app/src/test/java/com/example/SavingsPushTargetTest.kt
+++ b/app/src/test/java/com/example/SavingsPushTargetTest.kt
@@ -1,0 +1,15 @@
+package com.example
+
+import com.example.ui.SavingsPushTarget
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SavingsPushTargetTest {
+    @Test
+    fun exactTargetPreservesOpportunityAndOfferIds() {
+        assertEquals(
+            SavingsPushTarget(opportunityId = "opp-1", offerId = "offer-1"),
+            SavingsPushTarget(opportunityId = "opp-1", offerId = "offer-1")
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-08-10-exact-push-destination.md
+++ b/docs/superpowers/plans/2026-08-10-exact-push-destination.md
@@ -1,0 +1,238 @@
+# Exact Savings Push Destination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a verified-savings push open the exact currently valid `Opportunity -> Offer` pair instead of only opening the Savings tab.
+
+**Architecture:** Reuse the backend payload that already sends `type`, `opportunityId`, and `offerId`. Android converts only allowlisted payload fields into a typed navigation target, carries them through foreground notification PendingIntents and activity intents, stores a one-shot savings target in `MainViewModel`, and lets `ProvidersScreen` validate the pair against fresh `FinancialHomeResult` before focusing it. A stale/mismatched pair never auto-selects a replacement offer.
+
+**Tech Stack:** Kotlin, Jetpack Compose, StateFlow, Firebase Cloud Messaging, Android PendingIntent, existing Android/JVM unit and source-guard tests.
+
+## Global Constraints
+
+- Keep Stream A locked; this work stays stacked/queued and must not merge to Core before staging E2E correction cycle #2.
+- No backend ranking, savings arithmetic, commerce lifecycle, Gmail, Firestore rules or provider payload changes.
+- The backend remains authoritative for `opportunityId` and `offerId`; Android must never infer a replacement offer.
+- Only allowlisted push types can navigate.
+- A verified-savings push requires both nonblank `opportunityId` and `offerId` for exact focus.
+- If the exact pair is stale or mismatched, show current Savings state and a truthful stale-message; do not claim the old offer is still valid.
+- Foreground notification PendingIntents must not overwrite the routing extras of another savings opportunity.
+- Do not copy arbitrary FCM data into an Activity intent; copy only known routing keys.
+- Preserve private notification visibility and existing `NEW_INVOICE` observed-bills refresh behavior.
+
+---
+
+### Task 1: Typed Push Navigation Contract
+
+**Files:**
+- Modify: `app/src/main/java/com/example/PushNavigationPolicy.kt`
+- Modify: `app/src/test/java/com/example/PushNavigationPolicyTest.kt`
+
+**Interfaces:**
+- Produces: `PushNavigationTarget(tab: Int, opportunityId: String? = null, offerId: String? = null)`.
+- Produces: `navigationTargetForPush(type: String?, opportunityId: String?, offerId: String?): PushNavigationTarget?`.
+- Produces allowlisted extras `PUSH_OPPORTUNITY_ID_EXTRA` and `PUSH_OFFER_ID_EXTRA`.
+
+- [ ] **Step 1: Write failing pure-function tests**
+
+Add tests proving:
+```kotlin
+assertEquals(PushNavigationTarget(tab = 1), navigationTargetForPush("NEW_INVOICE", null, null))
+assertEquals(PushNavigationTarget(tab = 0), navigationTargetForPush("PUSH_TEST", null, null))
+assertEquals(
+    PushNavigationTarget(tab = 2, opportunityId = "opp-1", offerId = "offer-1"),
+    navigationTargetForPush("VERIFIED_SAVINGS_OPPORTUNITY", "opp-1", "offer-1")
+)
+assertNull(navigationTargetForPush("VERIFIED_SAVINGS_OPPORTUNITY", "", "offer-1"))
+assertNull(navigationTargetForPush("VERIFIED_SAVINGS_OPPORTUNITY", "opp-1", ""))
+assertNull(navigationTargetForPush("UNKNOWN", "opp-1", "offer-1"))
+```
+
+- [ ] **Step 2: Run Android unit tests and verify RED**
+
+Run through CI on the tests-only commit. Expected: compilation/test failure because `PushNavigationTarget` / `navigationTargetForPush` do not exist.
+
+- [ ] **Step 3: Implement the minimal typed policy**
+
+Keep existing tab mapping semantics for invoice/test. For verified savings, return a target only when both exact IDs are nonblank after trimming.
+
+- [ ] **Step 4: Run unit tests and verify GREEN**
+
+Expected: all navigation policy tests pass.
+
+- [ ] **Step 5: Commit**
+
+Commit only the policy and its tests.
+
+---
+
+### Task 2: Preserve Exact IDs Through Foreground Notification PendingIntent
+
+**Files:**
+- Modify: `app/src/main/java/com/example/ClickAndSaveMessagingService.kt`
+- Create or modify: `app/src/test/java/com/example/PushNavigationSourceGuardTest.kt`
+
+**Interfaces:**
+- Consumes: `navigationTargetForPush(...)` and the two allowlisted ID extras from Task 1.
+- Produces: an `Intent` containing only the recognized `type`, `opportunityId`, and `offerId` routing values.
+
+- [ ] **Step 1: Add failing source guards**
+
+Require the service to:
+```text
+read message.data["opportunityId"]
+read message.data["offerId"]
+pass them to navigationTargetForPush
+put only PUSH_TYPE_EXTRA / PUSH_OPPORTUNITY_ID_EXTRA / PUSH_OFFER_ID_EXTRA
+```
+Also require savings PendingIntent request codes to depend on the exact pair rather than a single constant `102`.
+
+- [ ] **Step 2: Verify RED in CI**
+
+Expected: source-guard failure because the current foreground path passes only `pushType`.
+
+- [ ] **Step 3: Implement minimal foreground routing**
+
+Change `showNotification` to receive the relevant data map or typed target. Copy only known values. Derive a stable positive request code for savings from `opportunityId|offerId`; keep fixed codes for Home/Bills.
+
+- [ ] **Step 4: Verify tests GREEN**
+
+Ensure `NEW_INVOICE` still triggers observed-bills refresh and notification privacy/channel behavior remains unchanged.
+
+- [ ] **Step 5: Commit**
+
+Commit service + source guards.
+
+---
+
+### Task 3: One-Shot Savings Push Target in MainViewModel / MainActivity
+
+**Files:**
+- Modify: `app/src/main/java/com/example/ui/MainViewModel.kt`
+- Modify: `app/src/main/java/com/example/MainActivity.kt`
+- Modify: `app/src/test/java/com/example/PushNavigationSourceGuardTest.kt`
+
+**Interfaces:**
+- Produces: `SavingsPushTarget(opportunityId: String, offerId: String)` in ViewModel state.
+- Produces: `setSavingsPushTarget(...)` and `clearSavingsPushTarget()`.
+- MainActivity consumes typed intent extras, requires authenticated Firebase user, routes to tab 2 and stores the exact pair.
+
+- [ ] **Step 1: Add failing tests/guards**
+
+Require Activity to:
+```text
+parse type + opportunityId + offerId through navigationTargetForPush
+set the exact savings target before/with tab navigation
+remove all consumed routing extras
+ignore malformed/unknown targets
+```
+Require ViewModel to expose a typed one-shot target, not raw arbitrary Intent data.
+
+- [ ] **Step 2: Verify RED**
+
+Expected: tests fail because only `type` is currently consumed.
+
+- [ ] **Step 3: Implement minimal state + Activity bridge**
+
+Do not persist the target to disk. It is navigation intent only. Keep the authentication gate already present in `applyPushDestination`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run unit/source tests.
+
+- [ ] **Step 5: Commit**
+
+Commit Activity/ViewModel bridge.
+
+---
+
+### Task 4: Validate and Focus Exact Opportunity/Offer in Savings
+
+**Files:**
+- Modify: `app/src/main/java/com/example/ui/screens/ProvidersScreen.kt`
+- Create: `app/src/main/java/com/example/ui/SavingsPushTargetPolicy.kt` if a pure matcher keeps the screen simple.
+- Create: `app/src/test/java/com/example/SavingsPushTargetPolicyTest.kt`
+- Modify: `app/src/test/java/com/example/CustomerUiSourceGuardTest.kt` only if an existing source guard needs the new contract.
+
+**Interfaces:**
+- Consumes: pending `SavingsPushTarget` and current `FinancialHomeResult.opportunities`.
+- Produces pure matching result: exact current pair, stale/missing pair, or no push target.
+
+- [ ] **Step 1: Write failing pure matching tests**
+
+Cover:
+```text
+exact opportunity ID + exact matched offer ID -> FOCUSED
+same opportunity but different current offer ID -> STALE
+missing opportunity -> STALE
+no push target -> NONE
+```
+
+- [ ] **Step 2: Verify RED**
+
+Expected: missing matcher/state.
+
+- [ ] **Step 3: Implement matcher and presentation behavior**
+
+When exact:
+- put the matched opportunity first in the rendered list;
+- show a small truthful marker such as `ההצעה מההתראה` on that card;
+- clear the ViewModel one-shot target after the screen captures it locally.
+
+When stale:
+- clear the one-shot target;
+- do not focus another offer;
+- show a customer-safe message: `ההצעה מההתראה השתנתה. מציגים את ההצעות העדכניות.`
+
+Do not modify savings numbers, `ACTION_STARTED`, consent, revalidation, or `acceptSavingsOpportunity`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run Android unit tests and source guards.
+
+- [ ] **Step 5: Commit**
+
+Commit matcher + Savings presentation only.
+
+---
+
+### Task 5: Full Same-SHA Verification and PR Evidence
+
+**Files:**
+- Update PR body / Issue #9 only after CI evidence exists.
+
+**Interfaces:**
+- Consumes all earlier tasks.
+- Produces a queued, same-SHA green checkpoint; no merge to Core.
+
+- [ ] **Step 1: Run full CI on exact HEAD**
+
+Require:
+```text
+backend tests: success
+Android unit tests: success
+lint: success
+debug APK: success
+staging signing verification: success
+artifact upload: success
+release APK: success
+```
+
+- [ ] **Step 2: Inspect the run result and artifact metadata**
+
+Do not claim completion while any step is queued/in-progress.
+
+- [ ] **Step 3: Re-read Issue #9 acceptance criteria**
+
+Confirm:
+- backend continues to supply exact IDs;
+- foreground path preserves exact IDs;
+- activity consumes only allowlisted typed routing;
+- Savings validates exact current Opportunity/Offer pair;
+- stale pair never silently selects a replacement;
+- existing invoice/test destinations still work;
+- App Check/Auth and action/consent contracts are untouched.
+
+- [ ] **Step 4: Update PR/Issue with RED->GREEN evidence**
+
+Keep PR Draft/queued until Stream A E2E correction cycle #2 passes.


### PR DESCRIPTION
Stacked Issue #9 reliability work on top of green PR #43. **Do not merge to Core before staging E2E correction cycle #2.**

Goal: a verified-savings push must open the exact current Opportunity -> Offer pair carried by the backend payload, not merely the Savings tab.

Implementation plan: `docs/superpowers/plans/2026-08-10-exact-push-destination.md`.

TDD phase 1 is intentionally tests-only. Expected initial CI result: Android unit compilation/test failure because `PushNavigationTarget` and `navigationTargetForPush` do not exist yet.

Guardrails:
- no backend ranking/savings/commerce changes;
- no arbitrary push-driven navigation;
- exact savings focus requires both opportunityId and offerId;
- stale/mismatched pair must not silently select a replacement offer;
- preserve notification privacy, NEW_INVOICE refresh, ACTION_STARTED, consent and exact-offer revalidation.