### PR TITLE
fix: least-privilege Production deploy IAM and artifact cleanup

### DIFF
--- a/functions/test/productionDeployIamRemediationGuard.test.js
+++ b/functions/test/productionDeployIamRemediationGuard.test.js
@@ -10,6 +10,12 @@ const verifyPath = path.resolve(__dirname, "../../scripts/verify-production-depl
 const bootstrap = fs.readFileSync(bootstrapPath, "utf8");
 const verify = fs.readFileSync(verifyPath, "utf8");
 
+function intendedRolesBlock(source) {
+  const match = source.match(/INTENDED_ROLES=\(([\s\S]*?)\)\nFORBIDDEN_ROLES=/);
+  assert.ok(match, "INTENDED_ROLES block must be present");
+  return match[1];
+}
+
 test("production deploy IAM uses a one-permission custom role for Cloud Run IAM policy updates", () => {
   assert.match(bootstrap, /CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"/);
   assert.match(bootstrap, /run\.services\.setIamPolicy/);
@@ -17,9 +23,10 @@ test("production deploy IAM uses a one-permission custom role for Cloud Run IAM 
   assert.match(verify, /CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"/);
   assert.match(verify, /run\.services\.setIamPolicy/);
 
-  assert.doesNotMatch(bootstrap, /INTENDED_ROLES=\([\s\S]*roles\/run\.admin/);
-  assert.doesNotMatch(bootstrap, /INTENDED_ROLES=\([\s\S]*roles\/cloudfunctions\.admin/);
-  assert.doesNotMatch(bootstrap, /INTENDED_ROLES=\([\s\S]*roles\/artifactregistry\.admin/);
+  const intended = intendedRolesBlock(bootstrap);
+  assert.doesNotMatch(intended, /roles\/run\.admin/);
+  assert.doesNotMatch(intended, /roles\/cloudfunctions\.admin/);
+  assert.doesNotMatch(intended, /roles\/artifactregistry\.admin/);
 });
 
 test("production IAM bootstrap preconfigures Firebase artifact cleanup in both deployment regions", () => {

--- a/functions/test/productionDeployIamRemediationGuard.test.js
+++ b/functions/test/productionDeployIamRemediationGuard.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const bootstrapPath = path.resolve(__dirname, "../../scripts/bootstrap-production-deploy-iam.sh");
+const verifyPath = path.resolve(__dirname, "../../scripts/verify-production-deploy-iam.sh");
+const bootstrap = fs.readFileSync(bootstrapPath, "utf8");
+const verify = fs.readFileSync(verifyPath, "utf8");
+
+test("production deploy IAM uses a one-permission custom role for Cloud Run IAM policy updates", () => {
+  assert.match(bootstrap, /CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"/);
+  assert.match(bootstrap, /run\.services\.setIamPolicy/);
+  assert.match(bootstrap, /--permissions="run\.services\.setIamPolicy"/);
+  assert.match(verify, /CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"/);
+  assert.match(verify, /run\.services\.setIamPolicy/);
+
+  assert.doesNotMatch(bootstrap, /INTENDED_ROLES=\([\s\S]*roles\/run\.admin/);
+  assert.doesNotMatch(bootstrap, /INTENDED_ROLES=\([\s\S]*roles\/cloudfunctions\.admin/);
+  assert.doesNotMatch(bootstrap, /INTENDED_ROLES=\([\s\S]*roles\/artifactregistry\.admin/);
+});
+
+test("production IAM bootstrap preconfigures Firebase artifact cleanup in both deployment regions", () => {
+  assert.match(
+    bootstrap,
+    /functions:artifacts:setpolicy[\s\S]*--location=europe-west1[\s\S]*--days=7/
+  );
+  assert.match(
+    bootstrap,
+    /functions:artifacts:setpolicy[\s\S]*--location=us-central1[\s\S]*--days=7/
+  );
+  assert.match(bootstrap, /EXPECTED_ARTIFACT_CLEANUP_DAYS="7"/);
+});

--- a/scripts/bootstrap-production-deploy-iam.sh
+++ b/scripts/bootstrap-production-deploy-iam.sh
@@ -16,13 +16,19 @@ GITHUB_OIDC_ISSUER="https://token.actions.githubusercontent.com"
 EXPECTED_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.repository_owner_id=assertion.repository_owner_id,attribute.environment=assertion.environment,attribute.ref=assertion.ref,attribute.workflow_ref=assertion.workflow_ref"
 EXPECTED_CONDITION="attribute.repository_id=='${GITHUB_REPOSITORY_ID}' && attribute.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && attribute.environment=='${GITHUB_ENVIRONMENT}' && attribute.ref=='${GITHUB_REF}' && attribute.workflow_ref=='${GITHUB_WORKFLOW_REF}'"
 EXPECTED_WIF_MEMBER="principalSet://iam.googleapis.com/projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${EXPECTED_POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
+CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"
+CUSTOM_DEPLOY_ROLE_TITLE="ClickAndSaveAI Firebase Deploy IAM Policy"
+CUSTOM_DEPLOY_ROLE_PERMISSION="run.services.setIamPolicy"
+EXPECTED_ARTIFACT_CLEANUP_DAYS="7"
 PROJECT_ID="${PROJECT_ID:-$EXPECTED_PROJECT_ID}"
+CUSTOM_DEPLOY_ROLE_NAME="projects/${EXPECTED_PROJECT_ID}/roles/${CUSTOM_DEPLOY_ROLE_ID}"
 
 INTENDED_ROLES=(
   roles/cloudfunctions.developer
   roles/firebaserules.admin
   roles/datastore.indexAdmin
   roles/serviceusage.serviceUsageConsumer
+  "$CUSTOM_DEPLOY_ROLE_NAME"
 )
 FORBIDDEN_ROLES=(
   roles/owner
@@ -47,6 +53,17 @@ contains() {
   for item in "$@"; do [[ "$item" == "$needle" ]] && return 0; done
   return 1
 }
+verify_custom_deploy_role() {
+  local role_json="$1"
+  CUSTOM_ROLE_JSON_INPUT="$role_json" python3 - "$CUSTOM_DEPLOY_ROLE_NAME" "$CUSTOM_DEPLOY_ROLE_PERMISSION" <<'PY'
+import json, os, sys
+expected_name, expected_permission = sys.argv[1:]
+role = json.loads(os.environ['CUSTOM_ROLE_JSON_INPUT'])
+assert role.get('name') == expected_name
+assert role.get('deleted', False) is not True
+assert sorted(role.get('includedPermissions', [])) == [expected_permission]
+PY
+}
 
 case "$PROJECT_ID" in
   clickandsaveai|clickandsaveai-staging) fail "Refusing forbidden non-Production project: $PROJECT_ID" ;;
@@ -54,6 +71,10 @@ esac
 [[ "$PROJECT_ID" == "$EXPECTED_PROJECT_ID" ]] || fail "PROJECT_ID must be exactly $EXPECTED_PROJECT_ID"
 command -v gcloud >/dev/null 2>&1 || fail "gcloud is required in an authenticated Production administrator shell."
 command -v python3 >/dev/null 2>&1 || fail "python3 is required."
+command -v firebase >/dev/null 2>&1 || fail "Firebase CLI >= 14 is required to configure Functions artifact cleanup policies."
+FIREBASE_CLI_VERSION="$(firebase --version 2>/dev/null || true)"
+FIREBASE_CLI_MAJOR="${FIREBASE_CLI_VERSION%%.*}"
+[[ "$FIREBASE_CLI_MAJOR" =~ ^[0-9]+$ && "$FIREBASE_CLI_MAJOR" -ge 14 ]] || fail "Firebase CLI >= 14 is required; found '${FIREBASE_CLI_VERSION:-unknown}'."
 ACTIVE_ACCOUNT="$(gcloud auth list --filter='status:ACTIVE' --format='value(account)' 2>/dev/null | head -n 1)"
 [[ -n "$ACTIVE_ACCOUNT" ]] || fail "No active gcloud account is available."
 
@@ -93,6 +114,20 @@ mapfile -t WIF_MEMBERS < <(gcloud iam service-accounts get-iam-policy "$EXPECTED
   | sed '/^[[:space:]]*$/d' | sort -u)
 [[ "${#WIF_MEMBERS[@]}" -eq 1 && "${WIF_MEMBERS[0]}" == "$EXPECTED_WIF_MEMBER" ]] || fail "Production WIF impersonation boundary is missing or broader than intended."
 
+CUSTOM_ROLE_JSON="$(gcloud iam roles describe "$CUSTOM_DEPLOY_ROLE_ID" --project="$PROJECT_ID" --format=json 2>/dev/null || true)"
+if [[ -z "$CUSTOM_ROLE_JSON" ]]; then
+  gcloud iam roles create "$CUSTOM_DEPLOY_ROLE_ID" \
+    --project="$PROJECT_ID" \
+    --title="$CUSTOM_DEPLOY_ROLE_TITLE" \
+    --description="ClickAndSaveAI Production Firebase deployer: Cloud Run IAM policy update only." \
+    --permissions="run.services.setIamPolicy" \
+    --stage=GA \
+    --quiet >/dev/null
+  CUSTOM_ROLE_JSON="$(gcloud iam roles describe "$CUSTOM_DEPLOY_ROLE_ID" --project="$PROJECT_ID" --format=json 2>/dev/null || true)"
+fi
+[[ -n "$CUSTOM_ROLE_JSON" ]] || fail "Custom Production deploy role is missing after bootstrap."
+verify_custom_deploy_role "$CUSTOM_ROLE_JSON" || fail "Custom Production deploy role is not exactly least-privilege; refusing IAM mutation."
+
 mapfile -t CURRENT_PROJECT_ROLES < <(gcloud projects get-iam-policy "$PROJECT_ID" \
   --flatten='bindings[].members' --filter="bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
   --format='value(bindings.role)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
@@ -122,7 +157,14 @@ mapfile -t FINAL_PROJECT_ROLES < <(gcloud projects get-iam-policy "$PROJECT_ID" 
   --flatten='bindings[].members' --filter="bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
   --format='value(bindings.role)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
 mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_ROLES[@]}" | sort -u)
-[[ "$(printf '%s\n' "${FINAL_PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]] || fail "Final deploy-SA project role set is not exactly the intended Block 3B.2B set."
+[[ "$(printf '%s\n' "${FINAL_PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]] || fail "Final deploy-SA project role set is not exactly the intended least-privilege set."
+
+printf 'Configuring Firebase Functions Artifact Registry cleanup policy in europe-west1 (%s days).\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
+firebase functions:artifacts:setpolicy --project="$PROJECT_ID" --location=europe-west1 --days=7
+printf 'Configuring Firebase Functions Artifact Registry cleanup policy in us-central1 (%s days).\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
+firebase functions:artifacts:setpolicy --project="$PROJECT_ID" --location=us-central1 --days=7
 
 printf 'Production deploy IAM foundation configured for %s.\n' "$EXPECTED_DEPLOY_SA"
+printf 'Custom deploy role permission exact: %s.\n' "$CUSTOM_DEPLOY_ROLE_PERMISSION"
+printf 'Artifact cleanup retention configured: %s days in europe-west1 and us-central1.\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
 printf 'Block 3B.3 runtime/build service-account actAs relationships remain intentionally NOT configured.\n'

--- a/scripts/verify-production-deploy-iam.sh
+++ b/scripts/verify-production-deploy-iam.sh
@@ -17,13 +17,17 @@ EXPECTED_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion
 EXPECTED_CONDITION="attribute.repository_id=='${GITHUB_REPOSITORY_ID}' && attribute.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && attribute.environment=='${GITHUB_ENVIRONMENT}' && attribute.ref=='${GITHUB_REF}' && attribute.workflow_ref=='${GITHUB_WORKFLOW_REF}'"
 EXPECTED_WIF_MEMBER="principalSet://iam.googleapis.com/projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${EXPECTED_POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
 GITHUB_REPOSITORY="vhanukaev1981/ClickAndSaveAI"
+CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"
+CUSTOM_DEPLOY_ROLE_PERMISSION="run.services.setIamPolicy"
 PROJECT_ID="${PROJECT_ID:-$EXPECTED_PROJECT_ID}"
+CUSTOM_DEPLOY_ROLE_NAME="projects/${EXPECTED_PROJECT_ID}/roles/${CUSTOM_DEPLOY_ROLE_ID}"
 
 INTENDED_ROLES=(
   roles/cloudfunctions.developer
   roles/firebaserules.admin
   roles/datastore.indexAdmin
   roles/serviceusage.serviceUsageConsumer
+  "$CUSTOM_DEPLOY_ROLE_NAME"
 )
 FORBIDDEN_ROLES=(
   roles/owner
@@ -102,14 +106,29 @@ mapfile -t WIF_MEMBERS < <(gcloud iam service-accounts get-iam-policy "$EXPECTED
   | sed '/^[[:space:]]*$/d' | sort -u)
 [[ "${#WIF_MEMBERS[@]}" -eq 1 && "${WIF_MEMBERS[0]}" == "$EXPECTED_WIF_MEMBER" ]] && pass "Production WIF impersonation boundary exact" || fail "Production WIF impersonation boundary mismatch"
 
+CUSTOM_ROLE_JSON="$(gcloud iam roles describe "$CUSTOM_DEPLOY_ROLE_ID" --project="$PROJECT_ID" --format=json 2>/dev/null || true)"
+if [[ -n "$CUSTOM_ROLE_JSON" ]] && CUSTOM_ROLE_JSON_INPUT="$CUSTOM_ROLE_JSON" python3 - "$CUSTOM_DEPLOY_ROLE_NAME" "$CUSTOM_DEPLOY_ROLE_PERMISSION" <<'PY'
+import json, os, sys
+expected_name, expected_permission = sys.argv[1:]
+role = json.loads(os.environ['CUSTOM_ROLE_JSON_INPUT'])
+assert role.get('name') == expected_name
+assert role.get('deleted', False) is not True
+assert sorted(role.get('includedPermissions', [])) == [expected_permission]
+PY
+then
+  pass "custom deploy role contains exactly run.services.setIamPolicy"
+else
+  fail "custom deploy role missing or broader than run.services.setIamPolicy"
+fi
+
 mapfile -t PROJECT_ROLES < <(gcloud projects get-iam-policy "$PROJECT_ID" \
   --flatten='bindings[].members' --filter="bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
   --format='value(bindings.role)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
 mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_ROLES[@]}" | sort -u)
 if [[ "$(printf '%s\n' "${PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]]; then
-  pass "deploy-SA project roles exactly match Block 3B.2B"
+  pass "deploy-SA project roles exactly match least-privilege Production set"
 else
-  fail "deploy-SA project roles do not exactly match Block 3B.2B"
+  fail "deploy-SA project roles do not exactly match least-privilege Production set"
 fi
 
 for role in "${FORBIDDEN_ROLES[@]}"; do
@@ -145,4 +164,5 @@ fi
 printf '\nProduction deploy IAM verification PASSED.\n'
 printf 'productionDeployIamConfigured=true\n'
 printf 'productionDeployEndToEndReady=false\n'
+printf 'customDeployRolePermission=%s\n' "$CUSTOM_DEPLOY_ROLE_PERMISSION"
 printf 'Block 3B.3 runtime/build service-account actAs relationships remain intentionally NOT configured.\n'


### PR DESCRIPTION
Production release remediation for the failed Firebase deploy after Functions updated successfully but Cloud Run IAM policy and Artifact Registry cleanup setup failed.

TDD status: this Draft PR initially contains only the failing regression guard. Implementation will follow only after RED is observed.

Scope:
- add a single-permission custom deploy role for `run.services.setIamPolicy`
- keep broad admin roles forbidden
- bootstrap Firebase Functions artifact cleanup policies in `europe-west1` and `us-central1`
- update verification to enforce the exact least-privilege state
- no Production deploy from this PR