### PR TITLE
Staging deploy — default runtime service account remediation

### DIFF
--- a/functions/src/index.js
+++ b/functions/src/index.js
@@ -20,7 +20,7 @@ const PRODUCTION_V2_SERVICE_ACCOUNT =
   "clicksave-v2-runtime@click-save-ai-production.iam.gserviceaccount.com";
 const productionV2ServiceAccount = projectID
   .equals("click-save-ai-production")
-  .thenElse(PRODUCTION_V2_SERVICE_ACCOUNT, "default");
+  .thenElse(PRODUCTION_V2_SERVICE_ACCOUNT, "");
 
 initializeApp();
 setGlobalOptions({
@@ -561,7 +561,6 @@ exports.createProviderLead = onCall(
     } catch (error) {
       throw invalidArgument(error);
     }
-
     const leadId = crypto
       .createHash("sha256")
       .update(`${uid}:${input.idempotencyKey}`)

--- a/functions/test/productionRuntimeIdentityBlock3B3C.test.js
+++ b/functions/test/productionRuntimeIdentityBlock3B3C.test.js
@@ -46,12 +46,13 @@ test("2 entry loads common index before every other exported module", () => {
   }
 });
 
-test("3 common v2 global options bind exact Production SA with non-Production default", () => {
+test("3 common v2 global options bind exact Production SA with omitted non-Production override", () => {
   has(index, /firebase-functions\/params/);
   has(index, /\bprojectID\b/);
   has(index, new RegExp(esc(v2)));
   has(index, new RegExp(`projectID\\s*\\.\\s*equals\\(\\s*["']${esc(prod)}["']\\s*\\)`));
-  has(index, /thenElse\(\s*PRODUCTION_V2_SERVICE_ACCOUNT\s*,\s*["']default["']\s*\)/);
+  has(index, /thenElse\(\s*PRODUCTION_V2_SERVICE_ACCOUNT\s*,\s*["']["']\s*\)/);
+  no(index, /thenElse\(\s*PRODUCTION_V2_SERVICE_ACCOUNT\s*,\s*["']default["']\s*\)/);
   has(index, /setGlobalOptions\s*\(\s*\{[\s\S]*?serviceAccount\s*:\s*productionV2ServiceAccount[\s\S]*?\}\s*\)/);
 });
 

--- a/functions/test/stagingDefaultServiceAccountRegression.test.js
+++ b/functions/test/stagingDefaultServiceAccountRegression.test.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const root = path.resolve(__dirname, "..", "..");
+const index = fs.readFileSync(path.join(root, "functions/src/index.js"), "utf8");
+
+test("non-Production v2 runtime fallback is omitted instead of becoming a literal default service account", () => {
+  assert.doesNotMatch(
+    index,
+    /thenElse\(\s*PRODUCTION_V2_SERVICE_ACCOUNT\s*,\s*["']default["']\s*\)/,
+    "A parameter Expression resolving to literal 'default' bypasses Firebase's shorthand normalization and is treated as an actual service account by Secret Manager."
+  );
+  assert.match(
+    index,
+    /thenElse\(\s*PRODUCTION_V2_SERVICE_ACCOUNT\s*,\s*["']["']\s*\)/,
+    "Non-Production must resolve to an empty service-account value so Firebase CLI falls back to the platform default runtime identity."
+  );
+});


### PR DESCRIPTION
Targeted remediation for staging deploy run #17 failure at Secret Manager IAM binding.

Observed error:
- Firebase deploy attempted to grant secret access to literal service account `default`
- Secret Manager returned HTTP 400 `Invalid service account (default)`

Root cause:
- the Production-only service-account guard is a parameter Expression whose non-Production branch resolves to the literal string `default`
- Firebase Functions shorthand normalization only converts literal `default` before Expression resolution; the resolved string reaches Firebase Tools as an explicit service-account value

Scope:
- preserve exact dedicated Production v2 runtime service account
- make non-Production service-account value absent/falsy so Firebase Tools resolves the actual platform default runtime identity
- regression test for this failure mode
- no OAuth scope changes
- no Production deployment
- no Google Play action
- no merge

TDD sequence: RED contract first, then minimal runtime fix after the expected failure is verified.