### PR TITLE
Block 3F: bind Production Web OAuth client to Functions runtime

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -702,6 +702,7 @@ jobs:
     env:
       SOURCE_SHA: ${{ inputs.source_sha }}
       PRODUCTION_FIREBASE_PROJECT_ID: ${{ vars.PRODUCTION_FIREBASE_PROJECT_ID }}
+      PRODUCTION_GOOGLE_WEB_CLIENT_ID: ${{ vars.PRODUCTION_GOOGLE_WEB_CLIENT_ID }}
 
     steps:
       - name: Check out exact approved candidate
@@ -716,7 +717,8 @@ jobs:
           set -euo pipefail
           [[ '${{ inputs.confirm_environment }}' == 'CLICKANDSAVEAI_PRODUCTION' ]] || exit 1
           [[ -n "$PRODUCTION_FIREBASE_PROJECT_ID" ]] || { echo 'PRODUCTION_FIREBASE_PROJECT_ID is missing.' >&2; exit 1; }
-          [[ "$PRODUCTION_FIREBASE_PROJECT_ID" != 'clickandsaveai-staging' ]] || { echo 'Refusing production deployment to staging project.' >&2; exit 1; }
+          [[ "$PRODUCTION_FIREBASE_PROJECT_ID" == 'click-save-ai-production' ]] || { echo 'Refusing Firebase deployment outside the exact Production project.' >&2; exit 1; }
+          [[ -n "$PRODUCTION_GOOGLE_WEB_CLIENT_ID" ]] || { echo 'PRODUCTION_GOOGLE_WEB_CLIENT_ID is missing.' >&2; exit 1; }
           [[ "$(git rev-parse HEAD)" == "$SOURCE_SHA" ]] || exit 1
 
       - name: Authenticate production deploy identity with GitHub OIDC
@@ -746,6 +748,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          RUNTIME_PARAMS_FILE="functions/.env.${PRODUCTION_FIREBASE_PROJECT_ID}"
+          [[ ! -e "$RUNTIME_PARAMS_FILE" ]] || { echo 'Refusing to overwrite an existing Production runtime parameter file.' >&2; exit 1; }
+          umask 077
+          printf 'GOOGLE_OAUTH_CLIENT_ID=%s\n' "$PRODUCTION_GOOGLE_WEB_CLIENT_ID" > "$RUNTIME_PARAMS_FILE"
+          trap 'rm -f "$RUNTIME_PARAMS_FILE"' EXIT
           firebase deploy \
             --project "$PRODUCTION_FIREBASE_PROJECT_ID" \
             --only firestore:rules,firestore:indexes,functions \

--- a/functions/test/productionOauthRuntimeBindingBlock3F.test.js
+++ b/functions/test/productionOauthRuntimeBindingBlock3F.test.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const root = path.resolve(__dirname, "..", "..");
+const workflow = fs.readFileSync(
+  path.join(root, ".github/workflows/production-release.yml"),
+  "utf8"
+);
+
+const deployStart = workflow.indexOf("\n  deploy-firebase-production:");
+assert.ok(deployStart >= 0, "deploy-firebase-production job must exist");
+const deployJob = workflow.slice(deployStart);
+
+test("Block 3F production deploy binds the authoritative Production Web client ID non-interactively", () => {
+  assert.match(
+    deployJob,
+    /PRODUCTION_GOOGLE_WEB_CLIENT_ID:\s*\$\{\{ vars\.PRODUCTION_GOOGLE_WEB_CLIENT_ID \}\}/
+  );
+  assert.match(
+    deployJob,
+    /\[\[ "\$PRODUCTION_FIREBASE_PROJECT_ID" == 'click-save-ai-production' \]\]/
+  );
+  assert.match(deployJob, /\[\[ -n "\$PRODUCTION_GOOGLE_WEB_CLIENT_ID" \]\]/);
+  assert.match(
+    deployJob,
+    /RUNTIME_PARAMS_FILE="functions\/\.env\.\$\{PRODUCTION_FIREBASE_PROJECT_ID\}"/
+  );
+  assert.match(deployJob, /umask 077/);
+  assert.match(deployJob, /printf 'GOOGLE_OAUTH_CLIENT_ID=%s\\n'/);
+  assert.match(deployJob, /trap 'rm -f "\$RUNTIME_PARAMS_FILE"' EXIT/);
+  assert.match(deployJob, /firebase deploy[\s\S]*--non-interactive/);
+});
+
+test("Block 3F production deploy keeps runtime OAuth and token-encryption secrets out of GitHub workflow inputs", () => {
+  assert.doesNotMatch(deployJob, /secrets\.GOOGLE_OAUTH_CLIENT_SECRET/);
+  assert.doesNotMatch(deployJob, /secrets\.OAUTH_TOKEN_ENCRYPTION_KEY/);
+  assert.doesNotMatch(deployJob, /GOOGLE_OAUTH_CLIENT_SECRET=/);
+  assert.doesNotMatch(deployJob, /OAUTH_TOKEN_ENCRYPTION_KEY=/);
+});
+
+test("Block 3F production deploy does not create Android OAuth, touch Play, or broaden IAM", () => {
+  assert.doesNotMatch(deployJob, /oauth.*android|android.*oauth/i);
+  assert.doesNotMatch(deployJob, /google[ -]?play|play.*publish|play.*upload/i);
+  assert.doesNotMatch(deployJob, /gcloud\s+projects\s+add-iam-policy-binding/);
+  assert.doesNotMatch(deployJob, /gcloud\s+services\s+(enable|disable)/);
+  assert.doesNotMatch(deployJob, /service-accounts\s+keys\s+create/);
+});


### PR DESCRIPTION
## Scope

Closes the authorized Block 3F repository-plumbing gap for the non-Play Production Web/server OAuth path.

- bind protected `PRODUCTION_GOOGLE_WEB_CLIENT_ID` to the Firebase Functions string parameter `GOOGLE_OAUTH_CLIENT_ID` during the separately authorized Production deploy path
- fail closed on wrong Production project or missing client ID
- keep `GOOGLE_OAUTH_CLIENT_SECRET` and `OAUTH_TOKEN_ENCRYPTION_KEY` in Firebase Functions/Google Secret Manager rather than GitHub workflow inputs
- materialize only the non-secret project-specific Functions parameter file transiently and remove it on exit
- no Google Play action, Android OAuth creation, Firebase deployment, IAM/WIF broadening, service-account keys, API changes, or secret values

Base is the exact Master Control protected-main SHA `aed448ea93aa513badd46fe3a082ea0215dcbf3c`.

Draft only. Do not merge or dispatch Production.