### PR TITLE
Staging Gmail OAuth — server auth code exchange remediation

### DIFF
--- a/functions/src/gmailConnectFunctions.js
+++ b/functions/src/gmailConnectFunctions.js
@@ -95,6 +95,7 @@ exports.connectGmail = onCall(
         client_secret: googleOAuthClientSecret.value(),
         code: serverAuthCode,
         grant_type: "authorization_code",
+        redirect_uri: "",
       });
       const grantedScopes = String(tokenPayload.scope || "").split(/\s+/).filter(Boolean);
       if (!grantedScopes.includes(GMAIL_READONLY_SCOPE)) {

--- a/functions/test/gmailOAuthCodeExchangeContract.test.js
+++ b/functions/test/gmailOAuthCodeExchangeContract.test.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const source = fs.readFileSync(
+  path.resolve(__dirname, "../src/gmailConnectFunctions.js"),
+  "utf8"
+);
+
+test("Gmail token exchange sends the complete server-auth-code contract", () => {
+  assert.match(source, /client_id:\s*googleOAuthClientId\.value\(\)/);
+  assert.match(source, /client_secret:\s*googleOAuthClientSecret\.value\(\)/);
+  assert.match(source, /code:\s*serverAuthCode/);
+  assert.match(source, /grant_type:\s*"authorization_code"/);
+  assert.match(source, /redirect_uri:\s*""/);
+});
+
+test("Gmail OAuth scope remains read-only", () => {
+  assert.match(
+    source,
+    /const GMAIL_READONLY_SCOPE = "https:\/\/www\.googleapis\.com\/auth\/gmail\.readonly";/
+  );
+  assert.doesNotMatch(source, /gmail\.modify|mail\.google\.com|gmail\.compose|gmail\.send/);
+});


### PR DESCRIPTION
Targeted remediation for the device-observed staging Gmail OAuth E2E failure.

Scope:
- backend Gmail OAuth authorization-code exchange only
- regression tests for the token exchange contract
- no Gmail scope expansion
- no Android V3/product changes
- no Production deployment or infrastructure mutation
- no Google Play action

Observed boundary: Google consent UI opens successfully in the private-test APK, but the Gmail connection does not complete after consent. The Android and staging backend Web OAuth client IDs match.

TDD sequence:
1. RED: add a regression test requiring the complete server-auth-code exchange contract, including the no-web redirect URI.
2. GREEN: apply the minimal backend fix only after the test fails for the expected reason.

Deployment is explicitly out of scope for this execution step. Staging deployment requires separate Master Control authorization after exact-head CI is green.