### PR TITLE
V3 Gmail diagnostics — surface connection failure

### DIFF
--- a/app/src/main/java/com/example/data/repository/BackendRepository.kt
+++ b/app/src/main/java/com/example/data/repository/BackendRepository.kt
@@ -18,12 +18,25 @@ data class GmailConnectionResult(
     val consentVersion: String
 )
 
+data class GmailRecoveryDiagnosticResult(
+    val initialBackfillCompleted: Boolean,
+    val initialBackfillCompletedAt: String,
+    val storedParserVersion: Int,
+    val activeParserVersion: Int,
+    val authoritativeInvoiceCount: Int,
+    val gmailMessageImportCount: Int,
+    val gmailMessageImportsParserVersionDistribution: Map<String, Int>,
+    val storedCandidateCount: Int,
+    val importsTruncated: Boolean
+)
+
 data class GmailSyncStatusResult(
     val connected: Boolean,
     val storedParserVersion: Int,
     val activeParserVersion: Int,
     val upgradeRequired: Boolean,
-    val lookback: String
+    val lookback: String,
+    val recoveryState: GmailRecoveryDiagnosticResult? = null
 )
 
 data class GmailWatchResult(
@@ -185,18 +198,42 @@ class BackendRepository(
         )
     }
 
-    suspend fun getGmailSyncStatus(): GmailSyncStatusResult {
+    suspend fun getGmailSyncStatus(includeRecoveryDiagnostics: Boolean = false): GmailSyncStatusResult {
         val response = functions.getHttpsCallable("getGmailSyncStatus")
-            .call()
+            .call(mapOf("includeRecoveryDiagnostics" to includeRecoveryDiagnostics))
             .await()
             .data
             .asStringMap()
+        val recoveryMap = response["recoveryState"].asStringMapOrNull()
+        val parserDistribution = recoveryMap
+            ?.get("gmailMessageImportsParserVersionDistribution")
+            .asStringMapOrNull()
+            .orEmpty()
+            .mapNotNull { (key, value) ->
+                val count = (value as? Number)?.toInt() ?: return@mapNotNull null
+                key to count
+            }
+            .toMap()
+        val recoveryState = recoveryMap?.let {
+            GmailRecoveryDiagnosticResult(
+                initialBackfillCompleted = it["initialBackfillCompleted"] as? Boolean ?: false,
+                initialBackfillCompletedAt = it["initialBackfillCompletedAt"] as? String ?: "",
+                storedParserVersion = (it["storedParserVersion"] as? Number)?.toInt() ?: 0,
+                activeParserVersion = (it["activeParserVersion"] as? Number)?.toInt() ?: 0,
+                authoritativeInvoiceCount = (it["authoritativeInvoiceCount"] as? Number)?.toInt() ?: 0,
+                gmailMessageImportCount = (it["gmailMessageImportCount"] as? Number)?.toInt() ?: 0,
+                gmailMessageImportsParserVersionDistribution = parserDistribution,
+                storedCandidateCount = (it["storedCandidateCount"] as? Number)?.toInt() ?: 0,
+                importsTruncated = it["importsTruncated"] as? Boolean ?: false
+            )
+        }
         return GmailSyncStatusResult(
             connected = response["connected"] as? Boolean ?: false,
             storedParserVersion = (response["storedParserVersion"] as? Number)?.toInt() ?: 0,
             activeParserVersion = (response["activeParserVersion"] as? Number)?.toInt() ?: 0,
             upgradeRequired = response["upgradeRequired"] as? Boolean ?: false,
-            lookback = response["lookback"] as? String ?: ""
+            lookback = response["lookback"] as? String ?: "",
+            recoveryState = recoveryState
         )
     }
 

--- a/app/src/main/java/com/example/data/repository/BackendRepository.kt
+++ b/app/src/main/java/com/example/data/repository/BackendRepository.kt
@@ -27,8 +27,43 @@ data class GmailRecoveryDiagnosticResult(
     val gmailMessageImportCount: Int,
     val gmailMessageImportsParserVersionDistribution: Map<String, Int>,
     val storedCandidateCount: Int,
+    val normalizedCandidateCount: Int,
+    val replayableCandidateCount: Int,
+    val replayableRecurringCount: Int,
+    val uniqueReplayableSourceCount: Int,
+    val duplicateCandidateCount: Int,
     val importsTruncated: Boolean
 )
+
+internal fun decodeGmailRecoveryDiagnostic(
+    recoveryMap: Map<String, Any?>?
+): GmailRecoveryDiagnosticResult? {
+    if (recoveryMap == null) return null
+    val parserDistribution = (recoveryMap["gmailMessageImportsParserVersionDistribution"] as? Map<*, *>)
+        .orEmpty()
+        .mapNotNull { (key, value) ->
+            val version = key?.toString() ?: return@mapNotNull null
+            val count = (value as? Number)?.toInt() ?: return@mapNotNull null
+            version to count
+        }
+        .toMap()
+    return GmailRecoveryDiagnosticResult(
+        initialBackfillCompleted = recoveryMap["initialBackfillCompleted"] as? Boolean ?: false,
+        initialBackfillCompletedAt = recoveryMap["initialBackfillCompletedAt"] as? String ?: "",
+        storedParserVersion = (recoveryMap["storedParserVersion"] as? Number)?.toInt() ?: 0,
+        activeParserVersion = (recoveryMap["activeParserVersion"] as? Number)?.toInt() ?: 0,
+        authoritativeInvoiceCount = (recoveryMap["authoritativeInvoiceCount"] as? Number)?.toInt() ?: 0,
+        gmailMessageImportCount = (recoveryMap["gmailMessageImportCount"] as? Number)?.toInt() ?: 0,
+        gmailMessageImportsParserVersionDistribution = parserDistribution,
+        storedCandidateCount = (recoveryMap["storedCandidateCount"] as? Number)?.toInt() ?: 0,
+        normalizedCandidateCount = (recoveryMap["normalizedCandidateCount"] as? Number)?.toInt() ?: 0,
+        replayableCandidateCount = (recoveryMap["replayableCandidateCount"] as? Number)?.toInt() ?: 0,
+        replayableRecurringCount = (recoveryMap["replayableRecurringCount"] as? Number)?.toInt() ?: 0,
+        uniqueReplayableSourceCount = (recoveryMap["uniqueReplayableSourceCount"] as? Number)?.toInt() ?: 0,
+        duplicateCandidateCount = (recoveryMap["duplicateCandidateCount"] as? Number)?.toInt() ?: 0,
+        importsTruncated = recoveryMap["importsTruncated"] as? Boolean ?: false
+    )
+}
 
 data class GmailSyncStatusResult(
     val connected: Boolean,
@@ -204,29 +239,7 @@ class BackendRepository(
             .await()
             .data
             .asStringMap()
-        val recoveryMap = response["recoveryState"].asStringMapOrNull()
-        val parserDistribution = recoveryMap
-            ?.get("gmailMessageImportsParserVersionDistribution")
-            .asStringMapOrNull()
-            .orEmpty()
-            .mapNotNull { (key, value) ->
-                val count = (value as? Number)?.toInt() ?: return@mapNotNull null
-                key to count
-            }
-            .toMap()
-        val recoveryState = recoveryMap?.let {
-            GmailRecoveryDiagnosticResult(
-                initialBackfillCompleted = it["initialBackfillCompleted"] as? Boolean ?: false,
-                initialBackfillCompletedAt = it["initialBackfillCompletedAt"] as? String ?: "",
-                storedParserVersion = (it["storedParserVersion"] as? Number)?.toInt() ?: 0,
-                activeParserVersion = (it["activeParserVersion"] as? Number)?.toInt() ?: 0,
-                authoritativeInvoiceCount = (it["authoritativeInvoiceCount"] as? Number)?.toInt() ?: 0,
-                gmailMessageImportCount = (it["gmailMessageImportCount"] as? Number)?.toInt() ?: 0,
-                gmailMessageImportsParserVersionDistribution = parserDistribution,
-                storedCandidateCount = (it["storedCandidateCount"] as? Number)?.toInt() ?: 0,
-                importsTruncated = it["importsTruncated"] as? Boolean ?: false
-            )
-        }
+        val recoveryState = decodeGmailRecoveryDiagnostic(response["recoveryState"].asStringMapOrNull())
         return GmailSyncStatusResult(
             connected = response["connected"] as? Boolean ?: false,
             storedParserVersion = (response["storedParserVersion"] as? Number)?.toInt() ?: 0,

--- a/app/src/main/java/com/example/data/repository/FinancialSessionRecovery.kt
+++ b/app/src/main/java/com/example/data/repository/FinancialSessionRecovery.kt
@@ -37,7 +37,13 @@ class FinancialSessionRecovery(
         val scan = try {
             recoverInvoices()
         } catch (error: Exception) {
-            return emit(preservePreviousOrFail(previous, safeReason(error)))
+            return emit(
+                preservePreviousAfterConfirmedConnection(
+                    previous = previous,
+                    connection = connection,
+                    reason = safeReason(error)
+                )
+            )
         }
 
         val financialHome = try {
@@ -52,7 +58,8 @@ class FinancialSessionRecovery(
                 FinancialSyncState.Partial(
                     latestScan = scan,
                     financialHome = previousHome,
-                    reason = safeReason(error)
+                    reason = safeReason(error),
+                    gmailConnection = connection
                 )
             )
         }
@@ -60,9 +67,39 @@ class FinancialSessionRecovery(
         return emit(
             FinancialSyncState.Ready(
                 latestScan = scan,
-                financialHome = financialHome
+                financialHome = financialHome,
+                gmailConnection = connection
             )
         )
+    }
+
+    private fun preservePreviousAfterConfirmedConnection(
+        previous: FinancialSyncState?,
+        connection: GmailConnectionResult,
+        reason: String
+    ): FinancialSyncState {
+        return when (previous) {
+            is FinancialSyncState.Ready -> FinancialSyncState.Partial(
+                latestScan = previous.latestScan,
+                financialHome = previous.financialHome,
+                reason = reason,
+                gmailConnection = connection,
+                activity = previous.activity
+            )
+            is FinancialSyncState.Partial -> FinancialSyncState.Partial(
+                latestScan = previous.latestScan,
+                financialHome = previous.financialHome,
+                reason = reason,
+                gmailConnection = connection,
+                activity = previous.activity
+            )
+            else -> FinancialSyncState.Partial(
+                latestScan = null,
+                financialHome = null,
+                reason = reason,
+                gmailConnection = connection
+            )
+        }
     }
 
     private fun preservePreviousOrFail(
@@ -73,12 +110,16 @@ class FinancialSessionRecovery(
             is FinancialSyncState.Ready -> FinancialSyncState.Partial(
                 latestScan = previous.latestScan,
                 financialHome = previous.financialHome,
-                reason = reason
+                reason = reason,
+                gmailConnection = previous.gmailConnection,
+                activity = previous.activity
             )
             is FinancialSyncState.Partial -> FinancialSyncState.Partial(
                 latestScan = previous.latestScan,
                 financialHome = previous.financialHome,
-                reason = reason
+                reason = reason,
+                gmailConnection = previous.gmailConnection,
+                activity = previous.activity
             )
             else -> FinancialSyncState.Failed(
                 reason = reason,

--- a/app/src/main/java/com/example/data/repository/GmailRecoveryDryRunRepository.kt
+++ b/app/src/main/java/com/example/data/repository/GmailRecoveryDryRunRepository.kt
@@ -1,0 +1,95 @@
+package com.example.data.repository
+
+import com.example.BuildConfig
+import com.google.firebase.functions.FirebaseFunctions
+import kotlinx.coroutines.tasks.await
+
+private const val RECOVERY_DRY_RUN_VERSION = "staging-controlled-gmail-recovery-dry-run-v1"
+
+data class GmailRecoveryDryRunResult(
+    val result: String,
+    val credentialPreflight: String,
+    val failureStage: String,
+    val recoveryDryRunVersion: String,
+    val messagesExamined: Int,
+    val candidateMessageCount: Int,
+    val pdfCandidateCount: Int,
+    val normalizedCandidateCount: Int,
+    val recurringBillCount: Int,
+    val uniqueRecurringSourceCount: Int,
+    val duplicateCount: Int,
+    val rejectedOneOffCount: Int,
+    val rejectedRefundCount: Int,
+    val rejectedReceiptOnlyCount: Int,
+    val rejectedContractCount: Int,
+    val unknownCount: Int
+) {
+    fun countOnlySummary(): String = buildString {
+        append(result)
+        append(" · preflight=")
+        append(credentialPreflight)
+        if (failureStage.isNotBlank()) {
+            append(" · stage=")
+            append(failureStage)
+        }
+        append(" · messages=")
+        append(messagesExamined)
+        append(" · candidates=")
+        append(candidateMessageCount)
+        append(" · pdf=")
+        append(pdfCandidateCount)
+        append(" · normalized=")
+        append(normalizedCandidateCount)
+        append(" · recurring=")
+        append(recurringBillCount)
+        append(" · uniqueSources=")
+        append(uniqueRecurringSourceCount)
+        append(" · duplicates=")
+        append(duplicateCount)
+        append(" · oneOff=")
+        append(rejectedOneOffCount)
+        append(" · refunds=")
+        append(rejectedRefundCount)
+        append(" · receipts=")
+        append(rejectedReceiptOnlyCount)
+        append(" · contracts=")
+        append(rejectedContractCount)
+        append(" · unknown=")
+        append(unknownCount)
+    }
+}
+
+class GmailRecoveryDryRunRepository(
+    private val functions: FirebaseFunctions = FirebaseFunctions.getInstance("europe-west1")
+) {
+    suspend fun run(): GmailRecoveryDryRunResult {
+        check(BuildConfig.DEBUG) { "Recovery dry-run is DEBUG-only." }
+        val raw = functions
+            .getHttpsCallable("runGmailRecoveryDryRun")
+            .call(mapOf("recoveryDryRunVersion" to RECOVERY_DRY_RUN_VERSION))
+            .await()
+            .data as? Map<*, *> ?: error("Recovery dry-run returned an invalid count-only response.")
+
+        fun text(key: String): String = raw[key]?.toString().orEmpty()
+        fun count(key: String): Int = (raw[key] as? Number)?.toInt() ?: 0
+
+        return GmailRecoveryDryRunResult(
+            result = text("result"),
+            credentialPreflight = text("credentialPreflight"),
+            failureStage = text("failureStage"),
+            recoveryDryRunVersion = text("recoveryDryRunVersion"),
+            messagesExamined = count("messagesExamined"),
+            candidateMessageCount = count("candidateMessageCount"),
+            pdfCandidateCount = count("pdfCandidateCount"),
+            normalizedCandidateCount = count("normalizedCandidateCount"),
+            recurringBillCount = count("recurringBillCount"),
+            uniqueRecurringSourceCount = count("uniqueRecurringSourceCount"),
+            duplicateCount = count("duplicateCount"),
+            rejectedOneOffCount = count("rejectedOneOffCount"),
+            rejectedRefundCount = count("rejectedRefundCount"),
+            rejectedReceiptOnlyCount = count("rejectedReceiptOnlyCount"),
+            rejectedContractCount = count("rejectedContractCount"),
+            unknownCount = count("unknownCount")
+        )
+    }
+}

--- a/app/src/main/java/com/example/data/repository/GmailRepository.kt
+++ b/app/src/main/java/com/example/data/repository/GmailRepository.kt
@@ -51,6 +51,36 @@ class GmailRepository(
     private val shoppingRepository: ShoppingRepository,
     private val backendRepository: BackendRepository = BackendRepository()
 ) {
+    companion object {
+        internal fun formatRecoveryDiagnostic(state: GmailRecoveryDiagnosticResult): String =
+            buildString {
+                append("Recovery diagnostic · completed=")
+                append(state.initialBackfillCompleted)
+                append(" · parser=")
+                append(state.storedParserVersion)
+                append("→")
+                append(state.activeParserVersion)
+                append(" · invoices=")
+                append(state.authoritativeInvoiceCount)
+                append(" · imports=")
+                append(state.gmailMessageImportCount)
+                append(" · storedCandidates=")
+                append(state.storedCandidateCount)
+                append(" · normalized=")
+                append(state.normalizedCandidateCount)
+                append(" · replayable=")
+                append(state.replayableCandidateCount)
+                append(" · recurring=")
+                append(state.replayableRecurringCount)
+                append(" · uniqueSources=")
+                append(state.uniqueReplayableSourceCount)
+                append(" · duplicates=")
+                append(state.duplicateCandidateCount)
+                append(" · truncated=")
+                append(state.importsTruncated)
+            }
+    }
+
     private val _syncState = MutableStateFlow<GmailSyncState>(GmailSyncState.Idle)
     val syncState: StateFlow<GmailSyncState> = _syncState.asStateFlow()
 
@@ -66,35 +96,6 @@ class GmailRepository(
     private val _recoveryDiagnostic = MutableStateFlow("")
     val recoveryDiagnostic: StateFlow<String> = _recoveryDiagnostic.asStateFlow()
 
-    private fun formatRecoveryDiagnostic(state: GmailRecoveryDiagnosticResult): String {
-        val distribution = state.gmailMessageImportsParserVersionDistribution
-            .toSortedMap()
-            .entries
-            .joinToString(", ") { (version, count) -> "v$version=$count" }
-            .ifBlank { "none" }
-        val completedAt = state.initialBackfillCompletedAt.ifBlank { "unknown" }
-        return buildString {
-            append("Recovery diagnostic · completed=")
-            append(state.initialBackfillCompleted)
-            append(" · completedAt=")
-            append(completedAt)
-            append(" · parser=")
-            append(state.storedParserVersion)
-            append("→")
-            append(state.activeParserVersion)
-            append(" · invoices=")
-            append(state.authoritativeInvoiceCount)
-            append(" · imports=")
-            append(state.gmailMessageImportCount)
-            append(" · candidates=")
-            append(state.storedCandidateCount)
-            append(" · importParsers=")
-            append(distribution)
-            append(" · truncated=")
-            append(state.importsTruncated)
-        }
-    }
-
     private suspend fun refreshRecoveryDiagnosticIfAvailable(connected: Boolean) {
         if (!BuildConfig.DEBUG || !connected) {
             _recoveryDiagnostic.value = ""
@@ -102,7 +103,7 @@ class GmailRepository(
         }
         runCatching { backendRepository.getGmailSyncStatus(includeRecoveryDiagnostics = true) }
             .onSuccess { status ->
-                _recoveryDiagnostic.value = status.recoveryState?.let(::formatRecoveryDiagnostic).orEmpty()
+                _recoveryDiagnostic.value = status.recoveryState?.let { formatRecoveryDiagnostic(it) }.orEmpty()
             }
             .onFailure { error ->
                 // Diagnostic availability must never alter Gmail connection truth.

--- a/app/src/main/java/com/example/data/repository/GmailRepository.kt
+++ b/app/src/main/java/com/example/data/repository/GmailRepository.kt
@@ -1,6 +1,7 @@
 package com.example.data.repository
 
 import android.util.Log
+import com.example.BuildConfig
 import com.example.data.local.InvoiceItem
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -62,6 +63,54 @@ class GmailRepository(
     private val _lastScanTime = MutableStateFlow("טרם בוצעה סריקה")
     val lastScanTime: StateFlow<String> = _lastScanTime.asStateFlow()
 
+    private val _recoveryDiagnostic = MutableStateFlow("")
+    val recoveryDiagnostic: StateFlow<String> = _recoveryDiagnostic.asStateFlow()
+
+    private fun formatRecoveryDiagnostic(state: GmailRecoveryDiagnosticResult): String {
+        val distribution = state.gmailMessageImportsParserVersionDistribution
+            .toSortedMap()
+            .entries
+            .joinToString(", ") { (version, count) -> "v$version=$count" }
+            .ifBlank { "none" }
+        val completedAt = state.initialBackfillCompletedAt.ifBlank { "unknown" }
+        return buildString {
+            append("Recovery diagnostic · completed=")
+            append(state.initialBackfillCompleted)
+            append(" · completedAt=")
+            append(completedAt)
+            append(" · parser=")
+            append(state.storedParserVersion)
+            append("→")
+            append(state.activeParserVersion)
+            append(" · invoices=")
+            append(state.authoritativeInvoiceCount)
+            append(" · imports=")
+            append(state.gmailMessageImportCount)
+            append(" · candidates=")
+            append(state.storedCandidateCount)
+            append(" · importParsers=")
+            append(distribution)
+            append(" · truncated=")
+            append(state.importsTruncated)
+        }
+    }
+
+    private suspend fun refreshRecoveryDiagnosticIfAvailable(connected: Boolean) {
+        if (!BuildConfig.DEBUG || !connected) {
+            _recoveryDiagnostic.value = ""
+            return
+        }
+        runCatching { backendRepository.getGmailSyncStatus(includeRecoveryDiagnostics = true) }
+            .onSuccess { status ->
+                _recoveryDiagnostic.value = status.recoveryState?.let(::formatRecoveryDiagnostic).orEmpty()
+            }
+            .onFailure { error ->
+                // Diagnostic availability must never alter Gmail connection truth.
+                _recoveryDiagnostic.value = ""
+                Log.w("GmailRepository", "Sanitized Gmail recovery diagnostic unavailable", error)
+            }
+    }
+
     private suspend fun ensureGmailWatch() {
         runCatching { backendRepository.startGmailWatch() }
             .onFailure { error ->
@@ -76,10 +125,12 @@ class GmailRepository(
             _isConnected.value = connection.connected
             _connectedEmail.value = if (connection.connected) connection.email else ""
             if (connection.connected) ensureGmailWatch()
+            refreshRecoveryDiagnosticIfAvailable(connection.connected)
             connection
         }.onFailure { error ->
             Log.e("GmailRepository", "Gmail status refresh failed", error)
             _isConnected.value = false
+            _recoveryDiagnostic.value = ""
         }
     }
 
@@ -121,6 +172,7 @@ class GmailRepository(
             _isConnected.value = connection.connected
             _connectedEmail.value = connection.email.ifBlank { userEmail }
             if (connection.connected) ensureGmailWatch()
+            refreshRecoveryDiagnosticIfAvailable(connection.connected)
             _syncState.value = GmailSyncState.Success(
                 invoicesFound = 0,
                 totalSavingsPotential = 0.0,
@@ -130,6 +182,7 @@ class GmailRepository(
         }.onFailure { error ->
             Log.e("GmailRepository", "Gmail connection failed", error)
             _isConnected.value = false
+            _recoveryDiagnostic.value = ""
             _syncState.value = GmailSyncState.Error(
                 errorMessage = error.localizedMessage ?: "חיבור Gmail נכשל.",
                 isAuthRequired = true
@@ -190,6 +243,7 @@ class GmailRepository(
             _isConnected.value = false
             _connectedEmail.value = ""
             _lastScanTime.value = "מנותק"
+            _recoveryDiagnostic.value = ""
             _syncState.value = GmailSyncState.Idle
         }.onFailure { error ->
             Log.e("GmailRepository", "Gmail disconnect failed", error)

--- a/app/src/main/java/com/example/data/repository/GmailRepository.kt
+++ b/app/src/main/java/com/example/data/repository/GmailRepository.kt
@@ -51,6 +51,21 @@ class GmailRepository(
     private val shoppingRepository: ShoppingRepository,
     private val backendRepository: BackendRepository = BackendRepository()
 ) {
+    private val _syncState = MutableStateFlow<GmailSyncState>(GmailSyncState.Idle)
+    val syncState: StateFlow<GmailSyncState> = _syncState.asStateFlow()
+
+    private val _isConnected = MutableStateFlow(false)
+    val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
+
+    private val _connectedEmail = MutableStateFlow("")
+    val connectedEmail: StateFlow<String> = _connectedEmail.asStateFlow()
+
+    private val _lastScanTime = MutableStateFlow("טרם בוצעה סריקה")
+    val lastScanTime: StateFlow<String> = _lastScanTime.asStateFlow()
+
+    private val _recoveryDiagnostic = MutableStateFlow("")
+    val recoveryDiagnostic: StateFlow<String> = _recoveryDiagnostic.asStateFlow()
+
     companion object {
         internal fun formatRecoveryDiagnostic(state: GmailRecoveryDiagnosticResult): String =
             buildString {
@@ -80,21 +95,6 @@ class GmailRepository(
                 append(state.importsTruncated)
             }
     }
-
-    private val _syncState = MutableStateFlow<GmailSyncState>(GmailSyncState.Idle)
-    val syncState: StateFlow<GmailSyncState> = _syncState.asStateFlow()
-
-    private val _isConnected = MutableStateFlow(false)
-    val isConnected: StateFlow<Boolean> = _isConnected.asStateFlow()
-
-    private val _connectedEmail = MutableStateFlow("")
-    val connectedEmail: StateFlow<String> = _connectedEmail.asStateFlow()
-
-    private val _lastScanTime = MutableStateFlow("טרם בוצעה סריקה")
-    val lastScanTime: StateFlow<String> = _lastScanTime.asStateFlow()
-
-    private val _recoveryDiagnostic = MutableStateFlow("")
-    val recoveryDiagnostic: StateFlow<String> = _recoveryDiagnostic.asStateFlow()
 
     private suspend fun refreshRecoveryDiagnosticIfAvailable(connected: Boolean) {
         if (!BuildConfig.DEBUG || !connected) {

--- a/app/src/main/java/com/example/data/repository/PrivacyRepository.kt
+++ b/app/src/main/java/com/example/data/repository/PrivacyRepository.kt
@@ -41,7 +41,7 @@ suspend fun BackendRepository.disconnectGmailAuthoritatively(): GmailDisconnectR
         .await()
         .data
         .privacyMap()
-    return GmailDisconnectResult(
+    val result = GmailDisconnectResult(
         connected = response["connected"] as? Boolean ?: false,
         ingestionStopped = response["ingestionStopped"] as? Boolean ?: false,
         watchStopStatus = response["watchStopStatus"] as? String ?: "UNKNOWN",
@@ -49,6 +49,14 @@ suspend fun BackendRepository.disconnectGmailAuthoritatively(): GmailDisconnectR
         externalCleanupConfirmed = response["externalCleanupConfirmed"] as? Boolean ?: false,
         idempotent = response["idempotent"] as? Boolean ?: false
     )
+    if (!result.externalCleanupConfirmed) {
+        throw IllegalStateException(
+            "Gmail provider cleanup is still pending. " +
+                "watchStopStatus=${result.watchStopStatus}; " +
+                "oauthRevocationStatus=${result.oauthRevocationStatus}"
+        )
+    }
+    return result
 }
 
 suspend fun BackendRepository.deleteImportedFinancialData(): ImportedFinancialDataDeletionResult {

--- a/app/src/main/java/com/example/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/example/ui/screens/ProfileScreen.kt
@@ -63,6 +63,7 @@ fun ProfileScreen(
     val financialSyncState by viewModel.financialSyncState.collectAsState()
     val privacyOperationState by viewModel.privacyOperationState.collectAsState()
     val gmailSyncStep by viewModel.gmailSyncStep.collectAsState()
+    val gmailRecoveryDiagnostic by viewModel.gmailRepository.recoveryDiagnostic.collectAsState()
     var pendingConfirmation by remember { mutableStateOf<String?>(null) }
 
     LazyColumn(
@@ -89,6 +90,16 @@ fun ProfileScreen(
                 gmailSyncStep = gmailSyncStep,
                 onRequestGmailAuthorization = onRequestGmailAuthorization
             )
+        }
+        if (BuildConfig.DEBUG && gmailRecoveryDiagnostic.isNotBlank()) {
+            item {
+                Text(
+                    text = gmailRecoveryDiagnostic,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.testTag("gmail_recovery_diagnostic")
+                )
+            }
         }
 
         item { V3SectionHeader("פרטיות והרשאות") }

--- a/app/src/main/java/com/example/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/example/ui/screens/ProfileScreen.kt
@@ -62,6 +62,7 @@ fun ProfileScreen(
     val authState by viewModel.authState.collectAsState()
     val financialSyncState by viewModel.financialSyncState.collectAsState()
     val privacyOperationState by viewModel.privacyOperationState.collectAsState()
+    val gmailSyncStep by viewModel.gmailSyncStep.collectAsState()
     var pendingConfirmation by remember { mutableStateOf<String?>(null) }
 
     LazyColumn(
@@ -85,6 +86,7 @@ fun ProfileScreen(
             GmailAuthorityCard(
                 financialSyncState = financialSyncState,
                 authState = authState,
+                gmailSyncStep = gmailSyncStep,
                 onRequestGmailAuthorization = onRequestGmailAuthorization
             )
         }
@@ -203,6 +205,7 @@ private fun AccountCard(authState: AuthState, onGoogleSignIn: () -> Unit, onSign
 private fun GmailAuthorityCard(
     financialSyncState: FinancialSyncState,
     authState: AuthState,
+    gmailSyncStep: String,
     onRequestGmailAuthorization: () -> Unit
 ) {
     val connection = financialSyncState.gmailConnectionOrNull
@@ -226,6 +229,14 @@ private fun GmailAuthorityCard(
                         Text("הרשאה: קריאה בלבד")
                     } else Text("Gmail אינו מחובר.")
                 }
+            }
+            if (gmailSyncStep.isNotBlank()) {
+                Text(
+                    gmailSyncStep,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.testTag("gmail_connection_message")
+                )
             }
             if (authState is AuthState.Authenticated && financialSyncState == FinancialSyncState.Disconnected) {
                 OutlinedButton(onClick = onRequestGmailAuthorization, modifier = Modifier.fillMaxWidth().testTag("connect_gmail")) {

--- a/app/src/main/java/com/example/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/example/ui/screens/ProfileScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,11 +43,13 @@ import androidx.compose.ui.unit.dp
 import com.example.BuildConfig
 import com.example.data.repository.AuthState
 import com.example.data.repository.FinancialSyncState
+import com.example.data.repository.GmailRecoveryDryRunRepository
 import com.example.data.repository.gmailConnectionOrNull
 import com.example.ui.MainViewModel
 import com.example.ui.PrivacyOperationUiState
 import com.example.ui.components.V3SectionHeader
 import com.example.ui.theme.TechBluePrimary
+import kotlinx.coroutines.launch
 
 private const val CONFIRM_DISCONNECT_GMAIL = "DISCONNECT_GMAIL"
 private const val CONFIRM_DELETE_IMPORTED_DATA = "DELETE_IMPORTED_FINANCIAL_DATA"
@@ -64,6 +67,10 @@ fun ProfileScreen(
     val privacyOperationState by viewModel.privacyOperationState.collectAsState()
     val gmailSyncStep by viewModel.gmailSyncStep.collectAsState()
     val gmailRecoveryDiagnostic by viewModel.gmailRepository.recoveryDiagnostic.collectAsState()
+    val recoveryDryRunRepository = remember { GmailRecoveryDryRunRepository() }
+    val recoveryDryRunScope = rememberCoroutineScope()
+    var recoveryDryRunStatus by remember { mutableStateOf("") }
+    var recoveryDryRunRunning by remember { mutableStateOf(false) }
     var pendingConfirmation by remember { mutableStateOf<String?>(null) }
 
     LazyColumn(
@@ -99,6 +106,38 @@ fun ProfileScreen(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.testTag("gmail_recovery_diagnostic")
                 )
+            }
+        }
+        if (BuildConfig.DEBUG) {
+            item {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    OutlinedButton(
+                        onClick = {
+                            recoveryDryRunRunning = true
+                            recoveryDryRunStatus = "Recovery dry-run running"
+                            recoveryDryRunScope.launch {
+                                val result = runCatching { recoveryDryRunRepository.run() }
+                                recoveryDryRunStatus = result.fold(
+                                    onSuccess = { it.countOnlySummary() },
+                                    onFailure = { "Recovery dry-run failed before a count-only result." }
+                                )
+                                recoveryDryRunRunning = false
+                            }
+                        },
+                        enabled = authState is AuthState.Authenticated && !recoveryDryRunRunning,
+                        modifier = Modifier.fillMaxWidth().testTag("gmail_recovery_dry_run")
+                    ) {
+                        Text("Recovery dry-run · Staging diagnostic")
+                    }
+                    if (recoveryDryRunStatus.isNotBlank()) {
+                        Text(
+                            text = recoveryDryRunStatus,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.testTag("gmail_recovery_dry_run_result")
+                        )
+                    }
+                }
             }
         }
 

--- a/app/src/test/java/com/example/FinancialRecoveryPipelineTest.kt
+++ b/app/src/test/java/com/example/FinancialRecoveryPipelineTest.kt
@@ -12,7 +12,6 @@ import com.example.data.repository.latestScanOrNull
 import com.example.data.repository.observedRecurringMonthlySpendOrNull
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -151,19 +150,21 @@ class FinancialRecoveryPipelineTest {
     }
 
     @Test
-    fun firstRecoveryScanFailureIsFailedButNeverAuthRequiredOrKnownZero() = runBlocking {
+    fun firstRecoveryScanFailurePreservesConfirmedGmailConnectionWithoutInventingFinancialTruth() = runBlocking {
+        val connection = GmailConnectionResult(true, "user@example.com", "gmail-readonly-v1")
         val recovery = FinancialSessionRecovery(
-            getConnectionStatus = {
-                GmailConnectionResult(true, "user@example.com", "gmail-readonly-v1")
-            },
+            getConnectionStatus = { connection },
             recoverInvoices = { throw IllegalStateException("temporary scan failure") },
             getFinancialHome = { home }
         )
 
         val result = recovery.refresh(previous = null)
 
-        assertTrue(result is FinancialSyncState.Failed)
-        assertFalse((result as FinancialSyncState.Failed).isAuthRequired)
+        assertTrue(result is FinancialSyncState.Partial)
+        val partial = result as FinancialSyncState.Partial
+        assertEquals(connection, partial.gmailConnection)
+        assertNull(partial.latestScan)
+        assertNull(partial.financialHome)
         assertNull(result.observedRecurringMonthlySpendOrNull)
     }
 }

--- a/app/src/test/java/com/example/FinancialRecoveryPipelineTest.kt
+++ b/app/src/test/java/com/example/FinancialRecoveryPipelineTest.kt
@@ -50,10 +50,11 @@ class FinancialRecoveryPipelineTest {
     fun connectedRecoveryCallsServerInRequiredOrderAndReachesReady() = runBlocking {
         val order = mutableListOf<String>()
         val states = mutableListOf<FinancialSyncState>()
+        val connection = GmailConnectionResult(true, "user@example.com", "gmail-readonly-v1")
         val recovery = FinancialSessionRecovery(
             getConnectionStatus = {
                 order += "connection"
-                GmailConnectionResult(true, "user@example.com", "gmail-readonly-v1")
+                connection
             },
             recoverInvoices = {
                 order += "scan"
@@ -70,7 +71,7 @@ class FinancialRecoveryPipelineTest {
         assertEquals(listOf("connection", "scan", "home"), order)
         assertEquals(FinancialSyncState.CheckingConnection, states.first())
         assertTrue(states.contains(FinancialSyncState.Recovering))
-        assertEquals(FinancialSyncState.Ready(scan, home), result)
+        assertEquals(FinancialSyncState.Ready(scan, home, gmailConnection = connection), result)
         assertEquals(result, states.last())
     }
 
@@ -100,10 +101,9 @@ class FinancialRecoveryPipelineTest {
 
     @Test
     fun financialHomeFailureAfterBillRecoveryRetainsBillsButNotInventedTotals() = runBlocking {
+        val connection = GmailConnectionResult(true, "user@example.com", "gmail-readonly-v1")
         val recovery = FinancialSessionRecovery(
-            getConnectionStatus = {
-                GmailConnectionResult(true, "user@example.com", "gmail-readonly-v1")
-            },
+            getConnectionStatus = { connection },
             recoverInvoices = { scan },
             getFinancialHome = { throw IllegalStateException("home unavailable") }
         )
@@ -114,7 +114,8 @@ class FinancialRecoveryPipelineTest {
         assertEquals(scan, result.latestScanOrNull)
         assertNull(result.financialHomeOrNull)
         assertNull(result.observedRecurringMonthlySpendOrNull)
-        assertTrue((result as FinancialSyncState.Partial).reason.isNotBlank())
+        assertEquals(connection, (result as FinancialSyncState.Partial).gmailConnection)
+        assertTrue(result.reason.isNotBlank())
     }
 
     @Test
@@ -123,10 +124,11 @@ class FinancialRecoveryPipelineTest {
         var scanCalls = 0
         var homeCalls = 0
         val previous = FinancialSyncState.Ready(scan, home)
+        val connection = GmailConnectionResult(true, "user@example.com", "gmail-readonly-v1")
         val recovery = FinancialSessionRecovery(
             getConnectionStatus = {
                 connectionCalls += 1
-                GmailConnectionResult(true, "user@example.com", "gmail-readonly-v1")
+                connection
             },
             recoverInvoices = {
                 scanCalls += 1
@@ -146,6 +148,7 @@ class FinancialRecoveryPipelineTest {
         assertTrue(result is FinancialSyncState.Partial)
         assertEquals(scan, result.latestScanOrNull)
         assertEquals(home, result.financialHomeOrNull)
+        assertEquals(connection, (result as FinancialSyncState.Partial).gmailConnection)
         assertEquals(99.0, result.observedRecurringMonthlySpendOrNull!!, 0.0)
     }
 

--- a/app/src/test/java/com/example/GateBRemoteAcceptanceTest.kt
+++ b/app/src/test/java/com/example/GateBRemoteAcceptanceTest.kt
@@ -82,6 +82,7 @@ class GateBRemoteAcceptanceTest {
             insights = emptyList(),
             opportunities = emptyList()
         )
+        val connection = GmailConnectionResult(true, "restored@example.com", "gmail-readonly-v1")
 
         var connectionStatusCalls = 0
         var recoveryScanCalls = 0
@@ -91,7 +92,7 @@ class GateBRemoteAcceptanceTest {
         fun recovery() = FinancialSessionRecovery(
             getConnectionStatus = {
                 connectionStatusCalls += 1
-                GmailConnectionResult(true, "restored@example.com", "gmail-readonly-v1")
+                connection
             },
             recoverInvoices = {
                 recoveryScanCalls += 1
@@ -105,13 +106,13 @@ class GateBRemoteAcceptanceTest {
         )
 
         val firstLaunch = recovery().refresh(previous = null)
-        assertEquals(FinancialSyncState.Ready(scan, home), firstLaunch)
+        assertEquals(FinancialSyncState.Ready(scan, home, gmailConnection = connection), firstLaunch)
         assertEquals(2, repository.invoices.first().size)
 
         // Simulate a new app process/fresh local financial session. The server still reports the
         // existing Gmail grant, so recovery must run directly without any OAuth reconnect step.
         val secondLaunch = recovery().refresh(previous = null)
-        assertEquals(FinancialSyncState.Ready(scan, home), secondLaunch)
+        assertEquals(FinancialSyncState.Ready(scan, home, gmailConnection = connection), secondLaunch)
 
         val restoredRows = repository.invoices.first()
         assertEquals(2, restoredRows.size)

--- a/app/src/test/java/com/example/GmailDisconnectCleanupContractTest.kt
+++ b/app/src/test/java/com/example/GmailDisconnectCleanupContractTest.kt
@@ -1,0 +1,16 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GmailDisconnectCleanupContractTest {
+    @Test
+    fun disconnectRequiresConfirmedProviderCleanupAndSurfacesStatuses() {
+        val source = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        assertTrue(source.contains("externalCleanupConfirmed"))
+        assertTrue(source.contains("watchStopStatus"))
+        assertTrue(source.contains("oauthRevocationStatus"))
+        assertTrue(source.contains("if (!result.externalCleanupConfirmed)"))
+    }
+}

--- a/app/src/test/java/com/example/GmailDisconnectCleanupContractTest.kt
+++ b/app/src/test/java/com/example/GmailDisconnectCleanupContractTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class GmailDisconnectCleanupContractTest {
     @Test
     fun disconnectRequiresConfirmedProviderCleanupAndSurfacesStatuses() {
-        val source = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        val source = File("src/main/java/com/example/data/repository/PrivacyRepository.kt").readText()
         assertTrue(source.contains("externalCleanupConfirmed"))
         assertTrue(source.contains("watchStopStatus"))
         assertTrue(source.contains("oauthRevocationStatus"))

--- a/app/src/test/java/com/example/GmailRecoveryDryRunContractTest.kt
+++ b/app/src/test/java/com/example/GmailRecoveryDryRunContractTest.kt
@@ -1,0 +1,60 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GmailRecoveryDryRunContractTest {
+    private fun source(path: String): String = File(path).readText()
+
+    @Test
+    fun debugRecoveryControlIsExplicitVersionedAndAbsentFromNormalRefreshPaths() {
+        val recoverySource = source("src/main/java/com/example/data/repository/GmailRecoveryDryRunRepository.kt")
+        val profileSource = source("src/main/java/com/example/ui/screens/ProfileScreen.kt")
+        val gmailSource = source("src/main/java/com/example/data/repository/GmailRepository.kt")
+        val mainViewModelSource = source("src/main/java/com/example/ui/MainViewModel.kt")
+
+        assertTrue(recoverySource.contains("runGmailRecoveryDryRun"))
+        assertTrue(recoverySource.contains("staging-controlled-gmail-recovery-dry-run-v1"))
+        assertTrue(profileSource.contains("BuildConfig.DEBUG"))
+        assertTrue(profileSource.contains("Recovery dry-run"))
+        assertFalse(gmailSource.contains("runGmailRecoveryDryRun"))
+        assertFalse(mainViewModelSource.contains("runGmailRecoveryDryRun"))
+    }
+
+    @Test
+    fun recoveryClientDecodesCountOnlyContractWithoutPersonalCandidateFields() {
+        val recoverySource = source("src/main/java/com/example/data/repository/GmailRecoveryDryRunRepository.kt")
+
+        for (required in listOf(
+            "messagesExamined",
+            "candidateMessageCount",
+            "pdfCandidateCount",
+            "normalizedCandidateCount",
+            "recurringBillCount",
+            "uniqueRecurringSourceCount",
+            "duplicateCount",
+            "rejectedOneOffCount",
+            "rejectedRefundCount",
+            "rejectedReceiptOnlyCount",
+            "rejectedContractCount",
+            "unknownCount"
+        )) {
+            assertTrue("Missing sanitized counter: $required", recoverySource.contains(required))
+        }
+
+        for (forbidden in listOf(
+            "providerName",
+            "monthlyCost",
+            "receivedDate",
+            "subject",
+            "sourceMessageId",
+            "filename",
+            "emailText",
+            "attachmentContent"
+        )) {
+            assertFalse("Recovery client must not expose $forbidden", recoverySource.contains(forbidden))
+        }
+    }
+}

--- a/app/src/test/java/com/example/V3GmailDiagnosticSurfaceContractTest.kt
+++ b/app/src/test/java/com/example/V3GmailDiagnosticSurfaceContractTest.kt
@@ -1,0 +1,15 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class V3GmailDiagnosticSurfaceContractTest {
+    @Test
+    fun profileSurfacesGmailConnectionFailureMessage() {
+        val source = File("src/main/java/com/example/ui/screens/ProfileScreen.kt").readText()
+        assertTrue(source.contains("viewModel.gmailSyncStep.collectAsState()"))
+        assertTrue(source.contains("gmailSyncStep.isNotBlank()"))
+        assertTrue(source.contains("Text(gmailSyncStep"))
+    }
+}

--- a/app/src/test/java/com/example/V3GmailDiagnosticSurfaceContractTest.kt
+++ b/app/src/test/java/com/example/V3GmailDiagnosticSurfaceContractTest.kt
@@ -10,6 +10,7 @@ class V3GmailDiagnosticSurfaceContractTest {
         val source = File("src/main/java/com/example/ui/screens/ProfileScreen.kt").readText()
         assertTrue(source.contains("viewModel.gmailSyncStep.collectAsState()"))
         assertTrue(source.contains("gmailSyncStep.isNotBlank()"))
-        assertTrue(source.contains("Text(gmailSyncStep"))
+        assertTrue(Regex("Text\\(\\s*gmailSyncStep\\s*,").containsMatchIn(source))
+        assertTrue(source.contains("gmail_connection_message"))
     }
 }

--- a/app/src/test/java/com/example/V3GmailRecoveryDiagnosticContractTest.kt
+++ b/app/src/test/java/com/example/V3GmailRecoveryDiagnosticContractTest.kt
@@ -1,0 +1,46 @@
+package com.example
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class V3GmailRecoveryDiagnosticContractTest {
+    @Test
+    fun backendDecodesOnlySanitizedRecoveryMetadataOnExplicitDebugRequest() {
+        val backend = File("src/main/java/com/example/data/repository/BackendRepository.kt").readText()
+        val gmail = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        val profile = File("src/main/java/com/example/ui/screens/ProfileScreen.kt").readText()
+
+        assertTrue(backend.contains("data class GmailRecoveryDiagnosticResult"))
+        for (field in listOf(
+            "initialBackfillCompleted",
+            "initialBackfillCompletedAt",
+            "storedParserVersion",
+            "activeParserVersion",
+            "authoritativeInvoiceCount",
+            "gmailMessageImportCount",
+            "gmailMessageImportsParserVersionDistribution",
+            "storedCandidateCount",
+            "importsTruncated"
+        )) {
+            assertTrue("missing diagnostic field $field", backend.contains(field))
+        }
+        assertTrue(backend.contains("recoveryState: GmailRecoveryDiagnosticResult?"))
+        assertTrue(backend.contains("getGmailSyncStatus(includeRecoveryDiagnostics: Boolean = false)"))
+        assertTrue(backend.contains("\"includeRecoveryDiagnostics\" to includeRecoveryDiagnostics"))
+
+        assertTrue(gmail.contains("BuildConfig.DEBUG"))
+        assertTrue(gmail.contains("getGmailSyncStatus(includeRecoveryDiagnostics = true)"))
+        assertTrue(gmail.contains("recoveryDiagnostic"))
+        assertTrue(profile.contains("gmail_recovery_diagnostic"))
+
+        for (forbidden in listOf(
+            "refreshToken",
+            "serverAuthCode",
+            "attachmentContent",
+            "messageBody"
+        )) {
+            assertTrue("diagnostic surface must not add $forbidden", !profile.contains(forbidden))
+        }
+    }
+}

--- a/app/src/test/java/com/example/V3GmailRecoveryDiagnosticContractTest.kt
+++ b/app/src/test/java/com/example/V3GmailRecoveryDiagnosticContractTest.kt
@@ -1,46 +1,135 @@
 package com.example
 
+import com.example.data.repository.GmailRecoveryDiagnosticResult
+import com.example.data.repository.GmailRepository
+import com.example.data.repository.decodeGmailRecoveryDiagnostic
 import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class V3GmailRecoveryDiagnosticContractTest {
     @Test
-    fun backendDecodesOnlySanitizedRecoveryMetadataOnExplicitDebugRequest() {
+    fun replayFieldsDecodeCorrectlyAndMissingNumericValuesDefaultToZero() {
+        val decoded = decodeGmailRecoveryDiagnostic(
+            mapOf(
+                "initialBackfillCompleted" to true,
+                "initialBackfillCompletedAt" to "2026-08-22T00:00:00Z",
+                "storedParserVersion" to 2L,
+                "activeParserVersion" to 3L,
+                "authoritativeInvoiceCount" to 4L,
+                "gmailMessageImportCount" to 5L,
+                "gmailMessageImportsParserVersionDistribution" to mapOf("2" to 5L),
+                "storedCandidateCount" to 6L,
+                "normalizedCandidateCount" to 7L,
+                "replayableCandidateCount" to 8L,
+                "replayableRecurringCount" to 9L,
+                "uniqueReplayableSourceCount" to 10L,
+                "duplicateCandidateCount" to 11L,
+                "importsTruncated" to true
+            )
+        )
+
+        assertNotNull(decoded)
+        decoded!!
+        assertEquals(7, decoded.normalizedCandidateCount)
+        assertEquals(8, decoded.replayableCandidateCount)
+        assertEquals(9, decoded.replayableRecurringCount)
+        assertEquals(10, decoded.uniqueReplayableSourceCount)
+        assertEquals(11, decoded.duplicateCandidateCount)
+
+        val missing = decodeGmailRecoveryDiagnostic(mapOf("initialBackfillCompleted" to false))!!
+        assertEquals(0, missing.normalizedCandidateCount)
+        assertEquals(0, missing.replayableCandidateCount)
+        assertEquals(0, missing.replayableRecurringCount)
+        assertEquals(0, missing.uniqueReplayableSourceCount)
+        assertEquals(0, missing.duplicateCandidateCount)
+    }
+
+    @Test
+    fun debugDiagnosticShowsReplayDecisionCountsWithoutDatesOrPersonalCandidateData() {
+        val state = GmailRecoveryDiagnosticResult(
+            initialBackfillCompleted = true,
+            initialBackfillCompletedAt = "2026-08-22T00:00:00Z",
+            storedParserVersion = 2,
+            activeParserVersion = 3,
+            authoritativeInvoiceCount = 4,
+            gmailMessageImportCount = 5,
+            gmailMessageImportsParserVersionDistribution = mapOf("2" to 5),
+            storedCandidateCount = 6,
+            normalizedCandidateCount = 7,
+            replayableCandidateCount = 8,
+            replayableRecurringCount = 9,
+            uniqueReplayableSourceCount = 10,
+            duplicateCandidateCount = 11,
+            importsTruncated = true
+        )
+
+        val line = GmailRepository.formatRecoveryDiagnostic(state)
+        for (token in listOf(
+            "completed=true",
+            "parser=2→3",
+            "invoices=4",
+            "imports=5",
+            "storedCandidates=6",
+            "normalized=7",
+            "replayable=8",
+            "recurring=9",
+            "uniqueSources=10",
+            "duplicates=11",
+            "truncated=true"
+        )) {
+            assertTrue("missing diagnostic token $token", line.contains(token))
+        }
+        assertFalse(line.contains(state.initialBackfillCompletedAt))
+
+        val gmail = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        val formatter = gmail.substringAfter("formatRecoveryDiagnostic").substringBefore("refreshRecoveryDiagnosticIfAvailable")
+        for (forbidden in listOf(
+            "providerName",
+            "sourceMessageId",
+            "subject",
+            "attachment",
+            "email",
+            "token",
+            "credential",
+            "monthlyCost",
+            "receivedDate"
+        )) {
+            assertFalse("diagnostic formatter must not render $forbidden", formatter.contains(forbidden, ignoreCase = true))
+        }
+    }
+
+    @Test
+    fun recoveryDiagnosticIsReadOnlyAndDoesNotChangeGmailConnectionBehavior() {
+        val gmail = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
+        val refresh = gmail.substringAfter("private suspend fun refreshRecoveryDiagnosticIfAvailable")
+            .substringBefore("private suspend fun ensureGmailWatch")
+
+        assertTrue(refresh.contains("getGmailSyncStatus(includeRecoveryDiagnostics = true)"))
+        assertFalse(refresh.contains("scanInvoices("))
+        assertFalse(refresh.contains("scanGmailInvoices("))
+        assertFalse(refresh.contains("connectGmail("))
+        assertFalse(refresh.contains("disconnectGmail"))
+        assertFalse(refresh.contains("_isConnected.value"))
+
+        assertTrue(gmail.contains("_isConnected.value = connection.connected"))
+        assertTrue(gmail.contains("if (connection.connected) ensureGmailWatch()"))
+    }
+
+    @Test
+    fun diagnosticRemainsDebugOnlyAndExplicitlyRequested() {
         val backend = File("src/main/java/com/example/data/repository/BackendRepository.kt").readText()
         val gmail = File("src/main/java/com/example/data/repository/GmailRepository.kt").readText()
         val profile = File("src/main/java/com/example/ui/screens/ProfileScreen.kt").readText()
 
-        assertTrue(backend.contains("data class GmailRecoveryDiagnosticResult"))
-        for (field in listOf(
-            "initialBackfillCompleted",
-            "initialBackfillCompletedAt",
-            "storedParserVersion",
-            "activeParserVersion",
-            "authoritativeInvoiceCount",
-            "gmailMessageImportCount",
-            "gmailMessageImportsParserVersionDistribution",
-            "storedCandidateCount",
-            "importsTruncated"
-        )) {
-            assertTrue("missing diagnostic field $field", backend.contains(field))
-        }
         assertTrue(backend.contains("recoveryState: GmailRecoveryDiagnosticResult?"))
         assertTrue(backend.contains("getGmailSyncStatus(includeRecoveryDiagnostics: Boolean = false)"))
         assertTrue(backend.contains("\"includeRecoveryDiagnostics\" to includeRecoveryDiagnostics"))
-
         assertTrue(gmail.contains("BuildConfig.DEBUG"))
         assertTrue(gmail.contains("getGmailSyncStatus(includeRecoveryDiagnostics = true)"))
-        assertTrue(gmail.contains("recoveryDiagnostic"))
         assertTrue(profile.contains("gmail_recovery_diagnostic"))
-
-        for (forbidden in listOf(
-            "refreshToken",
-            "serverAuthCode",
-            "attachmentContent",
-            "messageBody"
-        )) {
-            assertTrue("diagnostic surface must not add $forbidden", !profile.contains(forbidden))
-        }
     }
 }


### PR DESCRIPTION
Diagnostic-only Android remediation layered on the frozen V3 branch. Surfaces the existing Gmail sync/error message in Profile so a physical-device OAuth attempt reveals the exact callable failure instead of silently returning to `Gmail אינו מחובר`.

Scope:
- Android presentation only
- no backend change
- no OAuth scope change
- no Firebase/GCP mutation
- no Production deployment
- no Google Play action
- no merge

TDD: RED source contract first, then minimal Profile surface change.