### PR TITLE
fix: expose WIF ADC to Firebase bootstrap CLI

### DIFF
--- a/functions/test/productionDeployIamBootstrapWorkflow.test.js
+++ b/functions/test/productionDeployIamBootstrapWorkflow.test.js
@@ -92,6 +92,15 @@ test("bootstrap job uses WIF with bootstrap SA only and runs canonical scripts",
   assert.match(bootstrap, /bash scripts\/verify-production-deploy-iam\.sh/);
 });
 
+test("bootstrap exports WIF ADC credentials for non-interactive Firebase CLI authentication", () => {
+  const bootstrap = jobBlock("production-bootstrap-deploy-iam");
+  assert.match(
+    bootstrap,
+    /Authenticate bootstrap identity with GitHub OIDC[\s\S]*create_credentials_file: 'true'[\s\S]*export_environment_variables: 'true'/
+  );
+  assert.doesNotMatch(bootstrap, /firebase\s+login|FIREBASE_TOKEN|--token/);
+});
+
 test("bootstrap path includes key-material rejection guards and excludes deploy actions or broad admin grants", () => {
   const bootstrap = jobBlock("production-bootstrap-deploy-iam");
   assert.match(bootstrap, /external_account/);

--- a/functions/test/productionDeployIamBootstrapWorkflow.test.js
+++ b/functions/test/productionDeployIamBootstrapWorkflow.test.js
@@ -9,6 +9,7 @@ const root = path.resolve(process.cwd(), "..");
 const read = (relative) => fs.readFileSync(path.join(root, relative), "utf8");
 
 const workflow = read(".github/workflows/production-release.yml");
+const bootstrapScript = read("scripts/bootstrap-production-deploy-iam.sh");
 
 function jobBlock(name) {
   const marker = `  ${name}:\n`;
@@ -92,13 +93,18 @@ test("bootstrap job uses WIF with bootstrap SA only and runs canonical scripts",
   assert.match(bootstrap, /bash scripts\/verify-production-deploy-iam\.sh/);
 });
 
-test("bootstrap exports WIF ADC credentials for non-interactive Firebase CLI authentication", () => {
+test("bootstrap exposes validated WIF ADC credentials to Firebase CLI without interactive login or tokens", () => {
   const bootstrap = jobBlock("production-bootstrap-deploy-iam");
+  assert.match(bootstrap, /Authenticate bootstrap identity with GitHub OIDC[\s\S]*create_credentials_file: 'true'/);
+  assert.match(bootstrapScript, /GOOGLE_APPLICATION_CREDENTIALS/);
+  assert.match(bootstrapScript, /gha-creds-\*\.json/);
+  assert.match(bootstrapScript, /external_account/);
+  assert.match(bootstrapScript, /service_account_impersonation_url/);
   assert.match(
-    bootstrap,
-    /Authenticate bootstrap identity with GitHub OIDC[\s\S]*create_credentials_file: 'true'[\s\S]*export_environment_variables: 'true'/
+    bootstrapScript,
+    /clickandsaveai-github-bootstra@click-save-ai-production\.iam\.gserviceaccount\.com/
   );
-  assert.doesNotMatch(bootstrap, /firebase\s+login|FIREBASE_TOKEN|--token/);
+  assert.doesNotMatch(`${bootstrap}\n${bootstrapScript}`, /firebase\s+login|FIREBASE_TOKEN|--token/);
 });
 
 test("bootstrap path includes key-material rejection guards and excludes deploy actions or broad admin grants", () => {

--- a/scripts/bootstrap-production-deploy-iam.sh
+++ b/scripts/bootstrap-production-deploy-iam.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 EXPECTED_PROJECT_ID="click-save-ai-production"
 EXPECTED_PROJECT_NUMBER="991489557172"
+EXPECTED_BOOTSTRAP_SA="clickandsaveai-github-bootstra@click-save-ai-production.iam.gserviceaccount.com"
 EXPECTED_DEPLOY_SA="clickandsaveai-github-deployer@click-save-ai-production.iam.gserviceaccount.com"
 EXPECTED_POOL_ID="github-actions"
 EXPECTED_PROVIDER_ID="clickandsaveai-production"
@@ -65,6 +66,29 @@ role = json.loads(os.environ['CUSTOM_ROLE_JSON_INPUT'])
 assert role.get('name') == expected_name
 assert role.get('deleted', False) is not True
 assert sorted(role.get('includedPermissions', [])) == [expected_permission]
+PY
+}
+configure_firebase_adc() {
+  if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+    [[ -f "$GOOGLE_APPLICATION_CREDENTIALS" ]] || fail "GOOGLE_APPLICATION_CREDENTIALS points to a missing file."
+  else
+    local workspace="${GITHUB_WORKSPACE:-$PWD}"
+    local adc_files=()
+    mapfile -t adc_files < <(find "$workspace" -maxdepth 1 -type f -name 'gha-creds-*.json' -print | sort)
+    [[ "${#adc_files[@]}" -eq 1 ]] || fail "Expected exactly one GitHub Actions WIF credentials file for Firebase ADC; found ${#adc_files[@]}."
+    export GOOGLE_APPLICATION_CREDENTIALS="${adc_files[0]}"
+  fi
+
+  ADC_JSON_INPUT="$(cat "$GOOGLE_APPLICATION_CREDENTIALS")" python3 - "$EXPECTED_WIF_PROVIDER" "$EXPECTED_BOOTSTRAP_SA" <<'PY' || fail "Firebase ADC credential boundary mismatch."
+import json, os, sys
+expected_provider, expected_sa = sys.argv[1:]
+cred = json.loads(os.environ['ADC_JSON_INPUT'])
+assert cred.get('type') == 'external_account'
+assert 'private_key' not in cred and 'private_key_id' not in cred
+assert cred.get('audience') == f'//iam.googleapis.com/{expected_provider}'
+url = cred.get('service_account_impersonation_url', '')
+encoded_sa = expected_sa.replace('@', '%40')
+assert f'/serviceAccounts/{expected_sa}:generateAccessToken' in url or f'/serviceAccounts/{encoded_sa}:generateAccessToken' in url
 PY
 }
 
@@ -170,6 +194,7 @@ mapfile -t FINAL_PROJECT_ROLES < <(gcloud projects get-iam-policy "$PROJECT_ID" 
 mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_ROLES[@]}" "${PRESERVED_PREEXISTING_ROLES[@]}" | sed '/^[[:space:]]*$/d' | sort -u)
 [[ "$(printf '%s\n' "${FINAL_PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]] || fail "Final deploy-SA project role set is not exactly the intended set plus approved pre-existing roles."
 
+configure_firebase_adc
 printf 'Configuring Firebase Functions Artifact Registry cleanup policy in europe-west1 (%s days).\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
 firebase functions:artifacts:setpolicy --project="$PROJECT_ID" --location=europe-west1 --days=7
 printf 'Configuring Firebase Functions Artifact Registry cleanup policy in us-central1 (%s days).\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"


### PR DESCRIPTION
TDD remediation for Production Release Gate #27. The bootstrap WIF auth action created an external-account credentials file but explicitly set `export_environment_variables: false`, so Firebase CLI could not discover ADC and failed with `Failed to authenticate, have you run firebase login?`. Phase 1 intentionally adds the regression guard first; no Production IAM mutation or Firebase deploy is performed by this PR.