### PR TITLE
Production Enablement Block 3B.3 — runtime/build actAs boundary

### DIFF
--- a/scripts/bootstrap-production-runtime-build-actas.sh
+++ b/scripts/bootstrap-production-runtime-build-actas.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_PROJECT_ID="click-save-ai-production"
+EXPECTED_DEPLOY_SA="clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com"
+PROJECT_ID="${PROJECT_ID:-$EXPECTED_PROJECT_ID}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERIFIER="$ROOT/scripts/verify-production-runtime-build-actas.sh"
+
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+case "$PROJECT_ID" in
+  clickandsaveai|clickandsaveai-staging) fail "Refusing forbidden non-Production project: $PROJECT_ID" ;;
+esac
+[[ "$PROJECT_ID" == "$EXPECTED_PROJECT_ID" ]] || fail "PROJECT_ID must be exactly $EXPECTED_PROJECT_ID"
+[[ -x "$VERIFIER" ]] || fail "Verifier is missing or not executable: $VERIFIER"
+
+DISCOVERY_FILE="$(mktemp)"
+trap 'rm -f "$DISCOVERY_FILE"' EXIT
+
+printf 'Running fail-closed pre-mutation verification and live identity discovery...\n'
+PROJECT_ID="$PROJECT_ID" ALLOW_MISSING_ACTAS=1 DISCOVERY_OUTPUT="$DISCOVERY_FILE" bash "$VERIFIER"
+# The verifier validates both values against fixed Production identity patterns before emitting them.
+# shellcheck disable=SC1090
+source "$DISCOVERY_FILE"
+[[ -n "${RUNTIME_SA:-}" && -n "${BUILD_SA:-}" ]] || fail "Verifier did not emit proven runtime/build identities."
+
+INTENDED_SAS=("$RUNTIME_SA")
+[[ "$BUILD_SA" == "$RUNTIME_SA" ]] || INTENDED_SAS+=("$BUILD_SA")
+for sa in "${INTENDED_SAS[@]}"; do
+  if gcloud iam service-accounts get-iam-policy "$sa" --project="$PROJECT_ID" \
+    --flatten='bindings[].members' \
+    --filter="bindings.role=roles/iam.serviceAccountUser AND bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
+    --format='value(bindings.members)' 2>/dev/null | grep -Fqx "serviceAccount:${EXPECTED_DEPLOY_SA}"; then
+    printf 'actAs already present on intended identity %s; no write needed.\n' "$sa"
+    continue
+  fi
+  printf 'Granting %s actAs only on %s\n' "$EXPECTED_DEPLOY_SA" "$sa"
+  gcloud iam service-accounts add-iam-policy-binding "$sa" \
+    --project="$PROJECT_ID" \
+    --member="serviceAccount:${EXPECTED_DEPLOY_SA}" \
+    --role="roles/iam.serviceAccountUser" \
+    --condition=None \
+    --quiet >/dev/null
+done
+
+printf 'Running immediate independent post-write verification...\n'
+PROJECT_ID="$PROJECT_ID" ALLOW_MISSING_ACTAS=0 bash "$VERIFIER"
+printf 'Production runtime/build service-account actAs boundary configured and verified.\n'

--- a/scripts/bootstrap-production-runtime-build-actas.sh
+++ b/scripts/bootstrap-production-runtime-build-actas.sh
@@ -8,6 +8,12 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VERIFIER="$ROOT/scripts/verify-production-runtime-build-actas.sh"
 
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+append_unique() {
+  local value="$1" array_name="$2" item
+  local -n array_ref="$array_name"
+  for item in "${array_ref[@]:-}"; do [[ "$item" == "$value" ]] && return 0; done
+  array_ref+=("$value")
+}
 case "$PROJECT_ID" in
   clickandsaveai|clickandsaveai-staging) fail "Refusing forbidden non-Production project: $PROJECT_ID" ;;
 esac
@@ -19,13 +25,16 @@ trap 'rm -f "$DISCOVERY_FILE"' EXIT
 
 printf 'Running fail-closed pre-mutation verification and live identity discovery...\n'
 PROJECT_ID="$PROJECT_ID" ALLOW_MISSING_ACTAS=1 DISCOVERY_OUTPUT="$DISCOVERY_FILE" bash "$VERIFIER"
-# The verifier validates both values against fixed Production identity patterns before emitting them.
+# The verifier derives the runtime generation set from the configured export surface and validates
+# every emitted runtime/build identity live before this bootstrap performs any IAM write.
 # shellcheck disable=SC1090
 source "$DISCOVERY_FILE"
-[[ -n "${RUNTIME_SA:-}" && -n "${BUILD_SA:-}" ]] || fail "Verifier did not emit proven runtime/build identities."
+declare -p RUNTIME_SAS >/dev/null 2>&1 || fail "Verifier did not emit a proven runtime identity array."
+[[ "${#RUNTIME_SAS[@]}" -gt 0 && -n "${BUILD_SA:-}" ]] || fail "Verifier did not emit proven runtime/build identities."
 
-INTENDED_SAS=("$RUNTIME_SA")
-[[ "$BUILD_SA" == "$RUNTIME_SA" ]] || INTENDED_SAS+=("$BUILD_SA")
+INTENDED_SAS=()
+for runtime_sa in "${RUNTIME_SAS[@]}"; do append_unique "$runtime_sa" INTENDED_SAS; done
+append_unique "$BUILD_SA" INTENDED_SAS
 for sa in "${INTENDED_SAS[@]}"; do
   if gcloud iam service-accounts get-iam-policy "$sa" --project="$PROJECT_ID" \
     --flatten='bindings[].members' \

