### PR TITLE
fix: use actual Production bootstrap service account ID

### DIFF
--- a/.github/DO_NOT_USE
+++ b/.github/DO_NOT_USE
@@ -1,0 +1,1 @@
+temporary

--- a/.github/DO_NOT_USE
+++ b/.github/DO_NOT_USE
@@ -1,1 +1,0 @@
-temporary

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -186,6 +186,7 @@ jobs:
       - name: Verify signing identities and record exact-SHA traceability
         shell: bash
         run: |
+          set -euo pipefail
           APK="$(find app/build/outputs/apk/release -maxdepth 1 -name '*.apk' -print -quit)"
           AAB="$(find app/build/outputs/bundle/release -maxdepth 1 -name '*.aab' -print -quit)"
           [[ -n "$APK" && -n "$AAB" ]] || { echo 'Signed release APK/AAB not found.' >&2; exit 1; }

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -186,7 +186,6 @@ jobs:
       - name: Verify signing identities and record exact-SHA traceability
         shell: bash
         run: |
-          set -euo pipefail
           APK="$(find app/build/outputs/apk/release -maxdepth 1 -name '*.apk' -print -quit)"
           AAB="$(find app/build/outputs/bundle/release -maxdepth 1 -name '*.aab' -print -quit)"
           [[ -n "$APK" && -n "$AAB" ]] || { echo 'Signed release APK/AAB not found.' >&2; exit 1; }
@@ -364,7 +363,7 @@ jobs:
       EXPECTED_PROJECT_ID: click-save-ai-production
       EXPECTED_PROJECT_NUMBER: '991489557172'
       EXPECTED_WIF_PROVIDER: projects/991489557172/locations/global/workloadIdentityPools/github-actions/providers/clickandsaveai-production
-      EXPECTED_BOOTSTRAP_SA: clickandsaveai-github-bootstrap@click-save-ai-production.iam.gserviceaccount.com
+      EXPECTED_BOOTSTRAP_SA: clickandsaveai-github-bootstra@click-save-ai-production.iam.gserviceaccount.com
       EXPECTED_DEPLOY_SA: clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com
       EXPECTED_MAPPING: google.subject=assertion.sub,attribute.repository_id=assertion.repository_id,attribute.repository_owner_id=assertion.repository_owner_id,attribute.environment=assertion.environment,attribute.ref=assertion.ref,attribute.workflow_ref=assertion.workflow_ref
       EXPECTED_CONDITION: attribute.repository_id=='1314210715' && attribute.repository_owner_id=='64756523' && attribute.environment=='production' && attribute.ref=='refs/heads/main' && attribute.workflow_ref=='vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main'
@@ -423,7 +422,7 @@ jobs:
           export_environment_variables: 'false'
           project_id: ${{ env.EXPECTED_PROJECT_ID }}
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: clickandsaveai-github-bootstrap@click-save-ai-production.iam.gserviceaccount.com
+          service_account: clickandsaveai-github-bootstra@click-save-ai-production.iam.gserviceaccount.com
 
       - name: Pre-mutation fail-closed identity and trust-boundary verification
         env:

--- a/functions/test/productionDeployIamBootstrapWorkflow.test.js
+++ b/functions/test/productionDeployIamBootstrapWorkflow.test.js
@@ -62,7 +62,7 @@ test("bootstrap job enforces canonical identity boundary and source SHA", () => 
     "EXPECTED_WORKFLOW_REF: vhanukaev1981/ClickAndSaveAI/.github/workflows/production-release.yml@refs/heads/main",
     "EXPECTED_PROJECT_ID: click-save-ai-production",
     "EXPECTED_PROJECT_NUMBER: '991489557172'",
-    "EXPECTED_BOOTSTRAP_SA: clickandsaveai-github-bootstrap@click-save-ai-production.iam.gserviceaccount.com",
+    "EXPECTED_BOOTSTRAP_SA: clickandsaveai-github-bootstra@click-save-ai-production.iam.gserviceaccount.com",
     "EXPECTED_DEPLOY_SA: clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com",
     "ACTUAL_GITHUB_REPOSITORY",
     "ACTUAL_GITHUB_REPOSITORY_ID",
@@ -84,7 +84,7 @@ test("bootstrap job uses WIF with bootstrap SA only and runs canonical scripts",
   assert.match(bootstrap, /workload_identity_provider: \$\{\{ vars\.GCP_WORKLOAD_IDENTITY_PROVIDER \}\}/);
   assert.match(
     bootstrap,
-    /service_account: clickandsaveai-github-bootstrap@click-save-ai-production\.iam\.gserviceaccount\.com/
+    /service_account: clickandsaveai-github-bootstra@click-save-ai-production\.iam\.gserviceaccount\.com/
   );
   assert.doesNotMatch(bootstrap, /service_account: \$\{\{ vars\.GCP_DEPLOY_SERVICE_ACCOUNT \}\}/);
 


### PR DESCRIPTION
Replaces closed draft PR #114 after all canonical checks passed on exact head `4b2a8443f2ac7d7c3ae80b02ebacba39e326104c`.

Aligns the Production bootstrap workflow and regression test with the actual existing GCP service account:
`clickandsaveai-github-bootstra@click-save-ai-production.iam.gserviceaccount.com`

Safety preserved: no Production deploy, no IAM broadening, no service-account creation, no key creation, WIF boundaries unchanged.