### PR TITLE
fix: configure Functions artifact cleanup directly

### DIFF
--- a/functions/test/artifactRegistryCleanupPolicyGuard.test.js
+++ b/functions/test/artifactRegistryCleanupPolicyGuard.test.js
@@ -9,56 +9,83 @@ const root = path.resolve(__dirname, "..", "..");
 const bootstrapPath = path.join(root, "scripts", "bootstrap-production-deploy-iam.sh");
 const bootstrap = fs.readFileSync(bootstrapPath, "utf8");
 
-const EXPECTED_DAYS = "7";
 const LOCATIONS = ["europe-west1", "us-central1"];
 
-test("bootstrap declares EXPECTED_ARTIFACT_CLEANUP_DAYS as exactly 7", () => {
+test("bootstrap declares the exact 7-day Artifact Registry cleanup contract", () => {
   assert.match(bootstrap, /EXPECTED_ARTIFACT_CLEANUP_DAYS="7"/);
+  assert.match(bootstrap, /ARTIFACT_REPOSITORY_ID="gcf-artifacts"/);
+  assert.match(bootstrap, /ARTIFACT_CLEANUP_POLICY_ID="firebase-functions-cleanup"/);
+  assert.match(bootstrap, /"name": "firebase-functions-cleanup"/);
+  assert.match(bootstrap, /"action": \{"type": "Delete"\}/);
+  assert.match(bootstrap, /"tagState": "any"/);
+  assert.match(bootstrap, /"olderThan": "7d"/);
 });
 
-test("bootstrap requires Firebase CLI >= 14 before running setpolicy", () => {
-  assert.match(bootstrap, /firebase.*--version/);
-  assert.match(bootstrap, /FIREBASE_CLI_MAJOR.*-ge 14/);
-  const cliCheck = bootstrap.indexOf("FIREBASE_CLI_MAJOR");
-  const setpolicy = bootstrap.indexOf("functions:artifacts:setpolicy");
-  assert.ok(cliCheck < setpolicy, "Firebase CLI version gate must precede setpolicy invocations");
+test("bootstrap uses direct Artifact Registry cleanup-policy mutation rather than Firebase setpolicy", () => {
+  assert.match(bootstrap, /gcloud artifacts repositories set-cleanup-policies "\$ARTIFACT_REPOSITORY_ID"/);
+  assert.match(bootstrap, /--project="\$PROJECT_ID"/);
+  assert.match(bootstrap, /--location="\$location"/);
+  assert.match(bootstrap, /--policy="\$ARTIFACT_CLEANUP_POLICY_FILE"/);
+  assert.match(bootstrap, /--no-dry-run/);
+  assert.match(bootstrap, /--quiet/);
+  assert.doesNotMatch(bootstrap, /functions:artifacts:setpolicy/);
 });
 
-for (const location of LOCATIONS) {
-  test(`bootstrap configures setpolicy for ${location} with --project scoping and --days=${EXPECTED_DAYS}`, () => {
-    const pattern = new RegExp(
-      `functions:artifacts:setpolicy\\s+--project=["']?\\$PROJECT_ID["']?\\s+--location=${location}\\s+--days=${EXPECTED_DAYS}`
-    );
-    assert.match(bootstrap, pattern);
-  });
+test("bootstrap checks for gcf-artifacts before attempting cleanup configuration", () => {
+  const functionStart = bootstrap.indexOf("configure_artifact_cleanup() {");
+  const describe = bootstrap.indexOf("gcloud artifacts repositories describe", functionStart);
+  const mutation = bootstrap.indexOf("gcloud artifacts repositories set-cleanup-policies", functionStart);
+  const missingRepoGuard = bootstrap.indexOf('if [[ -z "$repo_json" ]]', functionStart);
 
-  test(`bootstrap logs cleanup-policy configuration for ${location} before executing it`, () => {
-    const logMsg = `Configuring Firebase Functions Artifact Registry cleanup policy in ${location}`;
-    const cmdPattern = new RegExp(`functions:artifacts:setpolicy[^\\n]*--location=${location}`);
-    const logIdx = bootstrap.indexOf(logMsg);
-    const cmdMatch = cmdPattern.exec(bootstrap);
-    assert.ok(logIdx !== -1, `log message for ${location} must be present`);
-    assert.ok(cmdMatch !== null, `setpolicy command for ${location} must be present`);
-    assert.ok(logIdx < cmdMatch.index, `log message for ${location} must precede its setpolicy command`);
-  });
-}
+  assert.ok(functionStart !== -1, "cleanup configuration function must be present");
+  assert.ok(describe > functionStart, "repository describe must be present in cleanup function");
+  assert.ok(missingRepoGuard > describe, "missing-repository guard must follow repository lookup");
+  assert.ok(mutation > missingRepoGuard, "cleanup mutation must happen only after repository-presence guard");
+});
 
-test("setpolicy commands do not use --force flag", () => {
-  const allSetpolicyLines = bootstrap
-    .split("\n")
-    .filter((line) => line.includes("functions:artifacts:setpolicy"));
-  assert.ok(allSetpolicyLines.length >= 2, "at least two setpolicy invocations must be present");
-  for (const line of allSetpolicyLines) {
-    assert.doesNotMatch(line, /--force/, `setpolicy command must not use --force: ${line}`);
+test("bootstrap logs cleanup configuration before the direct mutation", () => {
+  const functionStart = bootstrap.indexOf("configure_artifact_cleanup() {");
+  const log = bootstrap.indexOf("Configuring Artifact Registry cleanup policy", functionStart);
+  const mutation = bootstrap.indexOf("gcloud artifacts repositories set-cleanup-policies", functionStart);
+
+  assert.ok(log > functionStart, "cleanup configuration log must be present");
+  assert.ok(mutation > log, "cleanup log must precede Artifact Registry mutation");
+});
+
+test("direct cleanup mutation does not use --force", () => {
+  const mutationStart = bootstrap.indexOf("gcloud artifacts repositories set-cleanup-policies");
+  assert.ok(mutationStart !== -1, "Artifact Registry cleanup mutation must be present");
+  const mutationEnd = bootstrap.indexOf(">/dev/null", mutationStart);
+  const mutationBlock = bootstrap.slice(mutationStart, mutationEnd === -1 ? undefined : mutationEnd);
+  assert.doesNotMatch(mutationBlock, /--force/);
+});
+
+test("bootstrap verifies the exact live cleanup policy after mutation", () => {
+  assert.match(bootstrap, /cleanupPolicies/);
+  assert.match(bootstrap, /assert policy is not None/);
+  assert.match(bootstrap, /assert policy\.get\('id'\) == policy_id/);
+  assert.match(bootstrap, /assert policy\.get\('action'\) == 'DELETE'/);
+  assert.match(bootstrap, /assert condition\.get\('tagState'\) == 'ANY'/);
+  assert.match(bootstrap, /assert condition\.get\('olderThan'\) == '604800s'/);
+  assert.match(bootstrap, /assert repo\.get\('cleanupPolicyDryRun', False\) is False/);
+});
+
+test("bootstrap configures cleanup in both canonical Functions artifact regions", () => {
+  for (const location of LOCATIONS) {
+    assert.match(bootstrap, new RegExp(`configure_artifact_cleanup ${location}`));
   }
 });
 
-test("bootstrap configures cleanup policy after IAM role grants, not before", () => {
+test("bootstrap configures cleanup only after IAM role grants and exact final-role verification", () => {
   const iamGrant = bootstrap.indexOf("add-iam-policy-binding");
-  const firstSetpolicy = bootstrap.indexOf("functions:artifacts:setpolicy");
+  const finalRoleVerification = bootstrap.indexOf("Final deploy-SA project role set is not exactly");
+  const firstCleanupCall = bootstrap.indexOf("configure_artifact_cleanup europe-west1");
+
   assert.ok(iamGrant !== -1, "IAM grant block must be present");
-  assert.ok(firstSetpolicy !== -1, "setpolicy block must be present");
-  assert.ok(iamGrant < firstSetpolicy, "IAM grants must precede cleanup-policy setup");
+  assert.ok(finalRoleVerification !== -1, "final IAM role-set verification must be present");
+  assert.ok(firstCleanupCall !== -1, "cleanup configuration call must be present");
+  assert.ok(iamGrant < finalRoleVerification, "IAM grants must precede final role-set verification");
+  assert.ok(finalRoleVerification < firstCleanupCall, "exact IAM verification must precede cleanup-policy setup");
 });
 
 test("bootstrap reports artifact cleanup retention on success", () => {

--- a/functions/test/productionDeployIamRemediationGuard.test.js
+++ b/functions/test/productionDeployIamRemediationGuard.test.js
@@ -50,14 +50,18 @@ test("production IAM bootstra preserves only the exact actual Firebase Metadata 
   assert.match(verify, /approved pre-existing deploy-SA role/);
 });
 
-test("production IAM bootstrap preconfigures Firebase artifact cleanup in both deployment regions", () => {
-  assert.match(
-    bootstrap,
-    /functions:artifacts:setpolicy[\s\S]*--location=europe-west1[\s\S]*--days=7/
-  );
-  assert.match(
-    bootstrap,
-    /functions:artifacts:setpolicy[\s\S]*--location=us-central1[\s\S]*--days=7/
-  );
+test("production IAM bootstrap configures Firebase Functions artifact cleanup directly through Artifact Registry", () => {
+  assert.match(bootstrap, /ARTIFACT_REPOSITORY_ID="gcf-artifacts"/);
+  assert.match(bootstrap, /ARTIFACT_CLEANUP_POLICY_ID="firebase-functions-cleanup"/);
   assert.match(bootstrap, /EXPECTED_ARTIFACT_CLEANUP_DAYS="7"/);
+  assert.match(bootstrap, /"name": "firebase-functions-cleanup"/);
+  assert.match(bootstrap, /"action": \{"type": "Delete"\}/);
+  assert.match(bootstrap, /"tagState": "any"/);
+  assert.match(bootstrap, /"olderThan": "7d"/);
+  assert.match(bootstrap, /gcloud artifacts repositories set-cleanup-policies/);
+  assert.match(bootstrap, /--policy="\$ARTIFACT_CLEANUP_POLICY_FILE"/);
+  assert.match(bootstrap, /--no-dry-run/);
+  assert.match(bootstrap, /europe-west1/);
+  assert.match(bootstrap, /us-central1/);
+  assert.doesNotMatch(bootstrap, /functions:artifacts:setpolicy/);
 });

--- a/scripts/bootstrap-production-deploy-iam.sh
+++ b/scripts/bootstrap-production-deploy-iam.sh
@@ -21,6 +21,8 @@ CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"
 CUSTOM_DEPLOY_ROLE_TITLE="ClickAndSaveAI Firebase Deploy IAM Policy"
 CUSTOM_DEPLOY_ROLE_PERMISSION="run.services.setIamPolicy"
 EXPECTED_ARTIFACT_CLEANUP_DAYS="7"
+ARTIFACT_REPOSITORY_ID="gcf-artifacts"
+ARTIFACT_CLEANUP_POLICY_ID="firebase-functions-cleanup"
 PROJECT_ID="${PROJECT_ID:-$EXPECTED_PROJECT_ID}"
 CUSTOM_DEPLOY_ROLE_NAME="projects/${EXPECTED_PROJECT_ID}/roles/${CUSTOM_DEPLOY_ROLE_ID}"
 
@@ -89,6 +91,43 @@ assert cred.get('audience') == f'//iam.googleapis.com/{expected_provider}'
 url = cred.get('service_account_impersonation_url', '')
 encoded_sa = expected_sa.replace('@', '%40')
 assert f'/serviceAccounts/{expected_sa}:generateAccessToken' in url or f'/serviceAccounts/{encoded_sa}:generateAccessToken' in url
+PY
+}
+configure_artifact_cleanup() {
+  local location="$1"
+  local repo_json policy_json
+
+  repo_json="$(gcloud artifacts repositories describe "$ARTIFACT_REPOSITORY_ID" \
+    --project="$PROJECT_ID" --location="$location" --format=json 2>/dev/null || true)"
+  if [[ -z "$repo_json" ]]; then
+    printf 'Artifact Registry repository %s is not present in %s; cleanup policy not required there yet.\n' \
+      "$ARTIFACT_REPOSITORY_ID" "$location"
+    return 0
+  fi
+
+  printf 'Configuring Artifact Registry cleanup policy in %s (%s days).\n' \
+    "$location" "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
+  gcloud artifacts repositories set-cleanup-policies "$ARTIFACT_REPOSITORY_ID" \
+    --project="$PROJECT_ID" \
+    --location="$location" \
+    --policy="$ARTIFACT_CLEANUP_POLICY_FILE" \
+    --no-dry-run \
+    --quiet >/dev/null
+
+  policy_json="$(gcloud artifacts repositories describe "$ARTIFACT_REPOSITORY_ID" \
+    --project="$PROJECT_ID" --location="$location" --format=json)"
+  ARTIFACT_POLICY_JSON_INPUT="$policy_json" python3 - "$ARTIFACT_CLEANUP_POLICY_ID" <<'PY' || fail "Artifact cleanup policy verification failed in $location."
+import json, os, sys
+policy_id = sys.argv[1]
+repo = json.loads(os.environ['ARTIFACT_POLICY_JSON_INPUT'])
+policy = (repo.get('cleanupPolicies') or {}).get(policy_id)
+assert policy is not None
+assert policy.get('id') == policy_id
+assert policy.get('action') == 'DELETE'
+condition = policy.get('condition') or {}
+assert condition.get('tagState') == 'ANY'
+assert condition.get('olderThan') == '604800s'
+assert repo.get('cleanupPolicyDryRun', False) is False
 PY
 }
 
@@ -195,12 +234,25 @@ mapfile -t EXPECTED_SORTED < <(printf '%s\n' "${INTENDED_ROLES[@]}" "${PRESERVED
 [[ "$(printf '%s\n' "${FINAL_PROJECT_ROLES[@]}")" == "$(printf '%s\n' "${EXPECTED_SORTED[@]}")" ]] || fail "Final deploy-SA project role set is not exactly the intended set plus approved pre-existing roles."
 
 configure_firebase_adc
-printf 'Configuring Firebase Functions Artifact Registry cleanup policy in europe-west1 (%s days).\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
-firebase functions:artifacts:setpolicy --project="$PROJECT_ID" --location=europe-west1 --days=7
-printf 'Configuring Firebase Functions Artifact Registry cleanup policy in us-central1 (%s days).\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
-firebase functions:artifacts:setpolicy --project="$PROJECT_ID" --location=us-central1 --days=7
+ARTIFACT_CLEANUP_POLICY_FILE="$(mktemp)"
+trap 'rm -f "$ARTIFACT_CLEANUP_POLICY_FILE"' EXIT
+cat > "$ARTIFACT_CLEANUP_POLICY_FILE" <<'JSON'
+[
+  {
+    "name": "firebase-functions-cleanup",
+    "action": {"type": "Delete"},
+    "condition": {
+      "tagState": "any",
+      "olderThan": "7d"
+    }
+  }
+]
+JSON
+
+configure_artifact_cleanup europe-west1
+configure_artifact_cleanup us-central1
 
 printf 'Production deploy IAM foundation configured for %s.\n' "$EXPECTED_DEPLOY_SA"
 printf 'Custom deploy role permission exact: %s.\n' "$CUSTOM_DEPLOY_ROLE_PERMISSION"
-printf 'Artifact cleanup retention configured: %s days in europe-west1 and us-central1.\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
+printf 'Artifact cleanup retention configured: %s days where gcf-artifacts exists in europe-west1 and us-central1.\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
 printf 'Block 3B.3 runtime/build service-account actAs relationships remain intentionally NOT configured.\n'


### PR DESCRIPTION
TDD remediation for Production Release Gate #28 attempt #2. Firebase CLI authentication and Service Usage access now succeed, but `functions:artifacts:setpolicy` still fails with a generic cleanup-policy error after reaching the Artifact Registry mutation. This PR replaces that Firebase CLI wrapper with the canonical Artifact Registry cleanup-policy command for the exact `gcf-artifacts` repositories in europe-west1 and us-central1, preserving the Firebase policy id and 7-day retention. Phase 1 intentionally updates the regression guard first so CI should fail until the implementation is added. No Firebase deploy is performed by this PR.