### PR TITLE
Block 3F: prepare Firebase service-state diagnostic

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -31,6 +31,11 @@ on:
         required: true
         default: NO_3F_EXTERNAL_PROBE
         type: string
+      authorize_3f_service_state_probe:
+        description: Type PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY only when a separately authorized Block 3F Firebase Management API service-state read-only probe is intended
+        required: true
+        default: NO_3F_SERVICE_STATE_PROBE
+        type: string
 
 concurrency:
   group: clickandsaveai-production-release
@@ -38,7 +43,7 @@ concurrency:
 
 jobs:
   production-candidate:
-    if: ${{ inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' }}
+    if: ${{ inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_3f_service_state_probe != 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 45
@@ -233,7 +238,7 @@ jobs:
           rm -f app/src/release/google-services.json "$PRODUCTION_GOOGLE_SERVICES_JSON_PATH" "$PRODUCTION_UPLOAD_KEYSTORE_PATH"
 
   production-wif-auth-proof:
-    if: ${{ inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_wif_auth_proof == 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
+    if: ${{ inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_3f_service_state_probe != 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY' && inputs.authorize_wif_auth_proof == 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 10
@@ -331,7 +336,7 @@ jobs:
             'credential_type=external_account'
 
   production-3f-metadata-probe:
-    if: ${{ inputs.authorize_3f_metadata_probe == 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
+    if: ${{ inputs.authorize_3f_metadata_probe == 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_3f_service_state_probe != 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 10
@@ -437,7 +442,7 @@ jobs:
           rm -f "$BLOCK3F_GOOGLE_CONFIG_PATH" "$BLOCK3F_UPLOAD_KEYSTORE_PATH"
 
   production-3f-firebase-authority-probe:
-    if: ${{ inputs.authorize_3f_external_authority_probe == 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF' && inputs.authorize_3f_metadata_probe == 'NO_3F_PROBE' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
+    if: ${{ inputs.authorize_3f_external_authority_probe == 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_3f_service_state_probe != 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF' && inputs.authorize_3f_metadata_probe == 'NO_3F_PROBE' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 10
@@ -468,6 +473,7 @@ jobs:
           [[ '${{ inputs.authorize_firebase_deploy }}' == 'NO_DEPLOY' ]] || { echo 'External-authority probe requires authorize_firebase_deploy=NO_DEPLOY.' >&2; exit 1; }
           [[ '${{ inputs.authorize_wif_auth_proof }}' == 'NO_WIF_PROOF' ]] || { echo 'External-authority probe requires authorize_wif_auth_proof=NO_WIF_PROOF.' >&2; exit 1; }
           [[ '${{ inputs.authorize_3f_metadata_probe }}' == 'NO_3F_PROBE' ]] || { echo 'External-authority probe requires authorize_3f_metadata_probe=NO_3F_PROBE.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_3f_service_state_probe }}' == 'NO_3F_SERVICE_STATE_PROBE' ]] || { echo 'External-authority probe requires authorize_3f_service_state_probe=NO_3F_SERVICE_STATE_PROBE.' >&2; exit 1; }
           [[ '${{ inputs.confirm_environment }}' == 'CLICKANDSAVEAI_PRODUCTION' ]] || { echo 'Production confirmation phrase mismatch.' >&2; exit 1; }
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'source_sha must be an exact lowercase 40-character commit SHA.' >&2; exit 1; }
           [[ '${{ github.sha }}' == "$SOURCE_SHA" ]] || { echo 'External-authority probe source must equal the workflow main HEAD.' >&2; exit 1; }
@@ -517,9 +523,89 @@ jobs:
           BLOCK3F_FIREBASE_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: node scripts/production-3f-firebase-authority-probe.mjs
 
+  production-3f-firebase-service-state-probe:
+    if: ${{ inputs.authorize_3f_service_state_probe == 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY' && inputs.authorize_firebase_deploy == 'NO_DEPLOY' && inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF' && inputs.authorize_3f_metadata_probe == 'NO_3F_PROBE' && inputs.authorize_3f_external_authority_probe == 'NO_3F_EXTERNAL_PROBE' && inputs.confirm_environment == 'CLICKANDSAVEAI_PRODUCTION' }}
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      SOURCE_SHA: ${{ inputs.source_sha }}
+      EXPECTED_REPOSITORY: vhanukaev1981/ClickAndSaveAI
+      EXPECTED_REPOSITORY_ID: '1314210715'
+      EXPECTED_REPOSITORY_OWNER_ID: '64756523'
+      EXPECTED_ENVIRONMENT: production
+      EXPECTED_REF: refs/heads/main
+      EXPECTED_WORKFLOW_REF: vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main
+      EXPECTED_PROJECT_ID: click-save-ai-production
+      EXPECTED_PROJECT_NUMBER: '991489557172'
+      EXPECTED_DEPLOY_SA: clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_DEPLOY_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+    steps:
+      - name: Guard exact Block 3F Firebase service-state read-only boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ '${{ inputs.authorize_3f_service_state_probe }}' == 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY' ]] || { echo 'Block 3F service-state probe authorization phrase mismatch.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_firebase_deploy }}' == 'NO_DEPLOY' ]] || { echo 'Service-state probe requires authorize_firebase_deploy=NO_DEPLOY.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_wif_auth_proof }}' == 'NO_WIF_PROOF' ]] || { echo 'Service-state probe requires authorize_wif_auth_proof=NO_WIF_PROOF.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_3f_metadata_probe }}' == 'NO_3F_PROBE' ]] || { echo 'Service-state probe requires authorize_3f_metadata_probe=NO_3F_PROBE.' >&2; exit 1; }
+          [[ '${{ inputs.authorize_3f_external_authority_probe }}' == 'NO_3F_EXTERNAL_PROBE' ]] || { echo 'Service-state probe requires authorize_3f_external_authority_probe=NO_3F_EXTERNAL_PROBE.' >&2; exit 1; }
+          [[ '${{ inputs.confirm_environment }}' == 'CLICKANDSAVEAI_PRODUCTION' ]] || { echo 'Production confirmation phrase mismatch.' >&2; exit 1; }
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'source_sha must be an exact lowercase 40-character commit SHA.' >&2; exit 1; }
+          [[ '${{ github.sha }}' == "$SOURCE_SHA" ]] || { echo 'Service-state probe source must equal the workflow main HEAD.' >&2; exit 1; }
+          [[ '${{ github.repository }}' == "$EXPECTED_REPOSITORY" ]] || { echo 'Repository identity mismatch.' >&2; exit 1; }
+          [[ '${{ github.repository_id }}' == "$EXPECTED_REPOSITORY_ID" ]] || { echo 'Repository ID mismatch.' >&2; exit 1; }
+          [[ '${{ github.repository_owner_id }}' == "$EXPECTED_REPOSITORY_OWNER_ID" ]] || { echo 'Repository owner ID mismatch.' >&2; exit 1; }
+          [[ '${{ github.ref }}' == "$EXPECTED_REF" ]] || { echo 'Git ref mismatch.' >&2; exit 1; }
+          [[ '${{ github.workflow_ref }}' == "$EXPECTED_WORKFLOW_REF" ]] || { echo 'Workflow ref mismatch.' >&2; exit 1; }
+          [[ "$EXPECTED_ENVIRONMENT" == 'production' ]] || { echo 'Environment boundary mismatch.' >&2; exit 1; }
+          [[ "$EXPECTED_PROJECT_ID" == 'click-save-ai-production' ]] || { echo 'Production project boundary mismatch.' >&2; exit 1; }
+          [[ "$EXPECTED_PROJECT_NUMBER" == '991489557172' ]] || { echo 'Production project-number boundary mismatch.' >&2; exit 1; }
+          [[ -n "$GCP_WORKLOAD_IDENTITY_PROVIDER" ]] || { echo 'Required WIF provider variable is unavailable.' >&2; exit 1; }
+          [[ -n "$GCP_DEPLOY_SERVICE_ACCOUNT" ]] || { echo 'Required deploy service-account variable is unavailable.' >&2; exit 1; }
+          [[ "$GCP_DEPLOY_SERVICE_ACCOUNT" == "$EXPECTED_DEPLOY_SA" ]] || { echo 'Deploy service-account identity mismatch.' >&2; exit 1; }
+          [[ "$GCP_WORKLOAD_IDENTITY_PROVIDER" =~ ^projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/[^/]+/providers/[^/]+$ ]] || { echo 'WIF provider project-number boundary mismatch.' >&2; exit 1; }
+
+      - name: Check out exact Firebase service-state probe source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Node.js 22 for Service Usage read
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          package-manager-cache: false
+
+      - name: Authenticate Service Usage read-only identity
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          create_credentials_file: 'true'
+          cleanup_credentials: 'true'
+          export_environment_variables: 'false'
+          project_id: ${{ env.EXPECTED_PROJECT_ID }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          token_format: 'access_token'
+          access_token_lifetime: '600s'
+          access_token_scopes: 'https://www.googleapis.com/auth/cloud-platform.read-only'
+
+      - name: Read Firebase Management API service state and emit sanitized truth
+        env:
+          BLOCK3F_SERVICE_USAGE_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
+        run: node scripts/production-3f-firebase-service-state-probe.mjs
+
   deploy-firebase-production:
     needs: production-candidate
-    if: ${{ inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'DEPLOY_FIREBASE_PRODUCTION' }}
+    if: ${{ inputs.authorize_3f_metadata_probe != 'PROBE_3F_METADATA_ONLY' && inputs.authorize_3f_external_authority_probe != 'PROBE_3F_FIREBASE_AUTHORITY_READ_ONLY' && inputs.authorize_3f_service_state_probe != 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY' && inputs.authorize_wif_auth_proof != 'PROVE_WIF_AUTH_ONLY' && inputs.authorize_firebase_deploy == 'DEPLOY_FIREBASE_PRODUCTION' }}
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 30

--- a/functions/test/productionFirebaseServiceStateDiagnosticBlock3F.test.js
+++ b/functions/test/productionFirebaseServiceStateDiagnosticBlock3F.test.js
@@ -1,0 +1,269 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const root = path.resolve(process.cwd(), "..");
+const probePath = path.join(root, "scripts/production-3f-firebase-service-state-probe.mjs");
+const workflowPath = path.join(root, ".github/workflows/production-release.yml");
+const workflow = fs.readFileSync(workflowPath, "utf8");
+
+const EXPECTED_PROJECT_ID = "click-save-ai-production";
+const EXPECTED_PROJECT_NUMBER = "991489557172";
+const EXPECTED_SERVICE_NAME =
+  "projects/991489557172/services/firebase.googleapis.com";
+const EXPECTED_URL =
+  "https://serviceusage.googleapis.com/v1/projects/991489557172/services/firebase.googleapis.com";
+const UNKNOWN = "UNKNOWN_NO_ACCESS";
+
+function fakeJsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body;
+    },
+  };
+}
+
+function invalidJsonResponse(status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      throw new SyntaxError("SENSITIVE_INVALID_JSON_MUST_NOT_LEAK");
+    },
+  };
+}
+
+async function loadProbeModule() {
+  return import(`${pathToFileURL(probePath).href}?t=${Date.now()}-${Math.random()}`);
+}
+
+function callProbe(probeFirebaseServiceState, fetchImpl, accessToken = "SENSITIVE_ACCESS_TOKEN") {
+  return probeFirebaseServiceState({
+    accessToken,
+    expectedProjectId: EXPECTED_PROJECT_ID,
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    fetchImpl,
+  });
+}
+
+function assertUnknown(result, transport) {
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    `firebase_management_api_service_state=${UNKNOWN}`,
+    `firebase_management_api_service_read_transport=${transport}`,
+  ]);
+  assert.doesNotMatch(result.lines.join("\n"), /ENABLED|DISABLED/);
+}
+
+test("Service Usage GET classifies ENABLED only from the canonical service resource", async () => {
+  const { probeFirebaseServiceState } = await loadProbeModule();
+  let observed;
+  const result = await callProbe(probeFirebaseServiceState, async (url, options) => {
+    observed = { url: String(url), options };
+    return fakeJsonResponse(200, {
+      name: EXPECTED_SERVICE_NAME,
+      state: "ENABLED",
+      config: { name: "SENSITIVE_CONFIG_MUST_NOT_LEAK" },
+    });
+  });
+
+  assert.equal(observed.url, EXPECTED_URL);
+  assert.equal(observed.options.method, "GET");
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    "firebase_management_api_service_state=ENABLED",
+    "firebase_management_api_service_read_transport=SUCCESS_2XX",
+  ]);
+  assert.doesNotMatch(result.lines.join("\n"), /SENSITIVE_CONFIG_MUST_NOT_LEAK/);
+});
+
+test("Service Usage GET classifies DISABLED only from the canonical service resource", async () => {
+  const { probeFirebaseServiceState } = await loadProbeModule();
+  const result = await callProbe(probeFirebaseServiceState, async () =>
+    fakeJsonResponse(200, { name: EXPECTED_SERVICE_NAME, state: "DISABLED" })
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(result.lines, [
+    "firebase_management_api_service_state=DISABLED",
+    "firebase_management_api_service_read_transport=SUCCESS_2XX",
+  ]);
+});
+
+for (const [status, transport] of [
+  [401, "HTTP_401"],
+  [403, "HTTP_403"],
+  [404, "HTTP_404"],
+  [429, "HTTP_429"],
+  [500, "HTTP_5XX"],
+  [599, "HTTP_5XX"],
+  [418, "HTTP_OTHER_NON_2XX"],
+]) {
+  test(`HTTP ${status} remains UNKNOWN_NO_ACCESS and never implies DISABLED`, async () => {
+    const { probeFirebaseServiceState } = await loadProbeModule();
+    const result = await callProbe(probeFirebaseServiceState, async () =>
+      fakeJsonResponse(status, {
+        error: {
+          message: "SENSITIVE_ERROR_MESSAGE_MUST_NOT_LEAK",
+          details: "SENSITIVE_ERROR_DETAILS_MUST_NOT_LEAK",
+        },
+      })
+    );
+
+    assertUnknown(result, transport);
+    assert.doesNotMatch(
+      result.lines.join("\n"),
+      /SENSITIVE_ERROR_MESSAGE_MUST_NOT_LEAK|SENSITIVE_ERROR_DETAILS_MUST_NOT_LEAK/
+    );
+  });
+}
+
+test("network failures remain UNKNOWN_NO_ACCESS without leaking exception text", async () => {
+  const { probeFirebaseServiceState } = await loadProbeModule();
+  const result = await callProbe(probeFirebaseServiceState, async () => {
+    throw new Error("SENSITIVE_NETWORK_EXCEPTION_MUST_NOT_LEAK");
+  });
+  assertUnknown(result, "NETWORK_ERROR");
+  assert.doesNotMatch(result.lines.join("\n"), /SENSITIVE_NETWORK_EXCEPTION_MUST_NOT_LEAK/);
+});
+
+test("invalid successful JSON remains UNKNOWN_NO_ACCESS without leaking parser content", async () => {
+  const { probeFirebaseServiceState } = await loadProbeModule();
+  const result = await callProbe(probeFirebaseServiceState, async () => invalidJsonResponse());
+  assertUnknown(result, "INVALID_JSON");
+  assert.doesNotMatch(result.lines.join("\n"), /SENSITIVE_INVALID_JSON_MUST_NOT_LEAK/);
+});
+
+test("mismatched resource name fails closed and cannot classify service state", async () => {
+  const { probeFirebaseServiceState } = await loadProbeModule();
+  const result = await callProbe(probeFirebaseServiceState, async () =>
+    fakeJsonResponse(200, {
+      name: "projects/991489557172/services/other.googleapis.com",
+      state: "ENABLED",
+    })
+  );
+
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.lines, [
+    `firebase_management_api_service_state=${UNKNOWN}`,
+    "firebase_management_api_service_read_transport=SUCCESS_2XX",
+  ]);
+});
+
+test("unexpected Service Usage state fails closed", async () => {
+  const { probeFirebaseServiceState } = await loadProbeModule();
+  const result = await callProbe(probeFirebaseServiceState, async () =>
+    fakeJsonResponse(200, { name: EXPECTED_SERVICE_NAME, state: "STATE_UNSPECIFIED" })
+  );
+  assert.equal(result.exitCode, 1);
+  assert.match(result.lines.join("\n"), /service_state=UNKNOWN_NO_ACCESS/);
+});
+
+test("noncanonical project inputs fail before any network request", async () => {
+  const { probeFirebaseServiceState } = await loadProbeModule();
+  let calls = 0;
+  const result = await probeFirebaseServiceState({
+    accessToken: "SENSITIVE_ACCESS_TOKEN",
+    expectedProjectId: "clickandsaveai-staging",
+    expectedProjectNumber: EXPECTED_PROJECT_NUMBER,
+    fetchImpl: async () => {
+      calls += 1;
+      return fakeJsonResponse(200, { name: EXPECTED_SERVICE_NAME, state: "ENABLED" });
+    },
+  });
+  assert.equal(calls, 0);
+  assert.equal(result.exitCode, 1);
+  assert.match(result.lines.join("\n"), /UNKNOWN_NO_ACCESS/);
+});
+
+test("probe source is GET-only and contains no API enablement, IAM, build, deploy, or publication mutation", () => {
+  const source = fs.readFileSync(probePath, "utf8");
+  assert.match(source, /serviceusage\.googleapis\.com\/v1/);
+  assert.match(source, /firebase\.googleapis\.com/);
+  assert.match(source, /method:\s*["']GET["']/);
+  assert.doesNotMatch(source, /method:\s*["'](?:POST|PUT|PATCH|DELETE)["']/i);
+  for (const forbidden of [
+    /services\.(?:enable|disable|batchEnable)/i,
+    /services\s+(?:enable|disable)/i,
+    /add-iam-policy-binding|set-iam-policy|remove-iam-policy-binding/i,
+    /roles\/(?:owner|editor|viewer|firebase\.)/i,
+    /service-accounts\s+keys\s+create/i,
+    /firebase\s+deploy/i,
+    /assembleRelease|bundleRelease|gradle\s/i,
+    /google\s+play|play.*(?:upload|publish)/i,
+  ]) {
+    assert.doesNotMatch(source, forbidden);
+  }
+});
+
+test("workflow wires a dedicated fail-closed Service Usage probe with cloud-platform.read-only", () => {
+  assert.match(workflow, /authorize_3f_service_state_probe:/);
+  assert.match(workflow, /default: NO_3F_SERVICE_STATE_PROBE/);
+  assert.match(workflow, /PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY/);
+
+  const marker = "  production-3f-firebase-service-state-probe:\n";
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1);
+  const tail = workflow.slice(start + marker.length);
+  const nextJob = tail.match(/\n  [A-Za-z0-9_-]+:\n/);
+  const job = nextJob ? tail.slice(0, nextJob.index) : tail;
+
+  assert.match(job, /environment: production/);
+  assert.match(job, /permissions:\n      contents: read\n      id-token: write\n/);
+  assert.match(job, /uses: google-github-actions\/auth@v3/);
+  assert.match(
+    job,
+    /access_token_scopes: 'https:\/\/www\.googleapis\.com\/auth\/cloud-platform\.read-only'/
+  );
+  assert.match(job, /node scripts\/production-3f-firebase-service-state-probe\.mjs/);
+  assert.ok(job.includes("inputs.authorize_firebase_deploy == 'NO_DEPLOY'"));
+  assert.ok(job.includes("inputs.authorize_wif_auth_proof == 'NO_WIF_PROOF'"));
+  assert.ok(job.includes("inputs.authorize_3f_metadata_probe == 'NO_3F_PROBE'"));
+  assert.ok(job.includes("inputs.authorize_3f_external_authority_probe == 'NO_3F_EXTERNAL_PROBE'"));
+  assert.ok(
+    job.includes(
+      "inputs.authorize_3f_service_state_probe == 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY'"
+    )
+  );
+});
+
+test("all other Production modes explicitly exclude the Service Usage probe", () => {
+  const phrase =
+    "inputs.authorize_3f_service_state_probe != 'PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY'";
+  const jobMarkers = [
+    "  production-candidate:\n",
+    "  production-wif-auth-proof:\n",
+    "  production-3f-metadata-probe:\n",
+    "  production-3f-firebase-authority-probe:\n",
+    "  deploy-firebase-production:\n",
+  ];
+
+  for (const marker of jobMarkers) {
+    const start = workflow.indexOf(marker);
+    assert.notEqual(start, -1, `missing ${marker.trim()}`);
+    const tail = workflow.slice(start + marker.length);
+    const nextJob = tail.match(/\n  [A-Za-z0-9_-]+:\n/);
+    const job = nextJob ? tail.slice(0, nextJob.index) : tail;
+    assert.ok(job.includes(phrase), `${marker.trim()} does not exclude Service Usage mode`);
+  }
+});
+
+test("existing Firebase authority probe remains separate and keeps firebase.readonly scope", () => {
+  const marker = "  production-3f-firebase-authority-probe:\n";
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1);
+  const tail = workflow.slice(start + marker.length);
+  const nextJob = tail.match(/\n  [A-Za-z0-9_-]+:\n/);
+  const job = nextJob ? tail.slice(0, nextJob.index) : tail;
+  assert.match(
+    job,
+    /access_token_scopes: 'https:\/\/www\.googleapis\.com\/auth\/firebase\.readonly'/
+  );
+  assert.match(job, /node scripts\/production-3f-firebase-authority-probe\.mjs/);
+});

--- a/scripts/production-3f-firebase-service-state-probe.mjs
+++ b/scripts/production-3f-firebase-service-state-probe.mjs
@@ -1,0 +1,124 @@
+import { pathToFileURL } from "node:url";
+
+const CANONICAL_PROJECT_ID = "click-save-ai-production";
+const CANONICAL_PROJECT_NUMBER = "991489557172";
+const CANONICAL_SERVICE = "firebase.googleapis.com";
+const SERVICE_USAGE_BASE = "https://serviceusage.googleapis.com/v1";
+const UNKNOWN = "UNKNOWN_NO_ACCESS";
+
+const TRANSPORT = Object.freeze({
+  HTTP_401: "HTTP_401",
+  HTTP_403: "HTTP_403",
+  HTTP_404: "HTTP_404",
+  HTTP_429: "HTTP_429",
+  HTTP_5XX: "HTTP_5XX",
+  HTTP_OTHER_NON_2XX: "HTTP_OTHER_NON_2XX",
+  NETWORK_ERROR: "NETWORK_ERROR",
+  INVALID_JSON: "INVALID_JSON",
+  SUCCESS_2XX: "SUCCESS_2XX",
+});
+
+function outputLines(state = UNKNOWN, transport = TRANSPORT.NETWORK_ERROR) {
+  return [
+    `firebase_management_api_service_state=${state}`,
+    `firebase_management_api_service_read_transport=${transport}`,
+  ];
+}
+
+function resultFor(exitCode, state = UNKNOWN, transport = TRANSPORT.NETWORK_ERROR) {
+  return { exitCode, lines: outputLines(state, transport) };
+}
+
+function classifyHttpStatus(status) {
+  if (status === 401) return TRANSPORT.HTTP_401;
+  if (status === 403) return TRANSPORT.HTTP_403;
+  if (status === 404) return TRANSPORT.HTTP_404;
+  if (status === 429) return TRANSPORT.HTTP_429;
+  if (status >= 500 && status <= 599) return TRANSPORT.HTTP_5XX;
+  return TRANSPORT.HTTP_OTHER_NON_2XX;
+}
+
+function validateExpectedInputs(expectedProjectId, expectedProjectNumber) {
+  return (
+    expectedProjectId === CANONICAL_PROJECT_ID &&
+    expectedProjectNumber === CANONICAL_PROJECT_NUMBER
+  );
+}
+
+export async function probeFirebaseServiceState({
+  accessToken,
+  expectedProjectId,
+  expectedProjectNumber,
+  fetchImpl = globalThis.fetch,
+}) {
+  if (
+    typeof accessToken !== "string" ||
+    accessToken.length === 0 ||
+    typeof fetchImpl !== "function" ||
+    !validateExpectedInputs(expectedProjectId, expectedProjectNumber)
+  ) {
+    return resultFor(1);
+  }
+
+  const expectedName = `projects/${CANONICAL_PROJECT_NUMBER}/services/${CANONICAL_SERVICE}`;
+  const url = `${SERVICE_USAGE_BASE}/${expectedName}`;
+
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+    });
+  } catch {
+    return resultFor(0, UNKNOWN, TRANSPORT.NETWORK_ERROR);
+  }
+
+  if (
+    !response ||
+    typeof response.ok !== "boolean" ||
+    !Number.isInteger(response.status)
+  ) {
+    return resultFor(0, UNKNOWN, TRANSPORT.INVALID_JSON);
+  }
+
+  if (!response.ok) {
+    return resultFor(0, UNKNOWN, classifyHttpStatus(response.status));
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    return resultFor(0, UNKNOWN, TRANSPORT.INVALID_JSON);
+  }
+
+  if (!body || typeof body !== "object" || body.name !== expectedName) {
+    return resultFor(1, UNKNOWN, TRANSPORT.SUCCESS_2XX);
+  }
+
+  if (body.state === "ENABLED") {
+    return resultFor(0, "ENABLED", TRANSPORT.SUCCESS_2XX);
+  }
+  if (body.state === "DISABLED") {
+    return resultFor(0, "DISABLED", TRANSPORT.SUCCESS_2XX);
+  }
+
+  return resultFor(1, UNKNOWN, TRANSPORT.SUCCESS_2XX);
+}
+
+async function runCli() {
+  const result = await probeFirebaseServiceState({
+    accessToken: process.env.BLOCK3F_SERVICE_USAGE_ACCESS_TOKEN ?? "",
+    expectedProjectId: process.env.EXPECTED_PROJECT_ID ?? "",
+    expectedProjectNumber: process.env.EXPECTED_PROJECT_NUMBER ?? "",
+  });
+  for (const line of result.lines) console.log(line);
+  process.exitCode = result.exitCode;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await runCli();
+}