--- a/scripts/verify-production-runtime-build-actas.sh
+++ b/scripts/verify-production-runtime-build-actas.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_PROJECT_ID="click-save-ai-production"
+EXPECTED_PROJECT_NUMBER="991489557172"
+EXPECTED_DEPLOY_SA="clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com"
+EXPECTED_POOL_ID="github-actions"
+EXPECTED_PROVIDER_ID="clickandsaveai-production"
+EXPECTED_WIF_PROVIDER="projects/991489557172/locations/global/workloadIdentityPools/github-actions/providers/clickandsaveai-production"
+EXPECTED_RUNTIME_REGION="europe-west1"
+GITHUB_REPOSITORY_ID="1314210715"
+GITHUB_REPOSITORY_OWNER_ID="64756523"
+GITHUB_ENVIRONMENT="production"
+GITHUB_REF="refs/heads/main"
+GITHUB_WORKFLOW_REF="vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main"
+GITHUB_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+EXPECTED_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.repository_owner_id=assertion.repository_owner_id,attribute.environment=assertion.environment,attribute.ref=assertion.ref,attribute.workflow_ref=assertion.workflow_ref"
+EXPECTED_CONDITION="attribute.repository_id=='${GITHUB_REPOSITORY_ID}' && attribute.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && attribute.environment=='${GITHUB_ENVIRONMENT}' && attribute.ref=='${GITHUB_REF}' && attribute.workflow_ref=='${GITHUB_WORKFLOW_REF}'"
+EXPECTED_WIF_MEMBER="principalSet://iam.googleapis.com/projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${EXPECTED_POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
+GITHUB_REPOSITORY="vhanukaev1981/ClickAndSaveAI"
+PROJECT_ID="${PROJECT_ID:-$EXPECTED_PROJECT_ID}"
+ALLOW_MISSING_ACTAS="${ALLOW_MISSING_ACTAS:-0}"
+DISCOVERY_OUTPUT="${DISCOVERY_OUTPUT:-}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+INTENDED_DEPLOY_ROLES=(
+  roles/cloudfunctions.developer
+  roles/firebaserules.admin
+  roles/datastore.indexAdmin
+  roles/serviceusage.serviceUsageConsumer
+)
+DANGEROUS_IDENTITY_ROLES=(
+  roles/owner
+  roles/editor
+  roles/firebase.admin
+  roles/firebase.developAdmin
+  roles/cloudfunctions.admin
+  roles/run.admin
+  roles/resourcemanager.projectIamAdmin
+  roles/iam.serviceAccountAdmin
+  roles/iam.serviceAccountTokenCreator
+  roles/iam.serviceAccountUser
+  roles/secretmanager.admin
+  roles/storage.admin
+  roles/artifactregistry.admin
+)
+
+FAILED=0
+pass() { printf 'PASS  %s\n' "$*"; }
+fail() { printf 'FAIL  %s\n' "$*" >&2; FAILED=1; }
+fatal() { printf 'FAIL  %s\n' "$*" >&2; exit 1; }
+contains() {
+  local needle="$1"; shift
+  local item
+  for item in "$@"; do [[ "$item" == "$needle" ]] && return 0; done
+  return 1
+}
+normalize_sa() {
+  local value="$1"
+  value="${value//$'\r'/}"
+  value="${value//$'\n'/}"
+  value="${value#projects/${PROJECT_ID}/serviceAccounts/}"
+  printf '%s' "$value"
+}
+validate_production_sa_identity() {
+  local label="$1" sa="$2"
+  [[ -n "$sa" ]] || fatal "$label identity is empty."
+  [[ "$sa" != *"clickandsaveai-staging"* && "$sa" != *"@clickandsaveai."* ]] || fatal "$label identity references staging/legacy project: $sa"
+  case "$sa" in
+    "${EXPECTED_PROJECT_NUMBER}-compute@developer.gserviceaccount.com") ;;
+    "${EXPECTED_PROJECT_NUMBER}@cloudbuild.gserviceaccount.com") ;;
+    *"@${EXPECTED_PROJECT_ID}.iam.gserviceaccount.com") ;;
+    *) fatal "$label identity is not provably owned by Production project $EXPECTED_PROJECT_ID/$EXPECTED_PROJECT_NUMBER: $sa" ;;
+  esac
+}
+project_roles_for() {
+  local sa="$1"
+  gcloud projects get-iam-policy "$PROJECT_ID" \
+    --flatten='bindings[].members' \
+    --filter="bindings.members=serviceAccount:${sa}" \
+    --format='value(bindings.role)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u
+}
+sa_has_deployer_actas() {
+  local sa="$1"
+  gcloud iam service-accounts get-iam-policy "$sa" --project="$PROJECT_ID" \
+    --flatten='bindings[].members' \
+    --filter="bindings.role=roles/iam.serviceAccountUser AND bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
+    --format='value(bindings.members)' 2>/dev/null | sed '/^[[:space:]]*$/d' | grep -Fqx "serviceAccount:${EXPECTED_DEPLOY_SA}"
+}
+
+case "$PROJECT_ID" in
+  clickandsaveai|clickandsaveai-staging) fatal "forbidden non-Production project: $PROJECT_ID" ;;
+esac
+[[ "$PROJECT_ID" == "$EXPECTED_PROJECT_ID" ]] || fatal "PROJECT_ID must be exactly $EXPECTED_PROJECT_ID"
+[[ "$ALLOW_MISSING_ACTAS" == "0" || "$ALLOW_MISSING_ACTAS" == "1" ]] || fatal "ALLOW_MISSING_ACTAS must be 0 or 1"
+command -v gcloud >/dev/null 2>&1 || fatal "gcloud is required"
+command -v python3 >/dev/null 2>&1 || fatal "python3 is required"
+command -v curl >/dev/null 2>&1 || fatal "curl is required"
+
+ACTIVE_ACCOUNT="$(gcloud auth list --filter='status:ACTIVE' --format='value(account)' 2>/dev/null | head -n 1)"
+[[ -n "$ACTIVE_ACCOUNT" ]] || fatal "no active gcloud account"
+
+ACTUAL_PROJECT_ID="$(gcloud projects describe "$PROJECT_ID" --format='value(projectId)' 2>/dev/null || true)"
+ACTUAL_PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)' 2>/dev/null || true)"
+[[ "$ACTUAL_PROJECT_ID" == "$EXPECTED_PROJECT_ID" ]] && pass "Project ID exact" || fail "Project ID mismatch: ${ACTUAL_PROJECT_ID:-missing}"
+[[ "$ACTUAL_PROJECT_NUMBER" == "$EXPECTED_PROJECT_NUMBER" ]] && pass "Project Number exact" || fail "Project Number mismatch: ${ACTUAL_PROJECT_NUMBER:-missing}"
+[[ "$ACTUAL_PROJECT_ID" == "$EXPECTED_PROJECT_ID" && "$ACTUAL_PROJECT_NUMBER" == "$EXPECTED_PROJECT_NUMBER" ]] || fatal "Production project lock failed before identity discovery."
+
+ACTUAL_DEPLOY_SA="$(gcloud iam service-accounts describe "$EXPECTED_DEPLOY_SA" --project="$PROJECT_ID" --format='value(email)' 2>/dev/null || true)"
+[[ "$ACTUAL_DEPLOY_SA" == "$EXPECTED_DEPLOY_SA" ]] && pass "deploy SA exact" || fatal "deploy SA mismatch or missing"
+USER_KEY_COUNT="$(gcloud iam service-accounts keys list --iam-account="$EXPECTED_DEPLOY_SA" --managed-by=user --format='value(name)' 2>/dev/null | sed '/^[[:space:]]*$/d' | wc -l | tr -d '[:space:]')"
+[[ "$USER_KEY_COUNT" == "0" ]] && pass "user-managed deploy-SA key count = 0" || fatal "deploy SA has user-managed keys: $USER_KEY_COUNT"
+
+mapfile -t PROVIDER_IDS < <(gcloud iam workload-identity-pools providers list \
+  --project="$PROJECT_ID" --location=global --workload-identity-pool="$EXPECTED_POOL_ID" \
+  --format='value(name)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sed 's#^.*/##')
+[[ "${#PROVIDER_IDS[@]}" -eq 1 && "${PROVIDER_IDS[0]}" == "$EXPECTED_PROVIDER_ID" ]] || fatal "Production WIF provider inventory mismatch"
+PROVIDER_JSON="$(gcloud iam workload-identity-pools providers describe "$EXPECTED_PROVIDER_ID" \
+  --project="$PROJECT_ID" --location=global --workload-identity-pool="$EXPECTED_POOL_ID" --format=json 2>/dev/null || true)"
+[[ -n "$PROVIDER_JSON" ]] || fatal "Production WIF provider missing"
+PROVIDER_JSON_INPUT="$PROVIDER_JSON" python3 - "$EXPECTED_WIF_PROVIDER" "$GITHUB_OIDC_ISSUER" "$EXPECTED_MAPPING" "$EXPECTED_CONDITION" <<'PY' || fatal "Production WIF provider boundary mismatch"
+import json, os, sys
+expected_name, expected_issuer, mapping_csv, expected_condition = sys.argv[1:]
+p = json.loads(os.environ['PROVIDER_JSON_INPUT'])
+expected_mapping = dict(x.split('=',1) for x in mapping_csv.split(','))
+assert p.get('name') == expected_name
+assert str(p.get('disabled', False)).lower() == 'false'
+assert p.get('oidc', {}).get('issuerUri') == expected_issuer
+assert p.get('attributeMapping', {}) == expected_mapping
+assert p.get('attributeCondition', '') == expected_condition
+PY
+pass "Production WIF provider exact and enabled"
+mapfile -t WIF_MEMBERS < <(gcloud iam service-accounts get-iam-policy "$EXPECTED_DEPLOY_SA" \
+  --project="$PROJECT_ID" --flatten='bindings[].members' \
+  --filter='bindings.role=roles/iam.workloadIdentityUser' --format='value(bindings.members)' 2>/dev/null \
+  | sed '/^[[:space:]]*$/d' | sort -u)
+[[ "${#WIF_MEMBERS[@]}" -eq 1 && "${WIF_MEMBERS[0]}" == "$EXPECTED_WIF_MEMBER" ]] || fatal "Production WIF impersonation boundary mismatch"
+pass "Production WIF impersonation boundary exact"
+
+mapfile -t DEPLOY_PROJECT_ROLES < <(project_roles_for "$EXPECTED_DEPLOY_SA")
+mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_DEPLOY_ROLES[@]}" | sort -u)
+[[ "$(printf '%s\n' "${DEPLOY_PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]] || fatal "deploy-SA project roles do not exactly match Block 3B.2B"
+pass "deploy-SA project roles exactly match Block 3B.2B"
+
+PROJECT_POLICY_JSON="$(gcloud projects get-iam-policy "$PROJECT_ID" --format=json 2>/dev/null || true)"
+[[ -n "$PROJECT_POLICY_JSON" ]] || fatal "project IAM policy could not be read"
+PROJECT_POLICY_JSON_INPUT="$PROJECT_POLICY_JSON" python3 - <<'PY' || fatal "project-wide roles/iam.serviceAccountUser exists"
+import json, os
+p=json.loads(os.environ['PROJECT_POLICY_JSON_INPUT'])
+assert not any(b.get('role') == 'roles/iam.serviceAccountUser' and b.get('members') for b in p.get('bindings', []))
+PY
+pass "no project-wide roles/iam.serviceAccountUser binding"
+if [[ "$PROJECT_POLICY_JSON" == *"clickandsaveai-staging"* || "$PROJECT_POLICY_JSON" == *"serviceAccount:clickandsaveai-github-deployer@clickandsaveai.iam.gserviceaccount.com"* ]]; then
+  fatal "staging/legacy principal reference present in Production project IAM"
+fi
+pass "staging/legacy deploy principal references absent"
+
+python3 - "$ROOT" <<'PY' || fatal "repository runtime/build identity configuration is not the proven Block 3B.3 shape"
+from pathlib import Path
+import json,re,sys
+root=Path(sys.argv[1])
+fb=json.loads((root/'firebase.json').read_text())
+fn=fb.get('functions',{})
+assert fn.get('source')=='functions'
+assert fn.get('codebase')=='default'
+assert fn.get('runtime')=='nodejs22'
+blob='\n'.join(p.read_text(errors='replace') for p in sorted((root/'functions'/'src').glob('*.js')))
+assert 'firebase-functions/v2' in blob
+for bad in ('firebase-functions/v1', 'serviceAccountEmail'):
+    assert bad not in blob, bad
+assert not re.search(r'\bserviceAccount\s*:', blob), 'custom runtime serviceAccount option present'
+# Reject old generation-specific module imports while allowing v2, params, logger.
+for m in re.findall(r'firebase-functions/([^"\'\s)]+)', blob):
+    if not (m.startswith('v2') or m.startswith('params') or m.startswith('logger')):
+        raise AssertionError(f'unproven firebase-functions import: {m}')
+wf=(root/'.github/workflows/production-release.yml').read_text()
+assert '--only firestore:rules,firestore:indexes,functions' in wf.replace('\\\n',' ').replace('  ',' '), 'production deployment surface mismatch'
+assert '--service-account' not in wf
+assert '--build-service-account' not in wf
+fb_text=(root/'firebase.json').read_text()
+assert 'serviceAccount' not in fb_text
+assert 'buildServiceAccount' not in fb_text
+PY
+pass "repository proves Firebase Functions v2 default runtime identity path and no custom build identity"
+
+RUNTIME_SA="${EXPECTED_PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+validate_production_sa_identity "runtime" "$RUNTIME_SA"
+ACTUAL_RUNTIME_EMAIL="$(gcloud iam service-accounts describe "$RUNTIME_SA" --project="$PROJECT_ID" --format='value(email)' 2>/dev/null || true)"
+[[ "$ACTUAL_RUNTIME_EMAIL" == "$RUNTIME_SA" ]] || fatal "runtime identity mismatch or absent: expected $RUNTIME_SA, observed ${ACTUAL_RUNTIME_EMAIL:-missing}"
+pass "runtime identity exists and matches repository-derived 2nd-gen default: $RUNTIME_SA"
+
+BUILD_ERR="$(mktemp)"
+trap 'rm -f "$BUILD_ERR"' EXIT
+set +e
+BUILD_RAW="$(gcloud builds get-default-service-account --project="$PROJECT_ID" --region="$EXPECTED_RUNTIME_REGION" --format='value(serviceAccountEmail)' 2>"$BUILD_ERR")"
+BUILD_STATUS=$?
+set -e
+if [[ "$BUILD_STATUS" -ne 0 ]]; then
+  BUILD_MESSAGE="$(tr '\n' ' ' < "$BUILD_ERR" | sed 's/[[:space:]]\+/ /g')"
+  fatal "Cloud Build default service-account discovery failed; no API was enabled. gcloud: ${BUILD_MESSAGE:-unknown error}"
+fi
+BUILD_SA="$(normalize_sa "$BUILD_RAW")"
+[[ -n "$BUILD_SA" ]] || fatal "Cloud Build default service-account discovery returned an empty identity; no API was enabled or substituted"
+validate_production_sa_identity "build" "$BUILD_SA"
+ACTUAL_BUILD_EMAIL="$(gcloud iam service-accounts describe "$BUILD_SA" --project="$PROJECT_ID" --format='value(email)' 2>/dev/null || true)"
+[[ "$ACTUAL_BUILD_EMAIL" == "$BUILD_SA" ]] || fatal "build identity mismatch or absent: discovered $BUILD_SA, describe observed ${ACTUAL_BUILD_EMAIL:-missing}"
+pass "Cloud Build default identity live-discovered with gcloud builds get-default-service-account: $BUILD_SA"
+
+for identity in "$RUNTIME_SA" "$BUILD_SA"; do
+  mapfile -t IDENTITY_ROLES < <(project_roles_for "$identity")
+  for role in "${IDENTITY_ROLES[@]}"; do
+    if contains "$role" "${DANGEROUS_IDENTITY_ROLES[@]}" || [[ "$role" =~ ^roles/.+\.serviceAgent$ ]]; then
+      fatal "discovered identity $identity holds unexpectedly dangerous project role: $role"
+    fi
+  done
+  printf 'INFO  identity project roles %s: %s\n' "$identity" "${IDENTITY_ROLES[*]:-(none)}"
+  POLICY="$(gcloud iam service-accounts get-iam-policy "$identity" --project="$PROJECT_ID" --format=json 2>/dev/null || true)"
+  [[ -n "$POLICY" ]] || fatal "unable to inspect service-account IAM policy for $identity"
+done
+pass "runtime/build identity risk audit found no forbidden broad project roles"
+
+mapfile -t PROJECT_SERVICE_ACCOUNTS < <(gcloud iam service-accounts list --project="$PROJECT_ID" --format='value(email)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
+contains "$RUNTIME_SA" "${PROJECT_SERVICE_ACCOUNTS[@]}" || fatal "runtime service account absent from Production service-account inventory"
+contains "$BUILD_SA" "${PROJECT_SERVICE_ACCOUNTS[@]}" || fatal "build service account absent from Production service-account inventory"
+
+INTENDED_SAS=("$RUNTIME_SA")
+[[ "$BUILD_SA" == "$RUNTIME_SA" ]] || INTENDED_SAS+=("$BUILD_SA")
+for sa in "${PROJECT_SERVICE_ACCOUNTS[@]}"; do
+  if sa_has_deployer_actas "$sa"; then
+    if contains "$sa" "${INTENDED_SAS[@]}"; then
+      pass "deploy SA actAs present only on intended identity: $sa"
+    else
+      fatal "deploy SA has accidental roles/iam.serviceAccountUser on unintended Production service account: $sa"
+    fi
+  fi
+done
+
+if [[ "$ALLOW_MISSING_ACTAS" == "1" ]]; then
+  pass "pre-mutation mode allows intended actAs bindings to be absent"
+else
+  for sa in "${INTENDED_SAS[@]}"; do
+    sa_has_deployer_actas "$sa" || fatal "missing deploy-SA roles/iam.serviceAccountUser on intended identity: $sa"
+  done
+  pass "deploy SA has roles/iam.serviceAccountUser on every and only intended runtime/build identity"
+fi
+
+DEPLOYMENTS_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments?environment=production&per_page=1"
+CURL_HEADERS=(-H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28')
+if [[ -n "${GH_TOKEN:-}" ]]; then CURL_HEADERS+=( -H "Authorization: Bearer ${GH_TOKEN}" );
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then CURL_HEADERS+=( -H "Authorization: Bearer ${GITHUB_TOKEN}" ); fi
+DEPLOYMENTS_JSON="$(curl -fsSL "${CURL_HEADERS[@]}" "$DEPLOYMENTS_URL" 2>/dev/null || true)"
+if [[ -n "$DEPLOYMENTS_JSON" ]] && printf '%s' "$DEPLOYMENTS_JSON" | python3 -c 'import json,sys; x=json.load(sys.stdin); sys.exit(0 if isinstance(x,list) and len(x)==0 else 1)'; then
+  pass "Production deployments = 0"
+else
+  fatal "unable to verify Production deployments = 0"
+fi
+
+if [[ -n "$DISCOVERY_OUTPUT" ]]; then
+  umask 077
+  printf 'RUNTIME_SA=%q\nBUILD_SA=%q\n' "$RUNTIME_SA" "$BUILD_SA" > "$DISCOVERY_OUTPUT"
+fi
+
+if (( FAILED != 0 )); then
+  printf '\nProduction runtime/build actAs verification FAILED.\n' >&2
+  exit 1
+fi
+printf '\nProduction runtime/build actAs verification PASSED.\n'
+printf 'runtimeServiceAccount=%s\n' "$RUNTIME_SA"
+printf 'buildServiceAccount=%s\n' "$BUILD_SA"
+printf 'productionDeployIamConfigured=true\n'
+if [[ "$ALLOW_MISSING_ACTAS" == "1" ]]; then
+  printf 'productionRuntimeBuildActAsConfigured=false\n'
+else
+  printf 'productionRuntimeBuildActAsConfigured=true\n'
+fi
+printf 'productionWifConfigured=true\n'
+printf 'productionWifEndToEndVerified=false\n'
+printf 'productionDeployEndToEndReady=false\n'
+printf 'productionIdentityReady=false\n'
+printf 'productionDeployed=false\n'

--- a/scripts/verify-production-runtime-build-actas.sh
+++ b/scripts/verify-production-runtime-build-actas.sh
@@ -1,280 +1,102 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-EXPECTED_PROJECT_ID="click-save-ai-production"
-EXPECTED_PROJECT_NUMBER="991489557172"
-EXPECTED_DEPLOY_SA="clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com"
-EXPECTED_POOL_ID="github-actions"
-EXPECTED_PROVIDER_ID="clickandsaveai-production"
-EXPECTED_WIF_PROVIDER="projects/991489557172/locations/global/workloadIdentityPools/github-actions/providers/clickandsaveai-production"
-EXPECTED_RUNTIME_REGION="europe-west1"
-GITHUB_REPOSITORY_ID="1314210715"
-GITHUB_REPOSITORY_OWNER_ID="64756523"
-GITHUB_ENVIRONMENT="production"
-GITHUB_REF="refs/heads/main"
-GITHUB_WORKFLOW_REF="vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main"
-GITHUB_OIDC_ISSUER="https://token.actions.githubusercontent.com"
-EXPECTED_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.repository_owner_id=assertion.repository_owner_id,attribute.environment=assertion.environment,attribute.ref=assertion.ref,attribute.workflow_ref=assertion.workflow_ref"
-EXPECTED_CONDITION="attribute.repository_id=='${GITHUB_REPOSITORY_ID}' && attribute.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && attribute.environment=='${GITHUB_ENVIRONMENT}' && attribute.ref=='${GITHUB_REF}' && attribute.workflow_ref=='${GITHUB_WORKFLOW_REF}'"
-EXPECTED_WIF_MEMBER="principalSet://iam.googleapis.com/projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${EXPECTED_POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
-GITHUB_REPOSITORY="vhanukaev1981/ClickAndSaveAI"
-PROJECT_ID="${PROJECT_ID:-$EXPECTED_PROJECT_ID}"
-ALLOW_MISSING_ACTAS="${ALLOW_MISSING_ACTAS:-0}"
-DISCOVERY_OUTPUT="${DISCOVERY_OUTPUT:-}"
+P=click-save-ai-production; N=991489557172
+DEPLOY="clickandsaveai-github-deployer@$P.iam.gserviceaccount.com"
+POOL=github-actions; PROVIDER=clickandsaveai-production; REGION=europe-west1
+WIF_PROVIDER="projects/$N/locations/global/workloadIdentityPools/$POOL/providers/$PROVIDER"
+RID=1314210715; OID=64756523; ENV=production; REF=refs/heads/main
+WF='vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main'
+ISSUER=https://token.actions.githubusercontent.com
+MAPPING='google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.repository_owner_id=assertion.repository_owner_id,attribute.environment=assertion.environment,attribute.ref=assertion.ref,attribute.workflow_ref=assertion.workflow_ref'
+CONDITION="attribute.repository_id=='$RID' && attribute.repository_owner_id=='$OID' && attribute.environment=='$ENV' && attribute.ref=='$REF' && attribute.workflow_ref=='$WF'"
+WIF_MEMBER="principalSet://iam.googleapis.com/projects/$N/locations/global/workloadIdentityPools/$POOL/attribute.repository_id/$RID"
+REPO=vhanukaev1981/ClickAndSaveAI
+PROJECT_ID="${PROJECT_ID:-$P}"; ALLOW_MISSING_ACTAS="${ALLOW_MISSING_ACTAS:-0}"; DISCOVERY_OUTPUT="${DISCOVERY_OUTPUT:-}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-
-INTENDED_DEPLOY_ROLES=(
-  roles/cloudfunctions.developer
-  roles/firebaserules.admin
-  roles/datastore.indexAdmin
-  roles/serviceusage.serviceUsageConsumer
-)
-DANGEROUS_IDENTITY_ROLES=(
-  roles/owner
-  roles/editor
-  roles/firebase.admin
-  roles/firebase.developAdmin
-  roles/cloudfunctions.admin
-  roles/run.admin
-  roles/resourcemanager.projectIamAdmin
-  roles/iam.serviceAccountAdmin
-  roles/iam.serviceAccountTokenCreator
-  roles/iam.serviceAccountUser
-  roles/secretmanager.admin
-  roles/storage.admin
-  roles/artifactregistry.admin
-)
-
-FAILED=0
-pass() { printf 'PASS  %s\n' "$*"; }
-fail() { printf 'FAIL  %s\n' "$*" >&2; FAILED=1; }
-fatal() { printf 'FAIL  %s\n' "$*" >&2; exit 1; }
-contains() {
-  local needle="$1"; shift
-  local item
-  for item in "$@"; do [[ "$item" == "$needle" ]] && return 0; done
-  return 1
-}
-normalize_sa() {
-  local value="$1"
-  value="${value//$'\r'/}"
-  value="${value//$'\n'/}"
-  value="${value#projects/${PROJECT_ID}/serviceAccounts/}"
-  printf '%s' "$value"
-}
-validate_production_sa_identity() {
-  local label="$1" sa="$2"
-  [[ -n "$sa" ]] || fatal "$label identity is empty."
-  [[ "$sa" != *"clickandsaveai-staging"* && "$sa" != *"@clickandsaveai."* ]] || fatal "$label identity references staging/legacy project: $sa"
-  case "$sa" in
-    "${EXPECTED_PROJECT_NUMBER}-compute@developer.gserviceaccount.com") ;;
-    "${EXPECTED_PROJECT_NUMBER}@cloudbuild.gserviceaccount.com") ;;
-    *"@${EXPECTED_PROJECT_ID}.iam.gserviceaccount.com") ;;
-    *) fatal "$label identity is not provably owned by Production project $EXPECTED_PROJECT_ID/$EXPECTED_PROJECT_NUMBER: $sa" ;;
-  esac
-}
-project_roles_for() {
-  local sa="$1"
-  gcloud projects get-iam-policy "$PROJECT_ID" \
-    --flatten='bindings[].members' \
-    --filter="bindings.members=serviceAccount:${sa}" \
-    --format='value(bindings.role)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u
-}
-sa_has_deployer_actas() {
-  local sa="$1"
-  gcloud iam service-accounts get-iam-policy "$sa" --project="$PROJECT_ID" \
-    --flatten='bindings[].members' \
-    --filter="bindings.role=roles/iam.serviceAccountUser AND bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
-    --format='value(bindings.members)' 2>/dev/null | sed '/^[[:space:]]*$/d' | grep -Fqx "serviceAccount:${EXPECTED_DEPLOY_SA}"
-}
-
-case "$PROJECT_ID" in
-  clickandsaveai|clickandsaveai-staging) fatal "forbidden non-Production project: $PROJECT_ID" ;;
-esac
-[[ "$PROJECT_ID" == "$EXPECTED_PROJECT_ID" ]] || fatal "PROJECT_ID must be exactly $EXPECTED_PROJECT_ID"
-[[ "$ALLOW_MISSING_ACTAS" == "0" || "$ALLOW_MISSING_ACTAS" == "1" ]] || fatal "ALLOW_MISSING_ACTAS must be 0 or 1"
-command -v gcloud >/dev/null 2>&1 || fatal "gcloud is required"
-command -v python3 >/dev/null 2>&1 || fatal "python3 is required"
-command -v curl >/dev/null 2>&1 || fatal "curl is required"
-
-ACTIVE_ACCOUNT="$(gcloud auth list --filter='status:ACTIVE' --format='value(account)' 2>/dev/null | head -n 1)"
-[[ -n "$ACTIVE_ACCOUNT" ]] || fatal "no active gcloud account"
-
-ACTUAL_PROJECT_ID="$(gcloud projects describe "$PROJECT_ID" --format='value(projectId)' 2>/dev/null || true)"
-ACTUAL_PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)' 2>/dev/null || true)"
-[[ "$ACTUAL_PROJECT_ID" == "$EXPECTED_PROJECT_ID" ]] && pass "Project ID exact" || fail "Project ID mismatch: ${ACTUAL_PROJECT_ID:-missing}"
-[[ "$ACTUAL_PROJECT_NUMBER" == "$EXPECTED_PROJECT_NUMBER" ]] && pass "Project Number exact" || fail "Project Number mismatch: ${ACTUAL_PROJECT_NUMBER:-missing}"
-[[ "$ACTUAL_PROJECT_ID" == "$EXPECTED_PROJECT_ID" && "$ACTUAL_PROJECT_NUMBER" == "$EXPECTED_PROJECT_NUMBER" ]] || fatal "Production project lock failed before identity discovery."
-
-ACTUAL_DEPLOY_SA="$(gcloud iam service-accounts describe "$EXPECTED_DEPLOY_SA" --project="$PROJECT_ID" --format='value(email)' 2>/dev/null || true)"
-[[ "$ACTUAL_DEPLOY_SA" == "$EXPECTED_DEPLOY_SA" ]] && pass "deploy SA exact" || fatal "deploy SA mismatch or missing"
-USER_KEY_COUNT="$(gcloud iam service-accounts keys list --iam-account="$EXPECTED_DEPLOY_SA" --managed-by=user --format='value(name)' 2>/dev/null | sed '/^[[:space:]]*$/d' | wc -l | tr -d '[:space:]')"
-[[ "$USER_KEY_COUNT" == "0" ]] && pass "user-managed deploy-SA key count = 0" || fatal "deploy SA has user-managed keys: $USER_KEY_COUNT"
-
-mapfile -t PROVIDER_IDS < <(gcloud iam workload-identity-pools providers list \
-  --project="$PROJECT_ID" --location=global --workload-identity-pool="$EXPECTED_POOL_ID" \
-  --format='value(name)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sed 's#^.*/##')
-[[ "${#PROVIDER_IDS[@]}" -eq 1 && "${PROVIDER_IDS[0]}" == "$EXPECTED_PROVIDER_ID" ]] || fatal "Production WIF provider inventory mismatch"
-PROVIDER_JSON="$(gcloud iam workload-identity-pools providers describe "$EXPECTED_PROVIDER_ID" \
-  --project="$PROJECT_ID" --location=global --workload-identity-pool="$EXPECTED_POOL_ID" --format=json 2>/dev/null || true)"
-[[ -n "$PROVIDER_JSON" ]] || fatal "Production WIF provider missing"
-PROVIDER_JSON_INPUT="$PROVIDER_JSON" python3 - "$EXPECTED_WIF_PROVIDER" "$GITHUB_OIDC_ISSUER" "$EXPECTED_MAPPING" "$EXPECTED_CONDITION" <<'PY' || fatal "Production WIF provider boundary mismatch"
-import json, os, sys
-expected_name, expected_issuer, mapping_csv, expected_condition = sys.argv[1:]
-p = json.loads(os.environ['PROVIDER_JSON_INPUT'])
-expected_mapping = dict(x.split('=',1) for x in mapping_csv.split(','))
-assert p.get('name') == expected_name
-assert str(p.get('disabled', False)).lower() == 'false'
-assert p.get('oidc', {}).get('issuerUri') == expected_issuer
-assert p.get('attributeMapping', {}) == expected_mapping
-assert p.get('attributeCondition', '') == expected_condition
+DEPLOY_ROLES=(roles/cloudfunctions.developer roles/firebaserules.admin roles/datastore.indexAdmin roles/serviceusage.serviceUsageConsumer)
+BAD_ROLES=(roles/owner roles/editor roles/firebase.admin roles/firebase.developAdmin roles/cloudfunctions.admin roles/run.admin roles/resourcemanager.projectIamAdmin roles/iam.serviceAccountAdmin roles/iam.serviceAccountTokenCreator roles/iam.serviceAccountUser roles/secretmanager.admin roles/storage.admin roles/artifactregistry.admin)
+pass(){ printf 'PASS  %s\n' "$*"; }; fatal(){ printf 'FAIL  %s\n' "$*" >&2; exit 1; }
+contains(){ local n="$1" x; shift; for x in "$@"; do [[ "$x" == "$n" ]] && return 0; done; return 1; }
+add_unique(){ local v="$1" n="$2" x; local -n a="$n"; for x in "${a[@]:-}"; do [[ "$x" == "$v" ]] && return; done; a+=("$v"); }
+roles_for(){ gcloud projects get-iam-policy "$PROJECT_ID" --flatten='bindings[].members' --filter="bindings.members=serviceAccount:$1" --format='value(bindings.role)' 2>/dev/null|sed '/^$/d'|sort -u; }
+has_actas(){ gcloud iam service-accounts get-iam-policy "$1" --project="$PROJECT_ID" --flatten='bindings[].members' --filter="bindings.role=roles/iam.serviceAccountUser AND bindings.members=serviceAccount:$DEPLOY" --format='value(bindings.members)' 2>/dev/null|grep -Fqx "serviceAccount:$DEPLOY"; }
+valid_sa(){ local s="$1"; [[ -n "$s" && "$s" != *clickandsaveai-staging* && "$s" != *@clickandsaveai.* ]]||fatal "invalid Production service account: $s"; case "$s" in "$P@appspot.gserviceaccount.com"|"$N-compute@developer.gserviceaccount.com"|"$N@cloudbuild.gserviceaccount.com"|*"@$P.iam.gserviceaccount.com") :;; *) fatal "identity is not owned by Production: $s";; esac; }
+case "$PROJECT_ID" in clickandsaveai|clickandsaveai-staging) fatal "forbidden non-Production project: $PROJECT_ID";; esac
+[[ "$PROJECT_ID" == "$P" ]]||fatal "PROJECT_ID must be exactly $P"; [[ "$ALLOW_MISSING_ACTAS" =~ ^[01]$ ]]||fatal 'ALLOW_MISSING_ACTAS must be 0 or 1'
+for c in gcloud python3 curl; do command -v "$c" >/dev/null||fatal "$c is required"; done
+[[ -n "$(gcloud auth list --filter='status:ACTIVE' --format='value(account)' 2>/dev/null|head -1)" ]]||fatal 'no active gcloud account'
+PID="$(gcloud projects describe "$P" --format='value(projectId)' 2>/dev/null||true)"; PNUM="$(gcloud projects describe "$P" --format='value(projectNumber)' 2>/dev/null||true)"
+[[ "$PID" == "$P" ]]||fatal "Project ID mismatch: ${PID:-missing}"; [[ "$PNUM" == "$N" ]]||fatal "Project Number mismatch: ${PNUM:-missing}"; pass 'Project ID/Number exact'
+[[ "$(gcloud iam service-accounts describe "$DEPLOY" --project="$P" --format='value(email)' 2>/dev/null||true)" == "$DEPLOY" ]]||fatal 'deploy SA mismatch or missing'; pass 'deploy SA exact'
+KC="$(gcloud iam service-accounts keys list --iam-account="$DEPLOY" --managed-by=user --format='value(name)' 2>/dev/null|sed '/^$/d'|wc -l|tr -d '[:space:]')"; [[ "$KC" == 0 ]]||fatal "deploy SA has user-managed keys: $KC"; pass 'user-managed deploy-SA key count = 0'
+mapfile -t PIDS < <(gcloud iam workload-identity-pools providers list --project="$P" --location=global --workload-identity-pool="$POOL" --format='value(name)' 2>/dev/null|sed '/^$/d;s#^.*/##')
+[[ ${#PIDS[@]} -eq 1 && "${PIDS[0]}" == "$PROVIDER" ]]||fatal 'Production WIF provider inventory mismatch'
+PJ="$(gcloud iam workload-identity-pools providers describe "$PROVIDER" --project="$P" --location=global --workload-identity-pool="$POOL" --format=json 2>/dev/null||true)"; [[ -n "$PJ" ]]||fatal 'Production WIF provider missing'
+PJ="$PJ" python3 - "$WIF_PROVIDER" "$ISSUER" "$MAPPING" "$CONDITION" <<'PY' || fatal 'Production WIF provider boundary mismatch'
+import json,os,sys
+n,i,m,c=sys.argv[1:]; p=json.loads(os.environ['PJ']); mm=dict(x.split('=',1) for x in m.split(','))
+assert p.get('name')==n and str(p.get('disabled',False)).lower()=='false' and p.get('oidc',{}).get('issuerUri')==i and p.get('attributeMapping',{})==mm and p.get('attributeCondition','')==c
 PY
-pass "Production WIF provider exact and enabled"
-mapfile -t WIF_MEMBERS < <(gcloud iam service-accounts get-iam-policy "$EXPECTED_DEPLOY_SA" \
-  --project="$PROJECT_ID" --flatten='bindings[].members' \
-  --filter='bindings.role=roles/iam.workloadIdentityUser' --format='value(bindings.members)' 2>/dev/null \
-  | sed '/^[[:space:]]*$/d' | sort -u)
-[[ "${#WIF_MEMBERS[@]}" -eq 1 && "${WIF_MEMBERS[0]}" == "$EXPECTED_WIF_MEMBER" ]] || fatal "Production WIF impersonation boundary mismatch"
-pass "Production WIF impersonation boundary exact"
-
-mapfile -t DEPLOY_PROJECT_ROLES < <(project_roles_for "$EXPECTED_DEPLOY_SA")
-mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_DEPLOY_ROLES[@]}" | sort -u)
-[[ "$(printf '%s\n' "${DEPLOY_PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]] || fatal "deploy-SA project roles do not exactly match Block 3B.2B"
-pass "deploy-SA project roles exactly match Block 3B.2B"
-
-PROJECT_POLICY_JSON="$(gcloud projects get-iam-policy "$PROJECT_ID" --format=json 2>/dev/null || true)"
-[[ -n "$PROJECT_POLICY_JSON" ]] || fatal "project IAM policy could not be read"
-PROJECT_POLICY_JSON_INPUT="$PROJECT_POLICY_JSON" python3 - <<'PY' || fatal "project-wide roles/iam.serviceAccountUser exists"
-import json, os
-p=json.loads(os.environ['PROJECT_POLICY_JSON_INPUT'])
-assert not any(b.get('role') == 'roles/iam.serviceAccountUser' and b.get('members') for b in p.get('bindings', []))
+pass 'Production WIF provider exact and enabled'
+mapfile -t WM < <(gcloud iam service-accounts get-iam-policy "$DEPLOY" --project="$P" --flatten='bindings[].members' --filter='bindings.role=roles/iam.workloadIdentityUser' --format='value(bindings.members)' 2>/dev/null|sed '/^$/d'|sort -u)
+[[ ${#WM[@]} -eq 1 && "${WM[0]}" == "$WIF_MEMBER" ]]||fatal 'Production WIF impersonation boundary mismatch'; pass 'Production WIF impersonation boundary exact'
+mapfile -t DR < <(roles_for "$DEPLOY"); mapfile -t ER < <(printf '%s\n' "${DEPLOY_ROLES[@]}"|sort -u); [[ "$(printf '%s\n' "${DR[@]}")" == "$(printf '%s\n' "${ER[@]}")" ]]||fatal 'deploy-SA project roles do not exactly match Block 3B.2B'; pass 'deploy-SA project roles exactly match Block 3B.2B'
+POL="$(gcloud projects get-iam-policy "$P" --format=json 2>/dev/null||true)"; [[ -n "$POL" ]]||fatal 'project IAM policy unreadable'
+POL="$POL" python3 - <<'PY' || fatal 'project-wide roles/iam.serviceAccountUser exists'
+import json,os
+p=json.loads(os.environ['POL']); assert not any(b.get('role')=='roles/iam.serviceAccountUser' and b.get('members') for b in p.get('bindings',[]))
 PY
-pass "no project-wide roles/iam.serviceAccountUser binding"
-if [[ "$PROJECT_POLICY_JSON" == *"clickandsaveai-staging"* || "$PROJECT_POLICY_JSON" == *"serviceAccount:clickandsaveai-github-deployer@clickandsaveai.iam.gserviceaccount.com"* ]]; then
-  fatal "staging/legacy principal reference present in Production project IAM"
-fi
-pass "staging/legacy deploy principal references absent"
+[[ "$POL" != *clickandsaveai-staging* && "$POL" != *'serviceAccount:clickandsaveai-github-deployer@clickandsaveai.iam.gserviceaccount.com'* ]]||fatal 'staging/legacy deploy principal reference present'; pass 'no project-wide SA User; staging/legacy deploy principal references absent'
 
-python3 - "$ROOT" <<'PY' || fatal "repository runtime/build identity configuration is not the proven Block 3B.3 shape"
+A="$(python3 - "$ROOT" <<'PY'
 from pathlib import Path
 import json,re,sys
-root=Path(sys.argv[1])
-fb=json.loads((root/'firebase.json').read_text())
-fn=fb.get('functions',{})
-assert fn.get('source')=='functions'
-assert fn.get('codebase')=='default'
-assert fn.get('runtime')=='nodejs22'
-blob='\n'.join(p.read_text(errors='replace') for p in sorted((root/'functions'/'src').glob('*.js')))
-assert 'firebase-functions/v2' in blob
-for bad in ('firebase-functions/v1', 'serviceAccountEmail'):
-    assert bad not in blob, bad
-assert not re.search(r'\bserviceAccount\s*:', blob), 'custom runtime serviceAccount option present'
-# Reject old generation-specific module imports while allowing v2, params, logger.
-for m in re.findall(r'firebase-functions/([^"\'\s)]+)', blob):
-    if not (m.startswith('v2') or m.startswith('params') or m.startswith('logger')):
-        raise AssertionError(f'unproven firebase-functions import: {m}')
-wf=(root/'.github/workflows/production-release.yml').read_text()
-assert '--only firestore:rules,firestore:indexes,functions' in wf.replace('\\\n',' ').replace('  ',' '), 'production deployment surface mismatch'
-assert '--service-account' not in wf
-assert '--build-service-account' not in wf
-fb_text=(root/'firebase.json').read_text()
-assert 'serviceAccount' not in fb_text
-assert 'buildServiceAccount' not in fb_text
+r=Path(sys.argv[1]).resolve(); f=json.loads((r/'firebase.json').read_text()); fn=f.get('functions',{})
+assert isinstance(fn,dict) and fn.get('source')=='functions' and fn.get('codebase')=='default' and fn.get('runtime')=='nodejs22'
+def bad(v):
+ if isinstance(v,dict): return any(re.sub('[^a-z]','',str(k).lower()) in {'serviceaccount','serviceaccountemail','buildserviceaccount'} or bad(x) for k,x in v.items())
+ if isinstance(v,list): return any(map(bad,v))
+ return False
+assert not bad(f),'custom Firebase service-account configuration present'
+pkg=json.loads((r/'functions/package.json').read_text()); main=pkg.get('main'); assert isinstance(main,str) and main
+entry=(r/'functions'/main).resolve(); src=(r/'functions/src').resolve(); assert entry.is_file() and (entry.parent==src or src in entry.parents)
+IR=re.compile(r'''(?:require\s*\(\s*|\bfrom\s*)["'](firebase-functions(?:/[^"']+)?)['"]\s*\)?''')
+def cl(s):
+ if s=='firebase-functions/v1' or s.startswith('firebase-functions/v1/'): return 'v1'
+ if s=='firebase-functions/v2' or s.startswith('firebase-functions/v2/'): return 'v2'
+ return 'neutral'
+imports=[]
+for p in sorted(src.rglob('*.js')):
+ for s in IR.findall(p.read_text(errors='replace')): imports.append((p.relative_to(r).as_posix(),s,cl(s)))
+t=entry.read_text(errors='replace'); binds={}
+for n,q in re.findall(r'''\bconst\s+([\w$]+)\s*=\s*require\s*\(\s*["'](\./[^"']+)["']\s*\)''',t):
+ p=(entry.parent/q); p=p if p.suffix else p.with_suffix('.js'); binds[n]=p.resolve()
+m=re.search(r'module\.exports\s*=\s*\{(.*?)\}\s*;',t,re.S); assert m
+names=re.findall(r'\.\.\.\s*([\w$]+)',m.group(1)); assert names
+deployed=[]
+for n in names:
+ assert n in binds and binds[n].is_file(); rel=binds[n].relative_to(r).as_posix(); deployed.append(rel) if rel not in deployed else None
+if re.search(r'\bexports\.[\w$]+\s*=|\bmodule\.exports\.[\w$]+\s*=',t): deployed.append(entry.relative_to(r).as_posix())
+g=set(); so=re.compile(r'\b(?:serviceAccount|serviceAccountEmail)\s*:')
+for rel in deployed:
+ x=(r/rel).read_text(errors='replace'); assert not so.search(x),f'custom runtime service account option in deployed module: {rel}'
+ e={cl(s) for s in IR.findall(x)}&{'v1','v2'}; assert e,f'unable to prove Firebase Functions generation for exported module: {rel}'; g|=e
+assert g
+wf=(r/'.github/workflows/production-release.yml').read_text(); z=re.sub(r'\\\n\s*',' ',wf); z=re.sub(r'\s+',' ',z)
+assert '--only firestore:rules,firestore:indexes,functions' in z and '--service-account' not in wf and '--build-service-account' not in wf
+print(','.join(sorted(g))); print('|'.join(f'{a}->{b}->{c}' for a,b,c in imports))
 PY
-pass "repository proves Firebase Functions v2 default runtime identity path and no custom build identity"
-
-RUNTIME_SA="${EXPECTED_PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
-validate_production_sa_identity "runtime" "$RUNTIME_SA"
-ACTUAL_RUNTIME_EMAIL="$(gcloud iam service-accounts describe "$RUNTIME_SA" --project="$PROJECT_ID" --format='value(email)' 2>/dev/null || true)"
-[[ "$ACTUAL_RUNTIME_EMAIL" == "$RUNTIME_SA" ]] || fatal "runtime identity mismatch or absent: expected $RUNTIME_SA, observed ${ACTUAL_RUNTIME_EMAIL:-missing}"
-pass "runtime identity exists and matches repository-derived 2nd-gen default: $RUNTIME_SA"
-
-BUILD_ERR="$(mktemp)"
-trap 'rm -f "$BUILD_ERR"' EXIT
-set +e
-BUILD_RAW="$(gcloud builds get-default-service-account --project="$PROJECT_ID" --region="$EXPECTED_RUNTIME_REGION" --format='value(serviceAccountEmail)' 2>"$BUILD_ERR")"
-BUILD_STATUS=$?
-set -e
-if [[ "$BUILD_STATUS" -ne 0 ]]; then
-  BUILD_MESSAGE="$(tr '\n' ' ' < "$BUILD_ERR" | sed 's/[[:space:]]\+/ /g')"
-  fatal "Cloud Build default service-account discovery failed; no API was enabled. gcloud: ${BUILD_MESSAGE:-unknown error}"
-fi
-BUILD_SA="$(normalize_sa "$BUILD_RAW")"
-[[ -n "$BUILD_SA" ]] || fatal "Cloud Build default service-account discovery returned an empty identity; no API was enabled or substituted"
-validate_production_sa_identity "build" "$BUILD_SA"
-ACTUAL_BUILD_EMAIL="$(gcloud iam service-accounts describe "$BUILD_SA" --project="$PROJECT_ID" --format='value(email)' 2>/dev/null || true)"
-[[ "$ACTUAL_BUILD_EMAIL" == "$BUILD_SA" ]] || fatal "build identity mismatch or absent: discovered $BUILD_SA, describe observed ${ACTUAL_BUILD_EMAIL:-missing}"
-pass "Cloud Build default identity live-discovered with gcloud builds get-default-service-account: $BUILD_SA"
-
-for identity in "$RUNTIME_SA" "$BUILD_SA"; do
-  mapfile -t IDENTITY_ROLES < <(project_roles_for "$identity")
-  for role in "${IDENTITY_ROLES[@]}"; do
-    if contains "$role" "${DANGEROUS_IDENTITY_ROLES[@]}" || [[ "$role" =~ ^roles/.+\.serviceAgent$ ]]; then
-      fatal "discovered identity $identity holds unexpectedly dangerous project role: $role"
-    fi
-  done
-  printf 'INFO  identity project roles %s: %s\n' "$identity" "${IDENTITY_ROLES[*]:-(none)}"
-  POLICY="$(gcloud iam service-accounts get-iam-policy "$identity" --project="$PROJECT_ID" --format=json 2>/dev/null || true)"
-  [[ -n "$POLICY" ]] || fatal "unable to inspect service-account IAM policy for $identity"
-done
-pass "runtime/build identity risk audit found no forbidden broad project roles"
-
-mapfile -t PROJECT_SERVICE_ACCOUNTS < <(gcloud iam service-accounts list --project="$PROJECT_ID" --format='value(email)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
-contains "$RUNTIME_SA" "${PROJECT_SERVICE_ACCOUNTS[@]}" || fatal "runtime service account absent from Production service-account inventory"
-contains "$BUILD_SA" "${PROJECT_SERVICE_ACCOUNTS[@]}" || fatal "build service account absent from Production service-account inventory"
-
-INTENDED_SAS=("$RUNTIME_SA")
-[[ "$BUILD_SA" == "$RUNTIME_SA" ]] || INTENDED_SAS+=("$BUILD_SA")
-for sa in "${PROJECT_SERVICE_ACCOUNTS[@]}"; do
-  if sa_has_deployer_actas "$sa"; then
-    if contains "$sa" "${INTENDED_SAS[@]}"; then
-      pass "deploy SA actAs present only on intended identity: $sa"
-    else
-      fatal "deploy SA has accidental roles/iam.serviceAccountUser on unintended Production service account: $sa"
-    fi
-  fi
-done
-
-if [[ "$ALLOW_MISSING_ACTAS" == "1" ]]; then
-  pass "pre-mutation mode allows intended actAs bindings to be absent"
-else
-  for sa in "${INTENDED_SAS[@]}"; do
-    sa_has_deployer_actas "$sa" || fatal "missing deploy-SA roles/iam.serviceAccountUser on intended identity: $sa"
-  done
-  pass "deploy SA has roles/iam.serviceAccountUser on every and only intended runtime/build identity"
-fi
-
-DEPLOYMENTS_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments?environment=production&per_page=1"
-CURL_HEADERS=(-H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28')
-if [[ -n "${GH_TOKEN:-}" ]]; then CURL_HEADERS+=( -H "Authorization: Bearer ${GH_TOKEN}" );
-elif [[ -n "${GITHUB_TOKEN:-}" ]]; then CURL_HEADERS+=( -H "Authorization: Bearer ${GITHUB_TOKEN}" ); fi
-DEPLOYMENTS_JSON="$(curl -fsSL "${CURL_HEADERS[@]}" "$DEPLOYMENTS_URL" 2>/dev/null || true)"
-if [[ -n "$DEPLOYMENTS_JSON" ]] && printf '%s' "$DEPLOYMENTS_JSON" | python3 -c 'import json,sys; x=json.load(sys.stdin); sys.exit(0 if isinstance(x,list) and len(x)==0 else 1)'; then
-  pass "Production deployments = 0"
-else
-  fatal "unable to verify Production deployments = 0"
-fi
-
-if [[ -n "$DISCOVERY_OUTPUT" ]]; then
-  umask 077
-  printf 'RUNTIME_SA=%q\nBUILD_SA=%q\n' "$RUNTIME_SA" "$BUILD_SA" > "$DISCOVERY_OUTPUT"
-fi
-
-if (( FAILED != 0 )); then
-  printf '\nProduction runtime/build actAs verification FAILED.\n' >&2
-  exit 1
-fi
-printf '\nProduction runtime/build actAs verification PASSED.\n'
-printf 'runtimeServiceAccount=%s\n' "$RUNTIME_SA"
-printf 'buildServiceAccount=%s\n' "$BUILD_SA"
-printf 'productionDeployIamConfigured=true\n'
-if [[ "$ALLOW_MISSING_ACTAS" == "1" ]]; then
-  printf 'productionRuntimeBuildActAsConfigured=false\n'
-else
-  printf 'productionRuntimeBuildActAsConfigured=true\n'
-fi
-printf 'productionWifConfigured=true\n'
-printf 'productionWifEndToEndVerified=false\n'
-printf 'productionDeployEndToEndReady=false\n'
-printf 'productionIdentityReady=false\n'
-printf 'productionDeployed=false\n'
+)"||fatal 'repository runtime/build identity configuration is not the proven Block 3B.3A shape'
+GENS="${A%%$'\n'*}"; IMPORTS="${A#*$'\n'}"; printf 'INFO  deployed Firebase Functions generations: %s\n' "$GENS"; printf 'INFO  firebase-functions imports: %s\n' "$IMPORTS"; pass 'repository export surface/generations proven from configured entry point'
+RUNTIME_SAS=(); [[ ",$GENS," == *,v1,* ]]&&add_unique "$P@appspot.gserviceaccount.com" RUNTIME_SAS; [[ ",$GENS," == *,v2,* ]]&&add_unique "$N-compute@developer.gserviceaccount.com" RUNTIME_SAS; [[ ${#RUNTIME_SAS[@]} -gt 0 ]]||fatal 'no required runtime identity derived'
+for s in "${RUNTIME_SAS[@]}"; do valid_sa "$s"; [[ "$(gcloud iam service-accounts describe "$s" --project="$P" --format='value(email)' 2>/dev/null||true)" == "$s" ]]||fatal "runtime identity mismatch or absent: $s"; pass "required runtime identity exists: $s"; done
+BE="$(mktemp)"; trap 'rm -f "$BE"' EXIT; set +e; BR="$(gcloud builds get-default-service-account --project="$P" --region="$REGION" --format='value(serviceAccountEmail)' 2>"$BE")"; BS=$?; set -e
+[[ $BS -eq 0 ]]||fatal "Cloud Build default service-account discovery failed; no API was enabled. gcloud: $(tr '\n' ' '<"$BE")"; BUILD_SA="${BR#projects/$P/serviceAccounts/}"; BUILD_SA="${BUILD_SA//$'\r'/}"; BUILD_SA="${BUILD_SA//$'\n'/}"; [[ -n "$BUILD_SA" ]]||fatal 'Cloud Build discovery returned an empty identity; no API was enabled or substituted'; valid_sa "$BUILD_SA"; [[ "$(gcloud iam service-accounts describe "$BUILD_SA" --project="$P" --format='value(email)' 2>/dev/null||true)" == "$BUILD_SA" ]]||fatal "build identity mismatch or absent: $BUILD_SA"; pass "Cloud Build identity live-discovered: $BUILD_SA"
+INTENDED=(); for s in "${RUNTIME_SAS[@]}"; do add_unique "$s" INTENDED; done; add_unique "$BUILD_SA" INTENDED
+for s in "${INTENDED[@]}"; do mapfile -t RR < <(roles_for "$s"); for q in "${RR[@]}"; do (contains "$q" "${BAD_ROLES[@]}"||[[ "$q" =~ ^roles/.+\.serviceAgent$ ]])&&fatal "discovered identity $s holds forbidden role: $q"; done; [[ -n "$(gcloud iam service-accounts get-iam-policy "$s" --project="$P" --format=json 2>/dev/null||true)" ]]||fatal "unable to inspect SA IAM policy: $s"; done; pass 'runtime/build identity risk audit passed'
+mapfile -t ALL < <(gcloud iam service-accounts list --project="$P" --format='value(email)' 2>/dev/null|sed '/^$/d'|sort -u); for s in "${INTENDED[@]}"; do contains "$s" "${ALL[@]}"||fatal "required identity absent from Production inventory: $s"; done
+for s in "${ALL[@]}"; do if has_actas "$s"; then contains "$s" "${INTENDED[@]}"||fatal "accidental actAs on unintended Production SA: $s"; fi; done
+if [[ "$ALLOW_MISSING_ACTAS" == 0 ]]; then for s in "${INTENDED[@]}"; do has_actas "$s"||fatal "missing deploy-SA roles/iam.serviceAccountUser on intended identity: $s"; done; pass 'actAs exact on intended runtime/build identities'; else pass 'pre-mutation mode allows intended actAs bindings absent'; fi
+URL="https://api.github.com/repos/$REPO/deployments?environment=production&per_page=1"; H=(-H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28'); [[ -n "${GH_TOKEN:-}" ]]&&H+=(-H "Authorization: Bearer $GH_TOKEN"); [[ -z "${GH_TOKEN:-}" && -n "${GITHUB_TOKEN:-}" ]]&&H+=(-H "Authorization: Bearer $GITHUB_TOKEN"); D="$(curl -fsSL "${H[@]}" "$URL" 2>/dev/null||true)"; [[ -n "$D" ]]&&printf '%s' "$D"|python3 -c 'import json,sys;x=json.load(sys.stdin);assert isinstance(x,list) and not x' || fatal 'unable to verify Production deployments = 0'; pass 'Production deployments = 0'
+if [[ -n "$DISCOVERY_OUTPUT" ]]; then umask 077; { printf 'RUNTIME_SAS=('; for s in "${RUNTIME_SAS[@]}"; do printf ' %q' "$s"; done; printf ' )\nBUILD_SA=%q\n' "$BUILD_SA"; } >"$DISCOVERY_OUTPUT"; fi
+printf '\nProduction runtime/build actAs verification PASSED.\n'; printf 'runtimeServiceAccounts=%s\n' "$(IFS=,;printf '%s' "${RUNTIME_SAS[*]}")"; printf 'buildServiceAccount=%s\n' "$BUILD_SA"; printf 'productionDeployIamConfigured=true\n'; [[ "$ALLOW_MISSING_ACTAS" == 1 ]]&&printf 'productionRuntimeBuildActAsConfigured=false\n'||printf 'productionRuntimeBuildActAsConfigured=true\n'; printf 'productionWifConfigured=true\nproductionWifEndToEndVerified=false\nproductionDeployEndToEndReady=false\nproductionIdentityReady=false\nproductionDeployed=false\n'


### PR DESCRIPTION
## Scope

Implements Production Enablement Block 3B.3 plus the Block 3B.3A verifier correction only. Base remains exact Block 3B.2B SHA `87f5147287cc9c428f3c114cbeec01c32201ff6a`.

### Block 3B.3A correction

The prior verifier incorrectly concatenated all `functions/src/*.js`, globally prohibited `firebase-functions/v1`, and therefore assumed the Functions deployment surface was v2-only.

The configured Functions entry point is `functions/src/entry.js`. Its exported deployment surface is mixed-generation:
- v1: `functions/src/pushAccountCleanup.js` imports `firebase-functions/v1` and exports `onPushAccountDeleted` through the entry-point spread.
- v2: the remaining exported Functions modules use explicit `firebase-functions/v2/*` APIs.
- generation-neutral imports such as `firebase-functions/params` and `firebase-functions/logger` are catalogued but do not independently imply a runtime generation.

The verifier now derives generations only from modules actually exported by the configured entry point. Dead/unexported helpers do not create a runtime identity requirement.

### Runtime/build identity boundary

For the current mixed v1+v2 surface, the required default Production runtime identities are derived as:
- `click-save-ai-production@appspot.gserviceaccount.com` (1st gen)
- `991489557172-compute@developer.gserviceaccount.com` (2nd gen)

Both must exist live before any actAs write. No runtime service account is created.

Cloud Build remains live-discovered only with:
`gcloud builds get-default-service-account --project=click-save-ai-production --region=europe-west1 --format='value(serviceAccountEmail)'`

Failure or empty discovery stops without enabling any API. Runtime/build identities are deduplicated before any individual `roles/iam.serviceAccountUser` binding.

### Preserved safety checks

- exact Production project ID and number
- zero user-managed deploy-SA keys
- exact Block 3B.2A WIF provider and impersonation boundary
- exact Block 3B.2B deploy-SA project-role set
- no project-wide `roles/iam.serviceAccountUser`
- no Owner/Editor, Token Creator, broad Firebase/Functions/Run/IAM/Secret/Storage/Artifact Registry admin roles
- no service-agent roles on discovered runtime/build identities
- no staging/legacy identities
- no custom per-function/global/Firebase service-account override unless explicitly proven
- no API enablement
- no service-account/key creation
- zero Production deployments remains required

### Files changed by Block 3B.3A

Only:
- `scripts/bootstrap-production-runtime-build-actas.sh`
- `scripts/verify-production-runtime-build-actas.sh`

### Deterministic validation

The exact script bytes were tested with a fake-gcloud harness and shell syntax checks. Covered cases include:
- v2-only deployed surface
- v1-only deployed surface
- mixed v1+v2 deployed surface
- unexported/dead v1 ignored
- custom runtime SA stops
- missing required v1 runtime SA stops
- missing required v2 runtime SA stops
- both runtime SAs + overlapping build SA deduplicated
- both runtime SAs + separate build SA exact bindings only
- idempotent rerun
- no project-wide SA User
- no API enablement in scripts or observed command path
- Production target lock
- Cloud Build discovery failure stops
- Cloud Build empty discovery stops

Remote Git blob hashes match the tested local files exactly.

### External state

No Production IAM mutation is claimed or performed by this repository correction. `productionRuntimeBuildActAsConfigured` remains false until the owner executes the corrected exact-SHA Cloud Shell bootstrap after required exact-SHA PR CI is successful. PR must remain Draft/Open/Unmerged.