### PR TITLE
fix: preserve approved Production metadata reader role

### DIFF
--- a/functions/test/productionDeployIamRemediationGuard.test.js
+++ b/functions/test/productionDeployIamRemediationGuard.test.js
@@ -16,6 +16,12 @@ function intendedRolesBlock(source) {
   return match[1];
 }
 
+function approvedPreexistingRolesBlock(source) {
+  const match = source.match(/APPROVED_PREEXISTING_ROLES=\(([\s\S]*?)\)\nFORBIDDEN_ROLES=/);
+  assert.ok(match, "APPROVED_PREEXISTING_ROLES block must be present");
+  return match[1];
+}
+
 test("production deploy IAM uses a one-permission custom role for Cloud Run IAM policy updates", () => {
   assert.match(bootstrap, /CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"/);
   assert.match(bootstrap, /run\.services\.setIamPolicy/);
@@ -27,6 +33,19 @@ test("production deploy IAM uses a one-permission custom role for Cloud Run IAM 
   assert.doesNotMatch(intended, /roles\/run\.admin/);
   assert.doesNotMatch(intended, /roles\/cloudfunctions\.admin/);
   assert.doesNotMatch(intended, /roles\/artifactregistry\.admin/);
+});
+
+test("production IAM bootstra preserves only the exact approved Firebase Metadata Reader role when pre-existing", () => {
+  const metadataReaderRole = "projects/click-save-ai-production/roles/clickandsaveaiFirebaseMetadataReader";
+  const bootstrapApproved = approvedPreexistingRolesBlock(bootstrap);
+  const verifyApproved = approvedPreexistingRolesBlock(verify);
+
+  assert.match(bootstrapApproved, new RegExp(metadataReaderRole.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(verifyApproved, new RegExp(metadataReaderRole.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(intendedRolesBlock(bootstrap), /clickandsaveaiFirebaseMetadataReader/);
+  assert.doesNotMatch(intendedRolesBlock(verify), /clickandsaveaiFirebaseMetadataReader/);
+  assert.match(bootstrap, /PRESERVED_PREEXISTING_ROLES/);
+  assert.match(verify, /approved pre-existing deploy-SA role/);
 });
 
 test("production IAM bootstrap preconfigures Firebase artifact cleanup in both deployment regions", () => {

--- a/functions/test/productionDeployIamRemediationGuard.test.js
+++ b/functions/test/productionDeployIamRemediationGuard.test.js
@@ -11,7 +11,7 @@ const bootstrap = fs.readFileSync(bootstrapPath, "utf8");
 const verify = fs.readFileSync(verifyPath, "utf8");
 
 function intendedRolesBlock(source) {
-  const match = source.match(/INTENDED_ROLES=\(([\s\S]*?)\)\nFORBIDDEN_ROLES=/);
+  const match = source.match(/INTENDED_ROLES=\(([\s\S]*?)\)\n(?:APPROVED_PREEXISTING_ROLES|FORBIDDEN_ROLES)=/);
   assert.ok(match, "INTENDED_ROLES block must be present");
   return match[1];
 }
@@ -35,7 +35,7 @@ test("production deploy IAM uses a one-permission custom role for Cloud Run IAM 
   assert.doesNotMatch(intended, /roles\/artifactregistry\.admin/);
 });
 
-test("production IAM bootstra preserves only the exact approved Firebase Metadata Reader role when pre-existing", () => {
+test("production IAM bootstrap preserves only the exact approved Firebase Metadata Reader role when pre-existing", () => {
   const metadataReaderRole = "projects/click-save-ai-production/roles/clickandsaveaiFirebaseMetadataReader";
   const bootstrapApproved = approvedPreexistingRolesBlock(bootstrap);
   const verifyApproved = approvedPreexistingRolesBlock(verify);

--- a/scripts/bootstrap-production-deploy-iam.sh
+++ b/scripts/bootstrap-production-deploy-iam.sh
@@ -31,7 +31,7 @@ INTENDED_ROLES=(
   "$CUSTOM_DEPLOY_ROLE_NAME"
 )
 APPROVED_PREEXISTING_ROLES=(
-  "projects/${EXPECTED_PROJECT_ID}/roles/clickandsaveaiFirebaseMetadataReader"
+  "projects/click-save-ai-production/roles/clickandsaveaiFirebaseMetadataReader"
 )
 FORBIDDEN_ROLES=(
   roles/owner

--- a/scripts/bootstrap-production-deploy-iam.sh
+++ b/scripts/bootstrap-production-deploy-iam.sh
@@ -30,6 +30,9 @@ INTENDED_ROLES=(
   roles/serviceusage.serviceUsageConsumer
   "$CUSTOM_DEPLOY_ROLE_NAME"
 )
+APPROVED_PREEXISTING_ROLES=(
+  "projects/${EXPECTED_PROJECT_ID}/roles/clickandsaveaiFirebaseMetadataReader"
+)
 FORBIDDEN_ROLES=(
   roles/owner
   roles/editor
@@ -131,11 +134,19 @@ verify_custom_deploy_role "$CUSTOM_ROLE_JSON" || fail "Custom Production deploy 
 mapfile -t CURRENT_PROJECT_ROLES < <(gcloud projects get-iam-policy "$PROJECT_ID" \
   --flatten='bindings[].members' --filter="bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
   --format='value(bindings.role)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
+PRESERVED_PREEXISTING_ROLES=()
 for role in "${CURRENT_PROJECT_ROLES[@]}"; do
   if contains "$role" "${FORBIDDEN_ROLES[@]}" || [[ "$role" =~ ^roles/.+\.serviceAgent$ ]]; then
     fail "Forbidden project-level role already exists on deploy SA: $role"
   fi
-  contains "$role" "${INTENDED_ROLES[@]}" || fail "Unexpected pre-existing project role on deploy SA: $role"
+  if contains "$role" "${INTENDED_ROLES[@]}"; then
+    continue
+  fi
+  if contains "$role" "${APPROVED_PREEXISTING_ROLES[@]}"; then
+    PRESERVED_PREEXISTING_ROLES+=("$role")
+    continue
+  fi
+  fail "Unexpected pre-existing project role on deploy SA: $role"
 done
 
 for role in "${INTENDED_ROLES[@]}"; do
@@ -156,8 +167,8 @@ done
 mapfile -t FINAL_PROJECT_ROLES < <(gcloud projects get-iam-policy "$PROJECT_ID" \
   --flatten='bindings[].members' --filter="bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
   --format='value(bindings.role)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
-mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_ROLES[@]}" | sort -u)
-[[ "$(printf '%s\n' "${FINAL_PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]] || fail "Final deploy-SA project role set is not exactly the intended least-privilege set."
+mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_ROLES[@]}" "${PRESERVED_PREEXISTING_ROLES[@]}" | sed '/^[[:space:]]*$/d' | sort -u)
+[[ "$(printf '%s\n' "${FINAL_PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]] || fail "Final deploy-SA project role set is not exactly the intended set plus approved pre-existing roles."
 
 printf 'Configuring Firebase Functions Artifact Registry cleanup policy in europe-west1 (%s days).\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
 firebase functions:artifacts:setpolicy --project="$PROJECT_ID" --location=europe-west1 --days=7

--- a/scripts/verify-production-deploy-iam.sh
+++ b/scripts/verify-production-deploy-iam.sh
@@ -30,7 +30,7 @@ INTENDED_ROLES=(
   "$CUSTOM_DEPLOY_ROLE_NAME"
 )
 APPROVED_PREEXISTING_ROLES=(
-  "projects/${EXPECTED_PROJECT_ID}/roles/clickandsaveaiFirebaseMetadataReader"
+  "projects/click-save-ai-production/roles/clickandsaveaiFirebaseMetadataReader"
 )
 FORBIDDEN_ROLES=(
   roles/owner

--- a/scripts/verify-production-deploy-iam.sh
+++ b/scripts/verify-production-deploy-iam.sh
@@ -29,6 +29,9 @@ INTENDED_ROLES=(
   roles/serviceusage.serviceUsageConsumer
   "$CUSTOM_DEPLOY_ROLE_NAME"
 )
+APPROVED_PREEXISTING_ROLES=(
+  "projects/${EXPECTED_PROJECT_ID}/roles/clickandsaveaiFirebaseMetadataReader"
+)
 FORBIDDEN_ROLES=(
   roles/owner
   roles/editor
@@ -124,12 +127,28 @@ fi
 mapfile -t PROJECT_ROLES < <(gcloud projects get-iam-policy "$PROJECT_ID" \
   --flatten='bindings[].members' --filter="bindings.members=serviceAccount:${EXPECTED_DEPLOY_SA}" \
   --format='value(bindings.role)' 2>/dev/null | sed '/^[[:space:]]*$/d' | sort -u)
-mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_ROLES[@]}" | sort -u)
-if [[ "$(printf '%s\n' "${PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]]; then
-  pass "deploy-SA project roles exactly match least-privilege Production set"
-else
-  fail "deploy-SA project roles do not exactly match least-privilege Production set"
-fi
+for role in "${INTENDED_ROLES[@]}"; do
+  if contains "$role" "${PROJECT_ROLES[@]}"; then
+    pass "required deploy-SA project role present: $role"
+  else
+    fail "required deploy-SA project role missing: $role"
+  fi
+done
+for role in "${PROJECT_ROLES[@]}"; do
+  if contains "$role" "${INTENDED_ROLES[@]}"; then
+    continue
+  fi
+  if contains "$role" "${APPROVED_PREEXISTING_ROLES[@]}"; then
+    pass "approved pre-existing deploy-SA role present: $role"
+    continue
+  fi
+  fail "unexpected deploy-SA project role present: $role"
+done
+for role in "${APPROVED_PREEXISTING_ROLES[@]}"; do
+  if ! contains "$role" "${PROJECT_ROLES[@]}"; then
+    pass "approved pre-existing deploy-SA role absent (optional): $role"
+  fi
+done
 
 for role in "${FORBIDDEN_ROLES[@]}"; do
   if contains "$role" "${PROJECT_ROLES[@]}"; then fail "forbidden deploy-SA project role present: $role"; else pass "forbidden deploy-SA project role absent: $role"; fi


### PR DESCRIPTION
TDD remediation for the Production deploy-IAM bootstra failure caused by the intentional pre-existing custom role `projects/click-save-ai-production/roles/clickandsaveaiFirebaseMetadataReader` on the Production deploy service account.

Phase 1 is intentionally RED: regression coverage is added first. No Production IAM mutation, Firebase deploy, or role removal is performed by this PR.