### PR TITLE
Block 3E: prepare WIF auth-only proof path

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -16,6 +16,11 @@ on:
         required: true
         default: NO_DEPLOY
         type: string
+      authorize_wif_auth_proof:
+        description: Type PROVE_WIF_AUTH_ONLY only when a separately authorized WIF auth-only proof is intended
+        required: true
+        default: NO_WIF_PROOF
+        type: string
 
 concurrency:
   group: clickandsaveai-production-release
@@ -23,6 +28,7 @@ concurrency:
 
 jobs:
   production-candidate:
+    if: ${{ inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 45
@@ -216,9 +222,107 @@ jobs:
         run: |
           rm -f app/src/release/google-services.json "$PRODUCTION_GOOGLE_SERVICES_JSON_PATH" "$PRODUCTION_UPLOAD_KEYSTORE_PATH"
 
+  production-wif-auth-proof:
+    if: ${{ inputs.authorize_wif_auth_proof == 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      EXPECTED_REPOSITORY: vhanukaev1981/ClickAndSaveAI
+      EXPECTED_REPOSITORY_ID: '1314210715'
+      EXPECTED_REPOSITORY_OWNER_ID: '64756523'
+      EXPECTED_ENVIRONMENT: production
+      EXPECTED_REF: refs/heads/main
+      EXPECTED_WORKFLOW_REF: vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main
+      EXPECTED_PROJECT_ID: click-save-ai-production
+      EXPECTED_PROJECT_NUMBER: '991489557172'
+      EXPECTED_DEPLOY_SA: clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com
+
+    steps:
+      - name: Guard exact WIF auth-only boundary
+        env:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ '${{ inputs.authorize_wif_auth_proof }}' == 'PROVE_WIF_AUTH_ONLY' ]] || { echo 'WIF auth-only authorization phrase mismatch.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_firebase_deploy }}' == 'NO_DEPLOY' ]] || { echo 'WIF auth-only mode requires the deployment gate to remain closed.' >&2; exit 1; }
+          [[ '${{ inputs.confirm_environment }}' == 'CLICKANDSAVEAI_PRODUCTION' ]] || { echo 'Production confirmation phrase mismatch.' >&2; exit 1; }
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'source_sha must be an exact lowercase 40-character commit SHA.' >&2; exit 1; }
+          [[ '${{ github.sha }}' == "$SOURCE_SHA" ]] || { echo 'WIF auth-only source must equal the workflow main HEAD.' >&2; exit 1; }
+          [[ '${{ github.repository }}' == "$EXPECTED_REPOSITORY" ]] || { echo 'Repository identity mismatch.' >&2; exit 1; }
+          [[ '${{ github.repository_id }}' == "$EXPECTED_REPOSITORY_ID" ]] || { echo 'Repository ID mismatch.' >&2; exit 1; }
+          [[ '${{ github.repository_owner_id }}' == "$EXPECTED_REPOSITORY_OWNER_ID" ]] || { echo 'Repository owner ID mismatch.' >&2; exit 1; }
+          [[ '${{ github.ref }}' == "$EXPECTED_REF" ]] || { echo 'Git ref mismatch.' >&2; exit 1; }
+          [[ '${{ github.workflow_ref }}' == "$EXPECTED_WORKFLOW_REF" ]] || { echo 'Workflow ref mismatch.' >&2; exit 1; }
+          [[ "$EXPECTED_ENVIRONMENT" == 'production' ]] || { echo 'Environment boundary mismatch.' >&2; exit 1; }
+          [[ -n "$GCP_WORKLOAD_IDENTITY_PROVIDER" ]] || { echo 'Required WIF provider variable is unavailable.' >&2; exit 1; }
+          [[ -n "$GCP_DEPLOY_SERVICE_ACCOUNT" ]] || { echo 'Required deploy service-account variable is unavailable.' >&2; exit 1; }
+          [[ "$GCP_DEPLOY_SERVICE_ACCOUNT" == "$EXPECTED_DEPLOY_SA" ]] || { echo 'Deploy service-account identity mismatch.' >&2; exit 1; }
+          [[ "$GCP_WORKLOAD_IDENTITY_PROVIDER" =~ ^projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/[^/]+/providers/[^/]+$ ]] || { echo 'WIF provider project-number boundary mismatch.' >&2; exit 1; }
+
+      - name: Check out exact WIF proof source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Authenticate WIF auth-only identity
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          create_credentials_file: 'true'
+          cleanup_credentials: 'true'
+          export_environment_variables: 'false'
+          project_id: ${{ env.EXPECTED_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - name: Verify external-account credentials and emit sanitized identity metadata
+        env:
+          AUTH_PROJECT_ID: ${{ steps.auth.outputs.project_id }}
+          CREDENTIALS_FILE: ${{ steps.auth.outputs.credentials_file_path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$AUTH_PROJECT_ID" == "$EXPECTED_PROJECT_ID" ]] || { echo 'Authenticated project ID mismatch.' >&2; exit 1; }
+          [[ -n "$CREDENTIALS_FILE" && -f "$CREDENTIALS_FILE" ]] || { echo 'External-account credentials file was not created.' >&2; exit 1; }
+
+          CREDENTIAL_TYPE="$(jq -r '.type // empty' "$CREDENTIALS_FILE")"
+          [[ "$CREDENTIAL_TYPE" == 'external_account' ]] || { echo 'Credential type is not external_account.' >&2; exit 1; }
+          if jq -e '.type == "service_account" or has("private_key") or has("private_key_id")' "$CREDENTIALS_FILE" >/dev/null; then
+            echo 'Long-lived service-account key material is forbidden.' >&2
+            exit 1
+          fi
+
+          AUDIENCE="$(jq -r '.audience // empty' "$CREDENTIALS_FILE")"
+          IMPERSONATION_URL="$(jq -r '.service_account_impersonation_url // empty' "$CREDENTIALS_FILE")"
+          [[ "$AUDIENCE" =~ /projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/[^/]+/providers/[^/]+$ ]] || { echo 'Credential audience project-number boundary mismatch.' >&2; exit 1; }
+          EXPECTED_DEPLOY_SA_ENCODED="${EXPECTED_DEPLOY_SA//@/%40}"
+          [[ "$IMPERSONATION_URL" == *"/serviceAccounts/$EXPECTED_DEPLOY_SA:generateAccessToken" || "$IMPERSONATION_URL" == *"/serviceAccounts/$EXPECTED_DEPLOY_SA_ENCODED:generateAccessToken" ]] || { echo 'Credential impersonation identity mismatch.' >&2; exit 1; }
+
+          printf '%s\n' \
+            'wif_auth=verified' \
+            "repository=$EXPECTED_REPOSITORY" \
+            "repository_id=$EXPECTED_REPOSITORY_ID" \
+            "repository_owner_id=$EXPECTED_REPOSITORY_OWNER_ID" \
+            "environment=$EXPECTED_ENVIRONMENT" \
+            "ref=$EXPECTED_REF" \
+            "workflow_ref=$EXPECTED_WORKFLOW_REF" \
+            "project_id=$EXPECTED_PROJECT_ID" \
+            "project_number=$EXPECTED_PROJECT_NUMBER" \
+            "service_account=$EXPECTED_DEPLOY_SA" \
+            'credential_type=external_account'
+
   deploy-firebase-production:
     needs: production-candidate
-    if: ${{ inputs.authorize_firebase_deploy == 'DEPLOY_FIREBASE_PRODUCTION' }}
+    if: ${{ inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'DEPLOY_FIREBASE_PRODUCTION' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 30

--- a/functions/test/productionWifAuthProofBlock3E.test.js
+++ b/functions/test/productionWifAuthProofBlock3E.test.js
@@ -1,0 +1,143 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const root = path.resolve(process.cwd(), "..");
+const read = (relative) => fs.readFileSync(path.join(root, relative), "utf8");
+
+const workflow = read(".github/workflows/production-release.yml");
+const bootstrap = read("scripts/bootstrap-production-wif.sh");
+
+function jobBlock(name) {
+  const marker = `  ${name}:\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow job: ${name}`);
+  const tail = workflow.slice(start + marker.length);
+  const nextJob = tail.match(/\n  [A-Za-z0-9_-]+:\n/);
+  return nextJob ? tail.slice(0, nextJob.index) : tail;
+}
+
+test("Block 3E exposes an exact manual auth-only authorization input and stays workflow_dispatch-only", () => {
+  assert.match(workflow, /^on:\n  workflow_dispatch:\n/m);
+  assert.doesNotMatch(workflow, /\n  (?:push|pull_request|schedule|workflow_call):/);
+  assert.match(
+    workflow,
+    /authorize_wif_auth_proof:\n        description:.*\n        required: true\n        default: NO_WIF_PROOF\n        type: string/
+  );
+  assert.match(workflow, /PROVE_WIF_AUTH_ONLY/);
+});
+
+test("auth-only mode is mutually exclusive with production candidate and Firebase deploy", () => {
+  const candidate = jobBlock("production-candidate");
+  const deploy = jobBlock("deploy-firebase-production");
+  const proof = jobBlock("production-wif-auth-proof");
+
+  assert.ok(
+    candidate.includes("if: ${{ inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' }}"),
+    "production-candidate must be skipped in auth-only mode"
+  );
+  assert.doesNotMatch(candidate, /id-token:\s*write/);
+
+  assert.ok(
+    deploy.includes("inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY'"),
+    "Firebase deploy must be explicitly excluded from auth-only mode"
+  );
+  assert.ok(
+    deploy.includes("inputs.authorize_firebase_deploy == 'DEPLOY_FIREBASE_PRODUCTION'"),
+    "Firebase deploy must retain its exact deployment authorization phrase"
+  );
+
+  assert.ok(
+    proof.includes("inputs.authorize_wif_auth_proof == 'PROVE_WIF_AUTH_ONLY'"),
+    "auth proof must require the exact proof phrase"
+  );
+  assert.ok(
+    proof.includes("inputs.authorize_firebase_deploy == 'NO_DEPLOY'"),
+    "auth proof must require the deployment gate to remain NO_DEPLOY"
+  );
+  assert.ok(
+    proof.includes("inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION'"),
+    "auth proof must require the exact Production confirmation"
+  );
+});
+
+test("dedicated auth-proof job has the Production environment and minimal proof permissions", () => {
+  const proof = jobBlock("production-wif-auth-proof");
+
+  assert.match(proof, /environment: production/);
+  assert.match(proof, /permissions:\n      contents: read\n      id-token: write\n/);
+  assert.doesNotMatch(proof, /actions:\s*(?:read|write)/);
+  assert.doesNotMatch(proof, /(?:issues|pull-requests|packages|deployments|checks|statuses):\s*write/);
+
+  assert.match(proof, /uses: google-github-actions\/auth@v3/);
+  assert.match(proof, /workload_identity_provider: \$\{\{ vars\.GCP_WORKLOAD_IDENTITY_PROVIDER \}\}/);
+  assert.match(proof, /service_account: \$\{\{ vars\.GCP_DEPLOY_SERVICE_ACCOUNT \}\}/);
+});
+
+test("auth-proof job fail-closes on the canonical repository, workflow, identity and project boundary", () => {
+  const proof = jobBlock("production-wif-auth-proof");
+
+  for (const required of [
+    "EXPECTED_REPOSITORY: vhanukaev1981/ClickAndSaveAI",
+    "EXPECTED_REPOSITORY_ID: '1314210715'",
+    "EXPECTED_REPOSITORY_OWNER_ID: '64756523'",
+    "EXPECTED_ENVIRONMENT: production",
+    "EXPECTED_REF: refs/heads/main",
+    "EXPECTED_WORKFLOW_REF: vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main",
+    "EXPECTED_PROJECT_ID: click-save-ai-production",
+    "EXPECTED_PROJECT_NUMBER: '991489557172'",
+    "EXPECTED_DEPLOY_SA: clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com",
+    "${{ github.repository }}",
+    "${{ github.repository_id }}",
+    "${{ github.repository_owner_id }}",
+    "${{ github.ref }}",
+    "${{ github.workflow_ref }}",
+  ]) {
+    assert.ok(proof.includes(required), `missing fail-closed boundary: ${required}`);
+  }
+
+  assert.match(proof, /external_account/);
+  assert.match(proof, /service_account/);
+  assert.match(proof, /private_key/);
+  assert.match(proof, /credentials_file_path/);
+});
+
+test("auth-only path contains no signing, deployment, token logging, IAM mutation or staging reuse", () => {
+  const proof = jobBlock("production-wif-auth-proof");
+
+  assert.doesNotMatch(proof, /\$\{\{\s*secrets\./);
+  assert.doesNotMatch(proof, /PRODUCTION_UPLOAD_|PRODUCTION_GOOGLE_SERVICES_JSON_B64|PRODUCTION_RELEASE_CANDIDATE/);
+  assert.doesNotMatch(proof, /assembleRelease|bundleRelease|Build signed production candidate|apksigner|keytool/);
+  assert.doesNotMatch(proof, /firebase\s+deploy/i);
+  assert.doesNotMatch(proof, /gcloud\s+(?:functions|run|app)\s+deploy/i);
+  assert.doesNotMatch(proof, /gcloud\s+firestore|firestore.*deploy/i);
+  assert.doesNotMatch(proof, /google\s+play|play.*(?:upload|publish)/i);
+  assert.doesNotMatch(proof, /services\s+enable|add-iam-policy-binding|workload-identity-pools.*(?:create|update)|service-accounts.*create/i);
+  assert.doesNotMatch(proof, /bootstrap-production-wif|bootstrap-staging-wif|verify-staging-wif/);
+  assert.doesNotMatch(proof, /staging/i);
+
+  assert.doesNotMatch(proof, /token_format:\s*(?:access_token|id_token)/i);
+  assert.doesNotMatch(proof, /steps\.auth\.outputs\.(?:access_token|id_token)/i);
+  assert.doesNotMatch(proof, /ACTIONS_ID_TOKEN|OIDC_TOKEN|REFRESH_TOKEN/i);
+  assert.doesNotMatch(proof, /(?:echo|printf).*\b(?:access|refresh|oidc)\b.*token/i);
+  assert.doesNotMatch(proof, /(?:cat|sed|head|tail)\s+[^\n]*(?:GOOGLE_APPLICATION_CREDENTIALS|CREDENTIALS_FILE)/i);
+});
+
+test("canonical Production WIF trust boundary remains exact and is not broadened", () => {
+  assert.match(bootstrap, /GITHUB_REPOSITORY_ID="1314210715"/);
+  assert.match(bootstrap, /GITHUB_REPOSITORY_OWNER_ID="64756523"/);
+  assert.match(bootstrap, /GITHUB_ENVIRONMENT="production"/);
+  assert.match(bootstrap, /GITHUB_REF="refs\/heads\/main"/);
+  assert.match(
+    bootstrap,
+    /GITHUB_WORKFLOW_REF="vhanukaev1981\/ClickAndSaveAI\/\.github\/workflows\/production-release\.yml@refs\/heads\/main"/
+  );
+  assert.match(bootstrap, /attribute\.repository_id==/);
+  assert.match(bootstrap, /attribute\.repository_owner_id==/);
+  assert.match(bootstrap, /attribute\.environment==/);
+  assert.match(bootstrap, /attribute\.ref==/);
+  assert.match(bootstrap, /attribute\.workflow_ref==/);
+});


### PR DESCRIPTION
## Scope
Repository-only preparation for Issue #73 / Production Enablement Block 3E.

Adds a fail-closed, manual WIF auth-only proof path inside the canonical `.github/workflows/production-release.yml`, preserving the existing `workflow_ref` trust boundary on `refs/heads/main`.

## Design
- New `authorize_wif_auth_proof` input; default `NO_WIF_PROOF`; exact proof phrase `PROVE_WIF_AUTH_ONLY`.
- `production-candidate` is excluded from auth-only mode.
- `deploy-firebase-production` is excluded from auth-only mode and still requires `DEPLOY_FIREBASE_PRODUCTION`.
- Dedicated `production-wif-auth-proof` uses `environment: production`, `contents: read`, and `id-token: write` only.
- Proof uses only `GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_DEPLOY_SERVICE_ACCOUNT` with `google-github-actions/auth@v3`.
- Fail-closed checks cover canonical repository/owner IDs, main ref, canonical workflow_ref, production project ID/number, expected deploy service account, and external-account credential type.
- Auth-only path contains no signing secret materialization, signed build, deployment command, IAM mutation, token logging, staging reuse, or Google Play action.

## TDD evidence
The first branch commit added the Block 3E contract test and produced the expected RED: 327/332 passed; the five Block 3E implementation assertions failed because the input/job did not yet exist. The implementation commit addresses that contract; final exact-HEAD CI is required before PASS.

## Hard boundaries observed
- No Production Release workflow dispatch performed.
- No `environment: production` job executed by this work.
- No live GitHub OIDC/WIF authentication performed.
- No Firebase/Firestore/Functions/Cloud Run/App Engine deployment.
- No Production IAM/WIF, GitHub Environment, variable, or secret mutation.
- No Google Play upload/publication.
- No merge.

Truth boundary remains false for `productionWifEndToEndVerified`, `productionDeployEndToEndReady`, `productionDeployed`, and `googlePlayPublished`.