### PR DESCRIPTION
## Scope
Repository preparation only for the next Block 3F diagnostic. No Production workflow was dispatched and no live GCP/Firebase state was read or mutated.

## Changes
- add a dedicated `authorize_3f_service_state_probe` gate with exact phrase `PROBE_3F_FIREBASE_SERVICE_STATE_READ_ONLY`;
- add isolated `production-3f-firebase-service-state-probe` in the canonical `production-release.yml`;
- mint only a short-lived access token with `https://www.googleapis.com/auth/cloud-platform.read-only` when separately authorized later;
- perform exactly one Service Usage v1 GET-equivalent read of `projects/991489557172/services/firebase.googleapis.com`;
- emit only sanitized service state (`ENABLED`, `DISABLED`, or `UNKNOWN_NO_ACCESS`) and transport class;
- preserve `HTTP_403 => UNKNOWN_NO_ACCESS` semantics and never infer `DISABLED` from transport failure;
- keep candidate, WIF proof, metadata probe, Firebase authority probe, and Firebase deploy paths mutually exclusive;
- add fail-closed tests for endpoint identity, GET-only behavior, no API enable/disable, no IAM mutation, no deploy/build/Play action, no sensitive-body leakage, and preserved existing Firebase authority path.

## Frozen base
`d2514bb0afaa366ae542e21693fed1d816acce7d`

## Live boundary
No Production execution is authorized by this PR. Do not dispatch the new service-state probe until Master Control provides separate explicit authorization bound to the then-current protected `main` SHA.