### PR TITLE
fix: use actual Production metadata reader role ID

### DIFF
--- a/functions/test/productionDeployIamRemediationGuard.test.js
+++ b/functions/test/productionDeployIamRemediationGuard.test.js
@@ -35,15 +35,17 @@ test("production deploy IAM uses a one-permission custom role for Cloud Run IAM 
   assert.doesNotMatch(intended, /roles\/artifactregistry\.admin/);
 });
 
-test("production IAM bootstrap preserves only the exact approved Firebase Metadata Reader role when pre-existing", () => {
-  const metadataReaderRole = "projects/click-save-ai-production/roles/clickandsaveaiFirebaseMetadataReader";
+test("production IAM bootstra preserves only the exact actual Firebase Metadata Reader role when pre-existing", () => {
+  const metadataReaderRole = "projects/click-save-ai-production/roles/clickandsaveFirebaseMetadataReader";
   const bootstrapApproved = approvedPreexistingRolesBlock(bootstrap);
   const verifyApproved = approvedPreexistingRolesBlock(verify);
 
   assert.match(bootstrapApproved, new RegExp(metadataReaderRole.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(verifyApproved, new RegExp(metadataReaderRole.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-  assert.doesNotMatch(intendedRolesBlock(bootstrap), /clickandsaveaiFirebaseMetadataReader/);
-  assert.doesNotMatch(intendedRolesBlock(verify), /clickandsaveaiFirebaseMetadataReader/);
+  assert.doesNotMatch(intendedRolesBlock(bootstrap), /clickandsaveFirebaseMetadataReader/);
+  assert.doesNotMatch(intendedRolesBlock(verify), /clickandsaveFirebaseMetadataReader/);
+  assert.doesNotMatch(bootstrapApproved, /clickandsaveaiFirebaseMetadataReader/);
+  assert.doesNotMatch(verifyApproved, /clickandsaveaiFirebaseMetadataReader/);
   assert.match(bootstrap, /PRESERVED_PREEXISTING_ROLES/);
   assert.match(verify, /approved pre-existing deploy-SA role/);
 });

--- a/scripts/bootstrap-production-deploy-iam.sh
+++ b/scripts/bootstrap-production-deploy-iam.sh
@@ -31,7 +31,7 @@ INTENDED_ROLES=(
   "$CUSTOM_DEPLOY_ROLE_NAME"
 )
 APPROVED_PREEXISTING_ROLES=(
-  "projects/click-save-ai-production/roles/clickandsaveaiFirebaseMetadataReader"
+  "projects/click-save-ai-production/roles/clickandsaveFirebaseMetadataReader"
 )
 FORBIDDEN_ROLES=(
   roles/owner

--- a/scripts/verify-production-deploy-iam.sh
+++ b/scripts/verify-production-deploy-iam.sh
@@ -30,7 +30,7 @@ INTENDED_ROLES=(
   "$CUSTOM_DEPLOY_ROLE_NAME"
 )
 APPROVED_PREEXISTING_ROLES=(
-  "projects/click-save-ai-production/roles/clickandsaveaiFirebaseMetadataReader"
+  "projects/click-save-ai-production/roles/clickandsaveFirebaseMetadataReader"
 )
 FORBIDDEN_ROLES=(
   roles/owner


### PR DESCRIPTION
Production Release Gate #26 proved the live pre-existing custom role is `projects/click-save-ai-production/roles/clickandsaveFirebaseMetadataReader` (without `ai` in the role ID), while PR #117 had allowlisted a non-existent variant. This PR pins the exact live role ID in bootstrap + verifier and adds regression coverage rejecting the incorrect alias. No Production IAM mutation or deploy is performed by this PR.