### PR TITLE
Block 3F: prepare Firebase external-authority read-only probe

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -26,6 +26,11 @@ on:
         required: true
         default: NO_3F_PROBE
         type: string
+      authorize_3f_external_authority_probe:
+        description: Type PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY only when a separately authorized Block 3F Firebase external-authority read-only probe is intended
+        required: true
+        default: NO_3F_EXTERNAL_PROBE
+        type: string
 
 concurrency:
   group: clickandsaveai-production-release
@@ -33,7 +38,7 @@ concurrency:
 
 jobs:
   production-candidate:
-    if: ${{ inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' }}
+    if: ${{ inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 45
@@ -228,7 +233,7 @@ jobs:
           rm -f app/src/release/google-services.json "$PRODUCTION_GOOGLE_SERVICES_JSON_PATH" "$PRODUCTION_UPLOAD_KEYSTORE_PATH"
 
   production-wif-auth-proof:
-    if: ${{ inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_wif_auth_proof == 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
+    if: ${{ inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_wif_auth_proof == 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 10
@@ -326,7 +331,7 @@ jobs:
             'credential_type=external_account'
 
   production-3f-metadata-probe:
-    if: ${{ inputs.authorize_3f_metadata_probe == 'PROBE_3F_METADATA_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
+    if: ${{ inputs.authorize_3f_metadata_probe == 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 10
@@ -431,9 +436,90 @@ jobs:
         run: |
           rm -f "$BLOCK3F_GOOGLE_CONFIG_PATH" "$BLOCK3F_UPLOAD_KEYSTORE_PATH"
 
+  production-3f-firebase-authority-probe:
+    if: ${{ inputs.authorize_3f_external_authority_probe == 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF' && inputs.authorize_3f_metadata_probe == 'NO_3F_PROBE' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      EXPECTED_REPOSITORY: vhanukaev1981/ClickAndSaveAI
+      EXPECTED_REPOSITORY_ID: '1314210715'
+      EXPECTED_REPOSITORY_OWNER_ID: '64756523'
+      EXPECTED_ENVIRONMENT: production
+      EXPECTED_REF: refs/heads/main
+      EXPECTED_WORKFLOW_REF: vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main
+      EXPECTED_PROJECT_ID: click-save-ai-production
+      EXPECTED_PROJECT_NUMBER: '991489557172'
+      EXPECTED_PACKAGE: com.aistudio.clickandsaveai.app
+      EXPECTED_DEPLOY_SA: clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+    steps:
+      - name: Guard exact Block 3F Firebase external-authority read-only boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ '${{ inputs.authorize_3f_external_authority_probe }}' == 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' ]] || { echo 'Block 3F external-authority probe authorization phrase mismatch.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_firebase_deploy }}' == 'NO_DEPLOY' ]] || { echo 'External-authority probe requires authorize_firebase_deploy=NO_DEPLOY.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_wif_auth_proof }}' == 'NO_WIF_PROOF' ]] || { echo 'External-authority probe requires authorize_wif_auth_proof=NO_WIF_PROOF.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_3f_metadata_probe }}' == 'NO_3F_PROBE' ]] || { echo 'External-authority probe requires authorize_3f_metadata_probe=NO_3F_PROBE.' >&2; exit 1; }
+          [[ '${{ inputs.confirm_environment }}' == 'CLICKANDSAVEAI_PRODUCTION' ]] || { echo 'Production confirmation phrase mismatch.' >&2; exit 1; }
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'source_sha must be an exact lowercase 40-character commit SHA.' >&2; exit 1; }
+          [[ '${{ github.sha }}' == "$SOURCE_SHA" ]] || { echo 'External-authority probe source must equal the workflow main HEAD.' >&2; exit 1; }
+          [[ '${{ github.repository }}' == "$EXPECTED_REPOSITORY" ]] || { echo 'Repository identity mismatch.' >&2; exit 1; }
+          [[ '${{ github.repository_id }}' == "$EXPECTED_REPOSITORY_ID" ]] || { echo 'Repository ID mismatch.' >&2; exit 1; }
+          [[ '${{ github.repository_owner_id }}' == "$EXPECTED_REPOSITORY_OWNER_ID" ]] || { echo 'Repository owner ID mismatch.' >&2; exit 1; }
+          [[ '${{ github.ref }}' == "$EXPECTED_REF" ]] || { echo 'Git ref mismatch.' >&2; exit 1; }
+          [[ '${{ github.workflow_ref }}' == "$EXPECTED_WORKFLOW_REF" ]] || { echo 'Workflow ref mismatch.' >&2; exit 1; }
+          [[ "$EXPECTED_ENVIRONMENT" == 'production' ]] || { echo 'Environment boundary mismatch.' >&2; exit 1; }
+          [[ "$EXPECTED_PROJECT_ID" == 'click-save-ai-production' ]] || { echo 'Firebase project boundary mismatch.' >&2; exit 1; }
+          [[ "$EXPECTED_PROJECT_NUMBER" == '991489557172' ]] || { echo 'Firebase project-number boundary mismatch.' >&2; exit 1; }
+          [[ "$EXPECTED_PACKAGE" == 'com.aistudio.clickandsaveai.app' ]] || { echo 'Android package boundary mismatch.' >&2; exit 1; }
+          [[ -n "$GCP_WORKLOAD_IDENTITY_PROVIDER" ]] || { echo 'Required WIF provider variable is unavailable.' >&2; exit 1; }
+          [[ -n "$GCP_DEPLOY_SERVICE_ACCOUNT" ]] || { echo 'Required deploy service-account variable is unavailable.' >&2; exit 1; }
+          [[ "$GCP_DEPLOY_SERVICE_ACCOUNT" == "$EXPECTED_DEPLOY_SA" ]] || { echo 'Deploy service-account identity mismatch.' >&2; exit 1; }
+          [[ "$GCP_WORKLOAD_IDENTITY_PROVIDER" =~ ^projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/[^/]+/providers/[^/]+$ ]] || { echo 'WIF provider project-number boundary mismatch.' >&2; exit 1; }
+
+      - name: Check out exact Firebase authority probe source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Node.js 22 for Firebase authority read
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          package-manager-cache: false
+
+      - name: Authenticate Firebase authority read-only identity
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          create_credentials_file: 'true'
+          cleanup_credentials: 'true'
+          export_environment_variables: 'false'
+          project_id: ${{ env.EXPECTED_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          token_format: 'access_token'
+          access_token_lifetime: '600s'
+          access_token_scopes: 'https://www.googleapis.com/auth/firebase.readonly'
+
+      - name: Read Firebase external authority and emit sanitized truth
+        env:
+          BLOCK3F_FIREBASE_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+        run: node scripts/production-3f-firebase-authority-probe.mjs
+
   deploy-firebase-production:
     needs: production-candidate
-    if: ${{ inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'DEPLOY_FIREBASE_PRODUCTION' }}
+    if: ${{ inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'DEPLOY_FIREBASE_PRODUCTION' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 30

--- a/functions/test/productionFirebaseAuthorityProbeBlock3F.test.js
+++ b/functions/test/productionFirebaseAuthorityProbeBlock3F.test.js
@@ -1,0 +1,339 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const root = path.resolve(process.cwd(), "..");
+const workflowPath = path.join(root, ".github/workflows/production-release.yml");
+const probePath = path.join(root, "scripts/production-3f-firebase-authority-probe.mjs");
+const workflow = fs.readFileSync(workflowPath, "utf8");
+
+const AUTH_PHRASE = "PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY";
+const EXPECTED_PROJECT_ID = "click-save-ai-production";
+const EXPECTED_PROJECT_NUMBER = "991489557172";
+const EXPECTED_PACKAGE = "com.aistudio.clickandsaveai.app";
+const EXPECTED_DEPLOY_SA =
+  "clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com";
+
+function jobBlock(name) {
+  const marker = `  ${name}:\n`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow job: ${name}`);
+  const tail = workflow.slice(start + marker.length);
+  const nextJob = tail.match(/\n  [A-Za-z0-9_-]+:\n/);
+  return nextJob ? tail.slice(0, nextJob.index) : tail;
+}
+
+function fakeJsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+  };
+}
+
+async function loadProbeModule() {
+  assert.ok(
+    fs.existsSync(probePath),
+    "missing scripts/production-3f-firebase-authority-probe.mjs"
+  );
+  return import(`${pathToFileURL(probePath).href}?t=${Date.now()}-${Math.random()}`);
+}
+
+test("Block 3F external-authority probe has an exact manual authorization input with a closed default", () => {
+  assert.match(workflow, /^on:\n  workflow_dispatch:\n/m);
+  assert.doesNotMatch(workflow, /\n  (?:push|pull_request|schedule|workflow_call):/);
+  assert.match(
+    workflow,
+    /authorize_3f_external_authority_probe:\n        description:.*PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY.*\n        required: true\n        default: NO_3F_EXTERNAL_PROBE\n        type: string/
+  );
+});
+
+test("external-authority mode is mutually exclusive with every existing Production path", () => {
+  const candidate = jobBlock("production-candidate");
+  const wifProof = jobBlock("production-wif-auth-proof");
+  const metadataProbe = jobBlock("production-3f-metadata-probe");
+  const deploy = jobBlock("deploy-firebase-production");
+  const externalProbe = jobBlock("production-3f-firebase-authority-probe");
+
+  for (const [name, block] of [
+    ["production-candidate", candidate],
+    ["production-wif-auth-proof", wifProof],
+    ["production-3f-metadata-probe", metadataProbe],
+    ["deploy-firebase-production", deploy],
+  ]) {
+    assert.ok(
+      block.includes(`inputs.authorize_3f_external_authority_probe != '${AUTH_PHRASE}'`),
+      `${name} must be skipped in external-authority probe mode`
+    );
+  }
+
+  for (const required of [
+    `inputs.authorize_3f_external_authority_probe == '${AUTH_PHRASE}'`,
+    "inputs.authorize_firebase_deploy == 'NO_DEPLOY'",
+    "inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF'",
+    "inputs.authorize_3f_metadata_probe == 'NO_3F_PROBE'",
+    "inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION'",
+  ]) {
+    assert.ok(externalProbe.includes(required), `probe eligibility is missing: ${required}`);
+  }
+});
+
+test("dedicated Firebase authority probe reuses only the proven WIF identity boundary", () => {
+  const probe = jobBlock("production-3f-firebase-authority-probe");
+
+  assert.match(probe, /environment: production/);
+  assert.match(probe, /permissions:\n      contents: read\n      id-token: write\n/);
+  assert.doesNotMatch(
+    probe,
+    /(?:actions|issues|pull-requests|packages|deployments|checks|statuses):\s*write/
+  );
+
+  for (const expected of [
+    `EXPECTED_PROJECT_ID: ${EXPECTED_PROJECT_ID}`,
+    `EXPECTED_PROJECT_NUMBER: '${EXPECTED_PROJECT_NUMBER}'`,
+    `EXPECTED_PACKAGE: ${EXPECTED_PACKAGE}`,
+    `EXPECTED_DEPLOY_SA: ${EXPECTED_DEPLOY_SA}`,
+    "GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}",
+    "GCP_DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}",
+  ]) {
+    assert.ok(probe.includes(expected), `missing fixed boundary: ${expected}`);
+  }
+
+  for (const forbidden of [
+    "PRODUCTION_FIREBASE_PROJECT_ID",
+    "PRODUCTION_GOOGLE_WEB_CLIENT_ID",
+    "PRODUCTION_APP_SIGNING_CERT_SHA1",
+    "PRODUCTION_APP_SIGNING_CERT_SHA256",
+    "PRODUCTION_UPLOAD_KEY_ALIAS",
+    "PRODUCTION_GOOGLE_SERVICES_JSON_B64",
+    "PRODUCTION_UPLOAD_KEYSTORE_B64",
+    "PRODUCTION_UPLOAD_STORE_PASSWORD",
+    "PRODUCTION_UPLOAD_KEY_PASSWORD",
+  ]) {
+    assert.ok(!probe.includes(forbidden), `${forbidden} must not be required by this probe`);
+  }
+});
+
+test("WIF authentication is exact, ephemeral, access-token scoped, and has no long-lived key path", () => {
+  const probe = jobBlock("production-3f-firebase-authority-probe");
+
+  assert.match(probe, /uses: google-github-actions\/auth@v3/);
+  assert.match(probe, /create_credentials_file: 'true'/);
+  assert.match(probe, /cleanup_credentials: 'true'/);
+  assert.match(probe, /token_format: 'access_token'/);
+  assert.match(probe, /access_token_scopes: 'https:\/\/www\.googleapis\.com\/auth\/firebase\.readonly'/);
+  assert.match(probe, /workload_identity_provider: \$\{\{ vars\.GCP_WORKLOAD_IDENTITY_PROVIDER \}\}/);
+  assert.match(probe, /service_account: \$\{\{ vars\.GCP_DEPLOY_SERVICE_ACCOUNT \}\}/);
+  assert.match(probe, /\$\{\{ github\.sha \}\}.*\$SOURCE_SHA/);
+  assert.match(probe, /\$\{\{ github\.ref \}\}.*\$EXPECTED_REF/);
+  assert.match(probe, /\$GCP_DEPLOY_SERVICE_ACCOUNT.*\$EXPECTED_DEPLOY_SA/);
+  assert.match(probe, /projects\/\$\{EXPECTED_PROJECT_NUMBER\}\/locations\/global\/workloadIdentityPools/);
+  assert.doesNotMatch(probe, /service-accounts\s+keys\s+create|private_key|private_key_id/i);
+});
+
+test("workflow invokes the repository probe without build, deploy, publish, IAM mutation, API enablement, or config mutation", () => {
+  const probe = jobBlock("production-3f-firebase-authority-probe");
+
+  assert.match(probe, /node scripts\/production-3f-firebase-authority-probe\.mjs/);
+  for (const forbidden of [
+    /assembleRelease|bundleRelease|gradle\s/i,
+    /firebase\s+deploy/i,
+    /gcloud\s+(?:functions|run|app)\s+deploy/i,
+    /google\s+play|play.*(?:upload|publish)/i,
+    /services\s+enable|add-iam-policy-binding|set-iam-policy|remove-iam-policy-binding/i,
+    /workload-identity-pools.*(?:create|update|delete)/i,
+    /service-accounts.*(?:create|keys\s+create)/i,
+    /androidApps.*(?:create|patch|remove|undelete)/i,
+  ]) {
+    assert.doesNotMatch(probe, forbidden);
+  }
+});
+
+test("probe implementation is fixed to Firebase Management GET reads and contains no mutation method", async () => {
+  await loadProbeModule();
+  const source = fs.readFileSync(probePath, "utf8");
+
+  assert.match(source, /https:\/\/firebase\.googleapis\.com\/v1beta1/);
+  assert.match(source, /\/projects\/\$\{encodeURIComponent\(expectedProjectId\)\}/);
+  assert.match(source, /\/androidApps/);
+  assert.match(source, /\/config/);
+  assert.match(source, /method:\s*["']GET["']/);
+  assert.doesNotMatch(source, /method:\s*["'](?:POST|PUT|PATCH|DELETE)["']/i);
+  assert.doesNotMatch(
+    source,
+    /addFirebase|addGoogleAnalytics|services\.enable|create\(|patch\(|remove\(|undelete\(|setIamPolicy/i
+  );
+});
+
+test("authoritative 200 reads can verify exact Firebase project, Android package, and sanitized config metadata", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  const calls = [];
+  const config = {
+    project_info: { project_id: EXPECTED_PROJECT_ID, project_number: EXPECTED_PROJECT_NUMBER },
+    client: [
+      {
+        client_info: {
+          mobilesdk_app_id: "1:991489557172:android:abcdef",
+          android_client_info: { package_name: EXPECTED_PACKAGE },
+        },
+        api_key: [{ current_key: "MUST_NOT_LEAK" }],
+      },
+    ],
+  };
+
+  const fetchImpl = async (url, options) => {
+    calls.push({ url: String(url), method: options?.method, authorization: options?.headers?.Authorization });
+    if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
+      return fakeJsonResponse(200, {
+        projectId: EXPECTED_PROJECT_ID,
+        projectNumber: EXPECTED_PROJECT_NUMBER,
+        state: "ACTIVE",
+      });
+    }
+    if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
+      return fakeJsonResponse(200, {
+        apps: [
+          {
+            name: `projects/${EXPECTED_PROJECT_ID}/androidApps/1:991489557172:android:abcdef`,
+            appId: "1:991489557172:android:abcdef",
+            projectId: EXPECTED_PROJECT_ID,
+            packageName: EXPECTED_PACKAGE,
+            state: "ACTIVE",
+          },
+        ],
+      });
+    }
+    if (String(url).endsWith("/config")) {
+      return fakeJsonResponse(200, {
+        configFilename: "google-services.json",
+        configFileContents: Buffer.from(JSON.stringify(config), "utf8").toString("base64"),
+      });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  };
+
+  const result = await probeFirebaseAuthority({
+    accessToken: "SECRET_BEARER_TOKEN",
+    expectedProjectId: EXPECTED_PROJECT_ID,
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    expectedPackage: EXPECTED_PACKAGE,
+    fetchImpl,
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    "firebase_project_external_authority=VERIFIED_PRESENT",
+    "firebase_project_identity=VERIFIED_MATCH",
+    "firebase_android_app_external_authority=VERIFIED_PRESENT",
+    "firebase_android_package=VERIFIED_MATCH",
+    "firebase_android_config_authority=VERIFIED_PRESENT",
+    "firebase_android_config_project=VERIFIED_MATCH",
+    "firebase_android_config_package=VERIFIED_MATCH",
+  ]);
+  assert.equal(calls.length, 3);
+  assert.ok(calls.every((call) => call.method === "GET"));
+  assert.ok(calls.every((call) => call.authorization === "Bearer SECRET_BEARER_TOKEN"));
+  const output = result.lines.join("\n");
+  assert.doesNotMatch(output, /SECRET_BEARER_TOKEN|MUST_NOT_LEAK|current_key|configFileContents/);
+});
+
+test("403 or permission/API unavailability is UNKNOWN_NO_ACCESS and never verified absence", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  const result = await probeFirebaseAuthority({
+    accessToken: "secret",
+    expectedProjectId: EXPECTED_PROJECT_ID,
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    expectedPackage: EXPECTED_PACKAGE,
+    fetchImpl: async () => fakeJsonResponse(403, { error: { status: "PERMISSION_DENIED" } }),
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    "firebase_project_external_authority=UNKNOWN_NO_ACCESS",
+    "firebase_project_identity=UNKNOWN_NO_ACCESS",
+    "firebase_android_app_external_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_package=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_project=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_package=UNKNOWN_NO_ACCESS",
+  ]);
+  assert.doesNotMatch(result.lines.join("\n"), /VERIFIED_ABSENT/);
+});
+
+test("a successful authoritative Android-app list with no exact package establishes verified absence", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  const fetchImpl = async (url) => {
+    if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
+      return fakeJsonResponse(200, {
+        projectId: EXPECTED_PROJECT_ID,
+        projectNumber: EXPECTED_PROJECT_NUMBER,
+        state: "ACTIVE",
+      });
+    }
+    if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
+      return fakeJsonResponse(200, {
+        apps: [
+          {
+            name: `projects/${EXPECTED_PROJECT_ID}/androidApps/other`,
+            projectId: EXPECTED_PROJECT_ID,
+            packageName: "com.example.other",
+            state: "ACTIVE",
+          },
+        ],
+      });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  };
+
+  const result = await probeFirebaseAuthority({
+    accessToken: "secret",
+    expectedProjectId: EXPECTED_PROJECT_ID,
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    expectedPackage: EXPECTED_PACKAGE,
+    fetchImpl,
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    "firebase_project_external_authority=VERIFIED_PRESENT",
+    "firebase_project_identity=VERIFIED_MATCH",
+    "firebase_android_app_external_authority=VERIFIED_ABSENT",
+    "firebase_android_package=VERIFIED_ABSENT",
+    "firebase_android_config_authority=VERIFIED_ABSENT",
+    "firebase_android_config_project=VERIFIED_ABSENT",
+    "firebase_android_config_package=VERIFIED_ABSENT",
+  ]);
+});
+
+test("authoritative project or app identity mismatch fails closed", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  const result = await probeFirebaseAuthority({
+    accessToken: "secret",
+    expectedProjectId: EXPECTED_PROJECT_ID,
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    expectedPackage: EXPECTED_PACKAGE,
+    fetchImpl: async () =>
+      fakeJsonResponse(200, {
+        projectId: "different-project",
+        projectNumber: "123",
+        state: "ACTIVE",
+      }),
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.lines, [
+    "firebase_project_external_authority=MISMATCH",
+    "firebase_project_identity=MISMATCH",
+    "firebase_android_app_external_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_package=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_project=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_package=UNKNOWN_NO_ACCESS",
+  ]);
+});

--- a/functions/test/productionFirebaseAuthorityProbeBlock3F.test.js
+++ b/functions/test/productionFirebaseAuthorityProbeBlock3F.test.js
@@ -12,6 +12,7 @@ const probePath = path.join(root, "scripts/production-3f-firebase-authority-prob
 const workflow = fs.readFileSync(workflowPath, "utf8");
 
 const AUTH_PHRASE = "PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY";
+const EXTERNAL_AUTHORITY = "EXTERNALLY_AUTHORITATIVE_VERIFIED";
 const EXPECTED_PROJECT_ID = "click-save-ai-production";
 const EXPECTED_PROJECT_NUMBER = "991489557172";
 const EXPECTED_PACKAGE = "com.aistudio.clickandsaveai.app";
@@ -43,6 +44,43 @@ async function loadProbeModule() {
     "missing scripts/production-3f-firebase-authority-probe.mjs"
   );
   return import(`${pathToFileURL(probePath).href}?t=${Date.now()}-${Math.random()}`);
+}
+
+function canonicalProject() {
+  return {
+    projectId: EXPECTED_PROJECT_ID,
+    projectNumber: EXPECTED_PROJECT_NUMBER,
+    state: "ACTIVE",
+  };
+}
+
+function canonicalApp(appId = "1:991489557172:android:abcdef") {
+  return {
+    name: `projects/${EXPECTED_PROJECT_ID}/androidApps/${appId}`,
+    appId,
+    projectId: EXPECTED_PROJECT_ID,
+    packageName: EXPECTED_PACKAGE,
+    state: "ACTIVE",
+  };
+}
+
+function canonicalConfig() {
+  return {
+    project_info: {
+      project_id: EXPECTED_PROJECT_ID,
+      project_number: EXPECTED_PROJECT_NUMBER,
+    },
+    client: [
+      {
+        client_info: {
+          mobilesdk_app_id: "1:991489557172:android:abcdef",
+          android_client_info: { package_name: EXPECTED_PACKAGE },
+        },
+        api_key: [{ current_key: "MUST_NOT_LEAK" }],
+        oauth_client: [{ client_id: "MUST_NOT_LEAK_OAUTH" }],
+      },
+    ],
+  };
 }
 
 test("Block 3F external-authority probe has an exact manual authorization input with a closed default", () => {
@@ -84,7 +122,7 @@ test("external-authority mode is mutually exclusive with every existing Producti
   }
 });
 
-test("dedicated Firebase authority probe reuses only the proven WIF identity boundary", () => {
+test("dedicated Firebase authority probe preserves the accepted WIF identity boundary", () => {
   const probe = jobBlock("production-3f-firebase-authority-probe");
 
   assert.match(probe, /environment: production/);
@@ -120,24 +158,33 @@ test("dedicated Firebase authority probe reuses only the proven WIF identity bou
   }
 });
 
-test("WIF authentication is exact, ephemeral, access-token scoped, and has no long-lived key path", () => {
+test("WIF authentication boundary stays exact, ephemeral and firebase.readonly scoped", () => {
   const probe = jobBlock("production-3f-firebase-authority-probe");
 
   assert.match(probe, /uses: google-github-actions\/auth@v3/);
   assert.match(probe, /create_credentials_file: 'true'/);
   assert.match(probe, /cleanup_credentials: 'true'/);
   assert.match(probe, /token_format: 'access_token'/);
-  assert.match(probe, /access_token_scopes: 'https:\/\/www\.googleapis\.com\/auth\/firebase\.readonly'/);
-  assert.match(probe, /workload_identity_provider: \$\{\{ vars\.GCP_WORKLOAD_IDENTITY_PROVIDER \}\}/);
+  assert.match(
+    probe,
+    /access_token_scopes: 'https:\/\/www\.googleapis\.com\/auth\/firebase\.readonly'/
+  );
+  assert.match(
+    probe,
+    /workload_identity_provider: \$\{\{ vars\.GCP_WORKLOAD_IDENTITY_PROVIDER \}\}/
+  );
   assert.match(probe, /service_account: \$\{\{ vars\.GCP_DEPLOY_SERVICE_ACCOUNT \}\}/);
   assert.match(probe, /\$\{\{ github\.sha \}\}.*\$SOURCE_SHA/);
   assert.match(probe, /\$\{\{ github\.ref \}\}.*\$EXPECTED_REF/);
   assert.match(probe, /\$GCP_DEPLOY_SERVICE_ACCOUNT.*\$EXPECTED_DEPLOY_SA/);
-  assert.match(probe, /projects\/\$\{EXPECTED_PROJECT_NUMBER\}\/locations\/global\/workloadIdentityPools/);
+  assert.match(
+    probe,
+    /projects\/\$\{EXPECTED_PROJECT_NUMBER\}\/locations\/global\/workloadIdentityPools/
+  );
   assert.doesNotMatch(probe, /service-accounts\s+keys\s+create|private_key|private_key_id/i);
 });
 
-test("workflow invokes the repository probe without build, deploy, publish, IAM mutation, API enablement, or config mutation", () => {
+test("workflow invokes only the GET-only repository probe and preserves all no-mutation guards", () => {
   const probe = jobBlock("production-3f-firebase-authority-probe");
 
   assert.match(probe, /node scripts\/production-3f-firebase-authority-probe\.mjs/);
@@ -171,48 +218,25 @@ test("probe implementation is fixed to Firebase Management GET reads and contain
   );
 });
 
-test("authoritative 200 reads can verify exact Firebase project, Android package, and sanitized config metadata", async () => {
+test("successful authoritative project, app and config reads use external-authority truth distinct from relationships", async () => {
   const { probeFirebaseAuthority } = await loadProbeModule();
   const calls = [];
-  const config = {
-    project_info: { project_id: EXPECTED_PROJECT_ID, project_number: EXPECTED_PROJECT_NUMBER },
-    client: [
-      {
-        client_info: {
-          mobilesdk_app_id: "1:991489557172:android:abcdef",
-          android_client_info: { package_name: EXPECTED_PACKAGE },
-        },
-        api_key: [{ current_key: "MUST_NOT_LEAK" }],
-      },
-    ],
-  };
-
   const fetchImpl = async (url, options) => {
-    calls.push({ url: String(url), method: options?.method, authorization: options?.headers?.Authorization });
+    calls.push({
+      url: String(url),
+      method: options?.method,
+      authorization: options?.headers?.Authorization,
+    });
     if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
-      return fakeJsonResponse(200, {
-        projectId: EXPECTED_PROJECT_ID,
-        projectNumber: EXPECTED_PROJECT_NUMBER,
-        state: "ACTIVE",
-      });
+      return fakeJsonResponse(200, canonicalProject());
     }
     if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
-      return fakeJsonResponse(200, {
-        apps: [
-          {
-            name: `projects/${EXPECTED_PROJECT_ID}/androidApps/1:991489557172:android:abcdef`,
-            appId: "1:991489557172:android:abcdef",
-            projectId: EXPECTED_PROJECT_ID,
-            packageName: EXPECTED_PACKAGE,
-            state: "ACTIVE",
-          },
-        ],
-      });
+      return fakeJsonResponse(200, { apps: [canonicalApp()] });
     }
     if (String(url).endsWith("/config")) {
       return fakeJsonResponse(200, {
         configFilename: "google-services.json",
-        configFileContents: Buffer.from(JSON.stringify(config), "utf8").toString("base64"),
+        configFileContents: Buffer.from(JSON.stringify(canonicalConfig()), "utf8").toString("base64"),
       });
     }
     throw new Error(`unexpected URL: ${url}`);
@@ -228,53 +252,67 @@ test("authoritative 200 reads can verify exact Firebase project, Android package
 
   assert.equal(result.exitCode, 0);
   assert.deepEqual(result.lines, [
-    "firebase_project_external_authority=VERIFIED_PRESENT",
+    `firebase_project_external_authority=${EXTERNAL_AUTHORITY}`,
     "firebase_project_identity=VERIFIED_MATCH",
-    "firebase_android_app_external_authority=VERIFIED_PRESENT",
+    `firebase_android_app_external_authority=${EXTERNAL_AUTHORITY}`,
     "firebase_android_package=VERIFIED_MATCH",
-    "firebase_android_config_authority=VERIFIED_PRESENT",
+    `firebase_android_config_authority=${EXTERNAL_AUTHORITY}`,
     "firebase_android_config_project=VERIFIED_MATCH",
     "firebase_android_config_package=VERIFIED_MATCH",
   ]);
   assert.equal(calls.length, 3);
   assert.ok(calls.every((call) => call.method === "GET"));
   assert.ok(calls.every((call) => call.authorization === "Bearer SECRET_BEARER_TOKEN"));
+
   const output = result.lines.join("\n");
-  assert.doesNotMatch(output, /SECRET_BEARER_TOKEN|MUST_NOT_LEAK|current_key|configFileContents/);
+  assert.doesNotMatch(
+    output,
+    /SECRET_BEARER_TOKEN|MUST_NOT_LEAK|MUST_NOT_LEAK_OAUTH|current_key|oauth_client|configFileContents/
+  );
+  assert.doesNotMatch(output, /_external_authority=VERIFIED_PRESENT/);
+  assert.match(output, /firebase_project_identity=VERIFIED_MATCH/);
+  assert.match(output, /firebase_android_package=VERIFIED_MATCH/);
+  assert.match(output, /firebase_android_config_project=VERIFIED_MATCH/);
+  assert.match(output, /firebase_android_config_package=VERIFIED_MATCH/);
 });
 
-test("403 or permission/API unavailability is UNKNOWN_NO_ACCESS and never verified absence", async () => {
+test("403, other non-2xx and network failure remain UNKNOWN_NO_ACCESS and never verified absence", async () => {
   const { probeFirebaseAuthority } = await loadProbeModule();
-  const result = await probeFirebaseAuthority({
-    accessToken: "secret",
-    expectedProjectId: EXPECTED_PROJECT_ID,
-    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
-    expectedPackage: EXPECTED_PACKAGE,
-    fetchImpl: async () => fakeJsonResponse(403, { error: { status: "PERMISSION_DENIED" } }),
-  });
 
-  assert.equal(result.exitCode, 0);
-  assert.deepEqual(result.lines, [
-    "firebase_project_external_authority=UNKNOWN_NO_ACCESS",
-    "firebase_project_identity=UNKNOWN_NO_ACCESS",
-    "firebase_android_app_external_authority=UNKNOWN_NO_ACCESS",
-    "firebase_android_package=UNKNOWN_NO_ACCESS",
-    "firebase_android_config_authority=UNKNOWN_NO_ACCESS",
-    "firebase_android_config_project=UNKNOWN_NO_ACCESS",
-    "firebase_android_config_package=UNKNOWN_NO_ACCESS",
-  ]);
-  assert.doesNotMatch(result.lines.join("\n"), /VERIFIED_ABSENT/);
+  for (const fetchImpl of [
+    async () => fakeJsonResponse(403, { error: { status: "PERMISSION_DENIED" } }),
+    async () => fakeJsonResponse(500, { error: { status: "INTERNAL" } }),
+    async () => {
+      throw new Error("network unavailable");
+    },
+  ]) {
+    const result = await probeFirebaseAuthority({
+      accessToken: "secret",
+      expectedProjectId: EXPECTED_PROJECT_ID,
+      expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+      expectedPackage: EXPECTED_PACKAGE,
+      fetchImpl,
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(result.lines, [
+      "firebase_project_external_authority=UNKNOWN_NO_ACCESS",
+      "firebase_project_identity=UNKNOWN_NO_ACCESS",
+      "firebase_android_app_external_authority=UNKNOWN_NO_ACCESS",
+      "firebase_android_package=UNKNOWN_NO_ACCESS",
+      "firebase_android_config_authority=UNKNOWN_NO_ACCESS",
+      "firebase_android_config_project=UNKNOWN_NO_ACCESS",
+      "firebase_android_config_package=UNKNOWN_NO_ACCESS",
+    ]);
+    assert.doesNotMatch(result.lines.join("\n"), /VERIFIED_ABSENT/);
+  }
 });
 
-test("a successful authoritative Android-app list with no exact package establishes verified absence", async () => {
+test("complete authoritative Android inventory may prove absence while project authority stays externally verified", async () => {
   const { probeFirebaseAuthority } = await loadProbeModule();
   const fetchImpl = async (url) => {
     if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
-      return fakeJsonResponse(200, {
-        projectId: EXPECTED_PROJECT_ID,
-        projectNumber: EXPECTED_PROJECT_NUMBER,
-        state: "ACTIVE",
-      });
+      return fakeJsonResponse(200, canonicalProject());
     }
     if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
       return fakeJsonResponse(200, {
@@ -301,7 +339,7 @@ test("a successful authoritative Android-app list with no exact package establis
 
   assert.equal(result.exitCode, 0);
   assert.deepEqual(result.lines, [
-    "firebase_project_external_authority=VERIFIED_PRESENT",
+    `firebase_project_external_authority=${EXTERNAL_AUTHORITY}`,
     "firebase_project_identity=VERIFIED_MATCH",
     "firebase_android_app_external_authority=VERIFIED_ABSENT",
     "firebase_android_package=VERIFIED_ABSENT",
@@ -311,7 +349,7 @@ test("a successful authoritative Android-app list with no exact package establis
   ]);
 });
 
-test("authoritative project or app identity mismatch fails closed", async () => {
+test("authoritative project identity mismatch remains fail-closed", async () => {
   const { probeFirebaseAuthority } = await loadProbeModule();
   const result = await probeFirebaseAuthority({
     accessToken: "secret",
@@ -335,5 +373,46 @@ test("authoritative project or app identity mismatch fails closed", async () => 
     "firebase_android_config_authority=UNKNOWN_NO_ACCESS",
     "firebase_android_config_project=UNKNOWN_NO_ACCESS",
     "firebase_android_config_package=UNKNOWN_NO_ACCESS",
+  ]);
+});
+
+test("successful config authority remains externally verified even when config relationships mismatch", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  const badConfig = canonicalConfig();
+  badConfig.project_info.project_id = "different-project";
+  badConfig.client[0].client_info.android_client_info.package_name = "com.example.other";
+
+  const fetchImpl = async (url) => {
+    if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
+      return fakeJsonResponse(200, canonicalProject());
+    }
+    if (String(url).endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
+      return fakeJsonResponse(200, { apps: [canonicalApp()] });
+    }
+    if (String(url).endsWith("/config")) {
+      return fakeJsonResponse(200, {
+        configFileContents: Buffer.from(JSON.stringify(badConfig), "utf8").toString("base64"),
+      });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  };
+
+  const result = await probeFirebaseAuthority({
+    accessToken: "secret",
+    expectedProjectId: EXPECTED_PROJECT_ID,
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    expectedPackage: EXPECTED_PACKAGE,
+    fetchImpl,
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.lines, [
+    `firebase_project_external_authority=${EXTERNAL_AUTHORITY}`,
+    "firebase_project_identity=VERIFIED_MATCH",
+    `firebase_android_app_external_authority=${EXTERNAL_AUTHORITY}`,
+    "firebase_android_package=VERIFIED_MATCH",
+    `firebase_android_config_authority=${EXTERNAL_AUTHORITY}`,
+    "firebase_android_config_project=MISMATCH",
+    "firebase_android_config_package=MISMATCH",
   ]);
 });

--- a/functions/test/productionFirebaseAuthorityProbePaginationBlock3F.test.js
+++ b/functions/test/productionFirebaseAuthorityProbePaginationBlock3F.test.js
@@ -1,0 +1,122 @@
+"use strict";
+
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const probePath = path.resolve(
+  process.cwd(),
+  "../scripts/production-3f-firebase-authority-probe.mjs"
+);
+
+const EXPECTED_PROJECT_ID = "click-save-ai-production";
+const EXPECTED_PROJECT_NUMBER = "991489557172";
+const EXPECTED_PACKAGE = "com.aistudio.clickandsaveai.app";
+
+function fakeJsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+  };
+}
+
+async function loadProbeModule() {
+  return import(`${pathToFileURL(probePath).href}?t=${Date.now()}-${Math.random()}`);
+}
+
+test("Android app authority follows every pageToken before matching or declaring VERIFIED_ABSENT", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  const calls = [];
+  const config = {
+    project_info: {
+      project_id: EXPECTED_PROJECT_ID,
+      project_number: EXPECTED_PROJECT_NUMBER,
+    },
+    client: [
+      {
+        client_info: {
+          mobilesdk_app_id: "1:991489557172:android:target",
+          android_client_info: { package_name: EXPECTED_PACKAGE },
+        },
+      },
+    ],
+  };
+
+  const fetchImpl = async (url) => {
+    const parsed = new URL(String(url));
+    calls.push(parsed);
+
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
+      return fakeJsonResponse(200, {
+        projectId: EXPECTED_PROJECT_ID,
+        projectNumber: EXPECTED_PROJECT_NUMBER,
+        state: "ACTIVE",
+      });
+    }
+
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
+      if (!parsed.searchParams.has("pageToken")) {
+        return fakeJsonResponse(200, {
+          apps: [
+            {
+              name: `projects/${EXPECTED_PROJECT_ID}/androidApps/other`,
+              projectId: EXPECTED_PROJECT_ID,
+              packageName: "com.example.other",
+              state: "ACTIVE",
+            },
+          ],
+          nextPageToken: "PAGE_2_TOKEN",
+        });
+      }
+      assert.equal(parsed.searchParams.get("pageToken"), "PAGE_2_TOKEN");
+      return fakeJsonResponse(200, {
+        apps: [
+          {
+            name: `projects/${EXPECTED_PROJECT_ID}/androidApps/1:991489557172:android:target`,
+            appId: "1:991489557172:android:target",
+            projectId: EXPECTED_PROJECT_ID,
+            packageName: EXPECTED_PACKAGE,
+            state: "ACTIVE",
+          },
+        ],
+      });
+    }
+
+    if (parsed.pathname.endsWith("/config")) {
+      return fakeJsonResponse(200, {
+        configFilename: "google-services.json",
+        configFileContents: Buffer.from(JSON.stringify(config), "utf8").toString("base64"),
+      });
+    }
+
+    throw new Error(`unexpected URL: ${url}`);
+  };
+
+  const result = await probeFirebaseAuthority({
+    accessToken: "secret",
+    expectedProjectId: EXPECTED_PROJECT_ID,
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    expectedPackage: EXPECTED_PACKAGE,
+    fetchImpl,
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    "firebase_project_external_authority=VERIFIED_PRESENT",
+    "firebase_project_identity=VERIFIED_MATCH",
+    "firebase_android_app_external_authority=VERIFIED_PRESENT",
+    "firebase_android_package=VERIFIED_MATCH",
+    "firebase_android_config_authority=VERIFIED_PRESENT",
+    "firebase_android_config_project=VERIFIED_MATCH",
+    "firebase_android_config_package=VERIFIED_MATCH",
+  ]);
+
+  const appListCalls = calls.filter((call) =>
+    call.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)
+  );
+  assert.equal(appListCalls.length, 2);
+});

--- a/functions/test/productionFirebaseAuthorityProbePaginationBlock3F.test.js
+++ b/functions/test/productionFirebaseAuthorityProbePaginationBlock3F.test.js
@@ -10,6 +10,7 @@ const probePath = path.resolve(
   "../scripts/production-3f-firebase-authority-probe.mjs"
 );
 
+const EXTERNAL_AUTHORITY = "EXTERNALLY_AUTHORITATIVE_VERIFIED";
 const EXPECTED_PROJECT_ID = "click-save-ai-production";
 const EXPECTED_PROJECT_NUMBER = "991489557172";
 const EXPECTED_PACKAGE = "com.aistudio.clickandsaveai.app";
@@ -28,10 +29,26 @@ async function loadProbeModule() {
   return import(`${pathToFileURL(probePath).href}?t=${Date.now()}-${Math.random()}`);
 }
 
-test("Android app authority follows every pageToken before matching or declaring VERIFIED_ABSENT", async () => {
-  const { probeFirebaseAuthority } = await loadProbeModule();
-  const calls = [];
-  const config = {
+function canonicalProject() {
+  return {
+    projectId: EXPECTED_PROJECT_ID,
+    projectNumber: EXPECTED_PROJECT_NUMBER,
+    state: "ACTIVE",
+  };
+}
+
+function canonicalApp() {
+  return {
+    name: `projects/${EXPECTED_PROJECT_ID}/androidApps/1:991489557172:android:target`,
+    appId: "1:991489557172:android:target",
+    projectId: EXPECTED_PROJECT_ID,
+    packageName: EXPECTED_PACKAGE,
+    state: "ACTIVE",
+  };
+}
+
+function canonicalConfig() {
+  return {
     project_info: {
       project_id: EXPECTED_PROJECT_ID,
       project_number: EXPECTED_PROJECT_NUMBER,
@@ -45,17 +62,28 @@ test("Android app authority follows every pageToken before matching or declaring
       },
     ],
   };
+}
+
+function callProbe(probeFirebaseAuthority, fetchImpl) {
+  return probeFirebaseAuthority({
+    accessToken: "secret",
+    expectedProjectId: EXPECTED_PROJECT_ID,
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    expectedPackage: EXPECTED_PACKAGE,
+    fetchImpl,
+  });
+}
+
+test("Android app authority follows every pageToken before matching and emits external authority truth", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  const calls = [];
 
   const fetchImpl = async (url) => {
     const parsed = new URL(String(url));
     calls.push(parsed);
 
     if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
-      return fakeJsonResponse(200, {
-        projectId: EXPECTED_PROJECT_ID,
-        projectNumber: EXPECTED_PROJECT_NUMBER,
-        state: "ACTIVE",
-      });
+      return fakeJsonResponse(200, canonicalProject());
     }
 
     if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
@@ -73,44 +101,28 @@ test("Android app authority follows every pageToken before matching or declaring
         });
       }
       assert.equal(parsed.searchParams.get("pageToken"), "PAGE_2_TOKEN");
-      return fakeJsonResponse(200, {
-        apps: [
-          {
-            name: `projects/${EXPECTED_PROJECT_ID}/androidApps/1:991489557172:android:target`,
-            appId: "1:991489557172:android:target",
-            projectId: EXPECTED_PROJECT_ID,
-            packageName: EXPECTED_PACKAGE,
-            state: "ACTIVE",
-          },
-        ],
-      });
+      return fakeJsonResponse(200, { apps: [canonicalApp()] });
     }
 
     if (parsed.pathname.endsWith("/config")) {
       return fakeJsonResponse(200, {
         configFilename: "google-services.json",
-        configFileContents: Buffer.from(JSON.stringify(config), "utf8").toString("base64"),
+        configFileContents: Buffer.from(JSON.stringify(canonicalConfig()), "utf8").toString("base64"),
       });
     }
 
     throw new Error(`unexpected URL: ${url}`);
   };
 
-  const result = await probeFirebaseAuthority({
-    accessToken: "secret",
-    expectedProjectId: EXPECTED_PROJECT_ID,
-    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
-    expectedPackage: EXPECTED_PACKAGE,
-    fetchImpl,
-  });
+  const result = await callProbe(probeFirebaseAuthority, fetchImpl);
 
   assert.equal(result.exitCode, 0);
   assert.deepEqual(result.lines, [
-    "firebase_project_external_authority=VERIFIED_PRESENT",
+    `firebase_project_external_authority=${EXTERNAL_AUTHORITY}`,
     "firebase_project_identity=VERIFIED_MATCH",
-    "firebase_android_app_external_authority=VERIFIED_PRESENT",
+    `firebase_android_app_external_authority=${EXTERNAL_AUTHORITY}`,
     "firebase_android_package=VERIFIED_MATCH",
-    "firebase_android_config_authority=VERIFIED_PRESENT",
+    `firebase_android_config_authority=${EXTERNAL_AUTHORITY}`,
     "firebase_android_config_project=VERIFIED_MATCH",
     "firebase_android_config_package=VERIFIED_MATCH",
   ]);
@@ -119,4 +131,136 @@ test("Android app authority follows every pageToken before matching or declaring
     call.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)
   );
   assert.equal(appListCalls.length, 2);
+});
+
+test("VERIFIED_ABSENT is allowed only after the final authoritative Android-app page completes", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  let appPage = 0;
+
+  const result = await callProbe(probeFirebaseAuthority, async (url) => {
+    const parsed = new URL(String(url));
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
+      return fakeJsonResponse(200, canonicalProject());
+    }
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
+      appPage += 1;
+      if (appPage === 1) {
+        return fakeJsonResponse(200, {
+          apps: [{ packageName: "com.example.one" }],
+          nextPageToken: "PAGE_2",
+        });
+      }
+      assert.equal(parsed.searchParams.get("pageToken"), "PAGE_2");
+      return fakeJsonResponse(200, { apps: [{ packageName: "com.example.two" }] });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  assert.equal(appPage, 2);
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    `firebase_project_external_authority=${EXTERNAL_AUTHORITY}`,
+    "firebase_project_identity=VERIFIED_MATCH",
+    "firebase_android_app_external_authority=VERIFIED_ABSENT",
+    "firebase_android_package=VERIFIED_ABSENT",
+    "firebase_android_config_authority=VERIFIED_ABSENT",
+    "firebase_android_config_project=VERIFIED_ABSENT",
+    "firebase_android_config_package=VERIFIED_ABSENT",
+  ]);
+});
+
+test("second-page non-2xx is incomplete authority and remains UNKNOWN_NO_ACCESS, never VERIFIED_ABSENT", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+
+  const result = await callProbe(probeFirebaseAuthority, async (url) => {
+    const parsed = new URL(String(url));
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
+      return fakeJsonResponse(200, canonicalProject());
+    }
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
+      if (!parsed.searchParams.has("pageToken")) {
+        return fakeJsonResponse(200, {
+          apps: [{ packageName: "com.example.other" }],
+          nextPageToken: "PAGE_2",
+        });
+      }
+      return fakeJsonResponse(503, { error: { status: "UNAVAILABLE" } });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    `firebase_project_external_authority=${EXTERNAL_AUTHORITY}`,
+    "firebase_project_identity=VERIFIED_MATCH",
+    "firebase_android_app_external_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_package=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_project=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_package=UNKNOWN_NO_ACCESS",
+  ]);
+  assert.doesNotMatch(result.lines.join("\n"), /VERIFIED_ABSENT/);
+});
+
+test("repeated Android page token is incomplete authority and remains UNKNOWN_NO_ACCESS", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+
+  const result = await callProbe(probeFirebaseAuthority, async (url) => {
+    const parsed = new URL(String(url));
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
+      return fakeJsonResponse(200, canonicalProject());
+    }
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
+      return fakeJsonResponse(200, {
+        apps: [{ packageName: "com.example.other" }],
+        nextPageToken: "LOOP_TOKEN",
+      });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    `firebase_project_external_authority=${EXTERNAL_AUTHORITY}`,
+    "firebase_project_identity=VERIFIED_MATCH",
+    "firebase_android_app_external_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_package=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_project=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_package=UNKNOWN_NO_ACCESS",
+  ]);
+  assert.doesNotMatch(result.lines.join("\n"), /VERIFIED_ABSENT/);
+});
+
+test("page-limit exhaustion preserves MAX_ANDROID_APP_PAGES fail-closed behavior", async () => {
+  const { probeFirebaseAuthority } = await loadProbeModule();
+  let listCalls = 0;
+
+  const result = await callProbe(probeFirebaseAuthority, async (url) => {
+    const parsed = new URL(String(url));
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}`)) {
+      return fakeJsonResponse(200, canonicalProject());
+    }
+    if (parsed.pathname.endsWith(`/projects/${EXPECTED_PROJECT_ID}/androidApps`)) {
+      listCalls += 1;
+      return fakeJsonResponse(200, {
+        apps: [{ packageName: `com.example.${listCalls}` }],
+        nextPageToken: `PAGE_${listCalls + 1}`,
+      });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  assert.equal(listCalls, 100);
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    `firebase_project_external_authority=${EXTERNAL_AUTHORITY}`,
+    "firebase_project_identity=VERIFIED_MATCH",
+    "firebase_android_app_external_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_package=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_authority=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_project=UNKNOWN_NO_ACCESS",
+    "firebase_android_config_package=UNKNOWN_NO_ACCESS",
+  ]);
+  assert.doesNotMatch(result.lines.join("\n"), /VERIFIED_ABSENT/);
 });

--- a/scripts/production-3f-firebase-authority-probe.mjs
+++ b/scripts/production-3f-firebase-authority-probe.mjs
@@ -5,6 +5,7 @@ const CANONICAL_PROJECT_ID = "click-save-ai-production";
 const CANONICAL_PROJECT_NUMBER = "991489557172";
 const CANONICAL_PACKAGE = "com.aistudio.clickandsaveai.app";
 const UNKNOWN = "UNKNOWN_NO_ACCESS";
+const EXTERNAL_AUTHORITY = "EXTERNALLY_AUTHORITATIVE_VERIFIED";
 const MAX_ANDROID_APP_PAGES = 100;
 
 function linesFor({
@@ -144,7 +145,7 @@ export async function probeFirebaseAuthority({
   }
 
   const projectVerified = {
-    projectAuthority: "VERIFIED_PRESENT",
+    projectAuthority: EXTERNAL_AUTHORITY,
     projectIdentity: "VERIFIED_MATCH",
   };
 
@@ -199,7 +200,7 @@ export async function probeFirebaseAuthority({
 
   const appVerified = {
     ...projectVerified,
-    appAuthority: "VERIFIED_PRESENT",
+    appAuthority: EXTERNAL_AUTHORITY,
     packageIdentity: "VERIFIED_MATCH",
   };
   const configRead = await readJson(
@@ -230,7 +231,7 @@ export async function probeFirebaseAuthority({
       exitCode: 1,
       lines: linesFor({
         ...appVerified,
-        configAuthority: "VERIFIED_PRESENT",
+        configAuthority: EXTERNAL_AUTHORITY,
         configProject: configProjectMatches ? "VERIFIED_MATCH" : "MISMATCH",
         configPackage: configPackagePresent ? "VERIFIED_MATCH" : "MISMATCH",
       }),
@@ -241,7 +242,7 @@ export async function probeFirebaseAuthority({
     exitCode: 0,
     lines: linesFor({
       ...appVerified,
-      configAuthority: "VERIFIED_PRESENT",
+      configAuthority: EXTERNAL_AUTHORITY,
       configProject: "VERIFIED_MATCH",
       configPackage: "VERIFIED_MATCH",
     }),

--- a/scripts/production-3f-firebase-authority-probe.mjs
+++ b/scripts/production-3f-firebase-authority-probe.mjs
@@ -1,0 +1,232 @@
+import { pathToFileURL } from "node:url";
+
+const FIREBASE_MANAGEMENT_BASE = "https://firebase.googleapis.com/v1beta1";
+const CANONICAL_PROJECT_ID = "click-save-ai-production";
+const CANONICAL_PROJECT_NUMBER = "991489557172";
+const CANONICAL_PACKAGE = "com.aistudio.clickandsaveai.app";
+const UNKNOWN = "UNKNOWN_NO_ACCESS";
+
+function linesFor({
+  projectAuthority = UNKNOWN,
+  projectIdentity = UNKNOWN,
+  appAuthority = UNKNOWN,
+  packageIdentity = UNKNOWN,
+  configAuthority = UNKNOWN,
+  configProject = UNKNOWN,
+  configPackage = UNKNOWN,
+} = {}) {
+  return [
+    `firebase_project_external_authority=${projectAuthority}`,
+    `firebase_project_identity=${projectIdentity}`,
+    `firebase_android_app_external_authority=${appAuthority}`,
+    `firebase_android_package=${packageIdentity}`,
+    `firebase_android_config_authority=${configAuthority}`,
+    `firebase_android_config_project=${configProject}`,
+    `firebase_android_config_package=${configPackage}`,
+  ];
+}
+
+async function readJson(url, accessToken, fetchImpl) {
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+    });
+    if (!response?.ok) {
+      return { available: false, status: response?.status ?? 0, body: null };
+    }
+    const body = await response.json();
+    return { available: true, status: response.status, body };
+  } catch {
+    return { available: false, status: 0, body: null };
+  }
+}
+
+function safeDecodeConfig(encoded) {
+  if (typeof encoded !== "string" || encoded.length === 0) return null;
+  try {
+    const text = Buffer.from(encoded, "base64").toString("utf8");
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function projectIdentityMatches(project, expectedProjectId, expectedProjectNumber) {
+  return (
+    project &&
+    project.projectId === expectedProjectId &&
+    String(project.projectNumber ?? "") === expectedProjectNumber
+  );
+}
+
+function validateExpectedInputs(expectedProjectId, expectedProjectNumber, expectedPackage) {
+  return (
+    expectedProjectId === CANONICAL_PROJECT_ID &&
+    expectedProjectNumber === CANONICAL_PROJECT_NUMBER &&
+    expectedPackage === CANONICAL_PACKAGE
+  );
+}
+
+export async function probeFirebaseAuthority({
+  accessToken,
+  expectedProjectId,
+  expectedProjectNumber,
+  expectedPackage,
+  fetchImpl = globalThis.fetch,
+}) {
+  if (
+    typeof accessToken !== "string" ||
+    accessToken.length === 0 ||
+    typeof fetchImpl !== "function" ||
+    !validateExpectedInputs(expectedProjectId, expectedProjectNumber, expectedPackage)
+  ) {
+    return { exitCode: 1, lines: linesFor() };
+  }
+
+  const projectPath = `/projects/${encodeURIComponent(expectedProjectId)}`;
+  const projectRead = await readJson(
+    `${FIREBASE_MANAGEMENT_BASE}${projectPath}`,
+    accessToken,
+    fetchImpl
+  );
+
+  if (!projectRead.available) {
+    return { exitCode: 0, lines: linesFor() };
+  }
+
+  if (!projectIdentityMatches(projectRead.body, expectedProjectId, expectedProjectNumber)) {
+    return {
+      exitCode: 1,
+      lines: linesFor({ projectAuthority: "MISMATCH", projectIdentity: "MISMATCH" }),
+    };
+  }
+
+  const projectVerified = {
+    projectAuthority: "VERIFIED_PRESENT",
+    projectIdentity: "VERIFIED_MATCH",
+  };
+
+  const appsRead = await readJson(
+    `${FIREBASE_MANAGEMENT_BASE}${projectPath}/androidApps`,
+    accessToken,
+    fetchImpl
+  );
+  if (!appsRead.available) {
+    return { exitCode: 0, lines: linesFor(projectVerified) };
+  }
+
+  const apps = Array.isArray(appsRead.body?.apps) ? appsRead.body.apps : [];
+  const matches = apps.filter((app) => app?.packageName === expectedPackage);
+  if (matches.length === 0) {
+    return {
+      exitCode: 0,
+      lines: linesFor({
+        ...projectVerified,
+        appAuthority: "VERIFIED_ABSENT",
+        packageIdentity: "VERIFIED_ABSENT",
+        configAuthority: "VERIFIED_ABSENT",
+        configProject: "VERIFIED_ABSENT",
+        configPackage: "VERIFIED_ABSENT",
+      }),
+    };
+  }
+
+  if (matches.length !== 1) {
+    return {
+      exitCode: 1,
+      lines: linesFor({
+        ...projectVerified,
+        appAuthority: "MISMATCH",
+        packageIdentity: "MISMATCH",
+      }),
+    };
+  }
+
+  const app = matches[0];
+  const expectedNamePrefix = `projects/${expectedProjectId}/androidApps/`;
+  if (
+    typeof app.name !== "string" ||
+    !app.name.startsWith(expectedNamePrefix) ||
+    app.name.slice(expectedNamePrefix.length).includes("/") ||
+    (app.projectId !== undefined && app.projectId !== expectedProjectId)
+  ) {
+    return {
+      exitCode: 1,
+      lines: linesFor({
+        ...projectVerified,
+        appAuthority: "MISMATCH",
+        packageIdentity: "MISMATCH",
+      }),
+    };
+  }
+
+  const appVerified = {
+    ...projectVerified,
+    appAuthority: "VERIFIED_PRESENT",
+    packageIdentity: "VERIFIED_MATCH",
+  };
+  const configRead = await readJson(
+    `${FIREBASE_MANAGEMENT_BASE}/${app.name}/config`,
+    accessToken,
+    fetchImpl
+  );
+  if (!configRead.available) {
+    return { exitCode: 0, lines: linesFor(appVerified) };
+  }
+
+  const config = safeDecodeConfig(configRead.body?.configFileContents);
+  if (!config) {
+    return { exitCode: 0, lines: linesFor(appVerified) };
+  }
+
+  const configProjectId = config?.project_info?.project_id;
+  const configProjectNumber = String(config?.project_info?.project_number ?? "");
+  const clients = Array.isArray(config?.client) ? config.client : [];
+  const configPackagePresent = clients.some(
+    (client) => client?.client_info?.android_client_info?.package_name === expectedPackage
+  );
+  const configProjectMatches =
+    configProjectId === expectedProjectId && configProjectNumber === expectedProjectNumber;
+
+  if (!configProjectMatches || !configPackagePresent) {
+    return {
+      exitCode: 1,
+      lines: linesFor({
+        ...appVerified,
+        configAuthority: "VERIFIED_PRESENT",
+        configProject: configProjectMatches ? "VERIFIED_MATCH" : "MISMATCH",
+        configPackage: configPackagePresent ? "VERIFIED_MATCH" : "MISMATCH",
+      }),
+    };
+  }
+
+  return {
+    exitCode: 0,
+    lines: linesFor({
+      ...appVerified,
+      configAuthority: "VERIFIED_PRESENT",
+      configProject: "VERIFIED_MATCH",
+      configPackage: "VERIFIED_MATCH",
+    }),
+  };
+}
+
+async function runCli() {
+  const result = await probeFirebaseAuthority({
+    accessToken: process.env.BLOCK3F_FIREBASE_ACCESS_TOKEN ?? "",
+    expectedProjectId: process.env.EXPECTED_PROJECT_ID ?? "",
+    expectedProjectNumber: process.env.EXPECTED_PROJECT_NUMBER ?? "",
+    expectedPackage: process.env.EXPECTED_PACKAGE ?? "",
+  });
+  for (const line of result.lines) console.log(line);
+  process.exitCode = result.exitCode;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runCli();
+}

--- a/scripts/production-3f-firebase-authority-probe.mjs
+++ b/scripts/production-3f-firebase-authority-probe.mjs
@@ -5,6 +5,7 @@ const CANONICAL_PROJECT_ID = "click-save-ai-production";
 const CANONICAL_PROJECT_NUMBER = "991489557172";
 const CANONICAL_PACKAGE = "com.aistudio.clickandsaveai.app";
 const UNKNOWN = "UNKNOWN_NO_ACCESS";
+const MAX_ANDROID_APP_PAGES = 100;
 
 function linesFor({
   projectAuthority = UNKNOWN,
@@ -43,6 +44,42 @@ async function readJson(url, accessToken, fetchImpl) {
   } catch {
     return { available: false, status: 0, body: null };
   }
+}
+
+async function listAllAndroidApps(projectPath, accessToken, fetchImpl) {
+  const baseUrl = `${FIREBASE_MANAGEMENT_BASE}${projectPath}/androidApps`;
+  const apps = [];
+  const seenPageTokens = new Set();
+  let pageToken = "";
+
+  for (let page = 0; page < MAX_ANDROID_APP_PAGES; page += 1) {
+    const url = pageToken
+      ? `${baseUrl}?pageToken=${encodeURIComponent(pageToken)}`
+      : baseUrl;
+    const pageRead = await readJson(url, accessToken, fetchImpl);
+    if (!pageRead.available) {
+      return { available: false, apps: [] };
+    }
+
+    if (Array.isArray(pageRead.body?.apps)) {
+      apps.push(...pageRead.body.apps);
+    }
+
+    const nextPageToken =
+      typeof pageRead.body?.nextPageToken === "string"
+        ? pageRead.body.nextPageToken.trim()
+        : "";
+    if (!nextPageToken) {
+      return { available: true, apps };
+    }
+    if (seenPageTokens.has(nextPageToken)) {
+      return { available: false, apps: [] };
+    }
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
+  }
+
+  return { available: false, apps: [] };
 }
 
 function safeDecodeConfig(encoded) {
@@ -111,17 +148,12 @@ export async function probeFirebaseAuthority({
     projectIdentity: "VERIFIED_MATCH",
   };
 
-  const appsRead = await readJson(
-    `${FIREBASE_MANAGEMENT_BASE}${projectPath}/androidApps`,
-    accessToken,
-    fetchImpl
-  );
+  const appsRead = await listAllAndroidApps(projectPath, accessToken, fetchImpl);
   if (!appsRead.available) {
     return { exitCode: 0, lines: linesFor(projectVerified) };
   }
 
-  const apps = Array.isArray(appsRead.body?.apps) ? appsRead.body.apps : [];
-  const matches = apps.filter((app) => app?.packageName === expectedPackage);
+  const matches = appsRead.apps.filter((app) => app?.packageName === expectedPackage);
   if (matches.length === 0) {
     return {
       exitCode: 0,


### PR DESCRIPTION
Repository preparation only for Issue #74 / Master Control `NEXT ADVANCEMENT: external-authority read-only probe PREP AUTHORIZED`.

## Scope implemented

- Added dedicated `authorize_3f_external_authority_probe` input in canonical `.github/workflows/production-release.yml`
  - default: `NO_3F_EXTERNAL_PROBE`
  - exact authorization phrase: `PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY`
- Added dedicated `production-3f-firebase-authority-probe` job.
- Locked the job to the exact Production boundary:
  - project: `click-save-ai-production`
  - project number: `991489557172`
  - Android package: `com.aistudio.clickandsaveai.app`
  - deploy SA: `clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com`
- Reuses only the already-proven WIF provider + deploy service-account path.
- Uses an ephemeral access token scoped to `https://www.googleapis.com/auth/firebase.readonly`.
- Firebase Management API implementation is read-only (`GET`) and limited to:
  - exact Firebase project metadata
  - complete paginated Android-app inventory
  - exact matching Android app config metadata, sanitized in memory/output
- `403`, non-2xx, network failure, incomplete pagination, or unavailable authority remains `UNKNOWN_NO_ACCESS`.
- `VERIFIED_ABSENT` is permitted only after a complete authoritative Android-app inventory read.
- Run #2 truth is preserved: non-WIF protected Production config that was `NOT_AVAILABLE_TO_JOB` is not required or reinterpreted by this probe.
- External-authority mode is mutually exclusive with candidate build, existing WIF proof, existing metadata probe, and Firebase deploy paths.

## Explicitly not performed

- No `Production Release Gate` dispatch.
- No live OIDC/WIF/Production Firebase read.
- No Firebase provisioning or mutation.
- No API enablement.
- No IAM broadening or IAM mutation.
- No service-account key creation.
- No Play, OAuth, or App Check mutation.
- No signed Production build, deploy, or publish.
- No GitHub secret/variable mutation.
- No merge and no Block 3G work.

## TDD / verification

- Initial RED before implementation: 10 new Block 3F contract failures; 347 existing tests passed.
- Review identified Firebase Android-app pagination as an authority edge case.
- Pagination RED before fix: 357 tests passed; exactly 1 targeted pagination test failed.
- Final backend GREEN on head `5d1ac676e736341aa06953c76ca19250cda80663`: `358/358` tests passed.
- Final PR CI on the same head:
  - Production Operations CI #63 — success — run `31988581529`
  - Android and Backend CI #867 — success — run `31988581531`
  - Production Enablement Security CI #93 — success — run `31988581617`
- GitHub reports exactly 3 Actions runs for this head, all `pull_request` CI; no `Production Release Gate` run exists for this head.

This PR intentionally remains **DRAFT**. Do not merge. Live execution requires a separate explicit Master Control authorization.

Authoritative issue: #74