### PR TITLE
fix: allow existing Production scheduler job updates

### DIFF
--- a/functions/test/productionDeployIamRemediationGuard.test.js
+++ b/functions/test/productionDeployIamRemediationGuard.test.js
@@ -22,17 +22,19 @@ function approvedPreexistingRolesBlock(source) {
   return match[1];
 }
 
-test("production deploy IAM uses a one-permission custom role for Cloud Run IAM policy updates", () => {
+test("production deploy IAM custom role is exact least privilege for Cloud Run IAM and existing Scheduler updates", () => {
   assert.match(bootstrap, /CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"/);
-  assert.match(bootstrap, /run\.services\.setIamPolicy/);
-  assert.match(bootstrap, /--permissions="run\.services\.setIamPolicy"/);
+  assert.match(bootstrap, /CUSTOM_DEPLOY_ROLE_PERMISSIONS="run\.services\.setIamPolicy,cloudscheduler\.jobs\.update"/);
+  assert.match(bootstrap, /--permissions="\$CUSTOM_DEPLOY_ROLE_PERMISSIONS"/);
   assert.match(verify, /CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"/);
-  assert.match(verify, /run\.services\.setIamPolicy/);
+  assert.match(verify, /CUSTOM_DEPLOY_ROLE_PERMISSIONS="run\.services\.setIamPolicy,cloudscheduler\.jobs\.update"/);
+  assert.match(verify, /cloudscheduler\.jobs\.update/);
 
   const intended = intendedRolesBlock(bootstrap);
   assert.doesNotMatch(intended, /roles\/run\.admin/);
   assert.doesNotMatch(intended, /roles\/cloudfunctions\.admin/);
   assert.doesNotMatch(intended, /roles\/artifactregistry\.admin/);
+  assert.doesNotMatch(intended, /roles\/cloudscheduler\.admin/);
 });
 
 test("production IAM bootstra preserves only the exact actual Firebase Metadata Reader role when pre-existing", () => {

--- a/scripts/bootstrap-production-deploy-iam.sh
+++ b/scripts/bootstrap-production-deploy-iam.sh
@@ -19,7 +19,7 @@ EXPECTED_CONDITION="attribute.repository_id=='${GITHUB_REPOSITORY_ID}' && attrib
 EXPECTED_WIF_MEMBER="principalSet://iam.googleapis.com/projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${EXPECTED_POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
 CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"
 CUSTOM_DEPLOY_ROLE_TITLE="ClickAndSaveAI Firebase Deploy IAM Policy"
-CUSTOM_DEPLOY_ROLE_PERMISSION="run.services.setIamPolicy"
+CUSTOM_DEPLOY_ROLE_PERMISSIONS="run.services.setIamPolicy,cloudscheduler.jobs.update"
 EXPECTED_ARTIFACT_CLEANUP_DAYS="7"
 ARTIFACT_REPOSITORY_ID="gcf-artifacts"
 ARTIFACT_CLEANUP_POLICY_ID="firebase-functions-cleanup"
@@ -49,6 +49,7 @@ FORBIDDEN_ROLES=(
   roles/secretmanager.admin
   roles/storage.admin
   roles/artifactregistry.admin
+  roles/cloudscheduler.admin
   roles/iam.serviceAccountUser
 )
 
@@ -61,13 +62,14 @@ contains() {
 }
 verify_custom_deploy_role() {
   local role_json="$1"
-  CUSTOM_ROLE_JSON_INPUT="$role_json" python3 - "$CUSTOM_DEPLOY_ROLE_NAME" "$CUSTOM_DEPLOY_ROLE_PERMISSION" <<'PY'
+  CUSTOM_ROLE_JSON_INPUT="$role_json" python3 - "$CUSTOM_DEPLOY_ROLE_NAME" "$CUSTOM_DEPLOY_ROLE_PERMISSIONS" <<'PY'
 import json, os, sys
-expected_name, expected_permission = sys.argv[1:]
+expected_name, expected_permissions_csv = sys.argv[1:]
+expected_permissions = sorted(expected_permissions_csv.split(','))
 role = json.loads(os.environ['CUSTOM_ROLE_JSON_INPUT'])
 assert role.get('name') == expected_name
 assert role.get('deleted', False) is not True
-assert sorted(role.get('includedPermissions', [])) == [expected_permission]
+assert sorted(role.get('includedPermissions', [])) == expected_permissions
 PY
 }
 configure_firebase_adc() {
@@ -185,12 +187,22 @@ if [[ -z "$CUSTOM_ROLE_JSON" ]]; then
   gcloud iam roles create "$CUSTOM_DEPLOY_ROLE_ID" \
     --project="$PROJECT_ID" \
     --title="$CUSTOM_DEPLOY_ROLE_TITLE" \
-    --description="ClickAndSaveAI Production Firebase deployer: Cloud Run IAM policy update only." \
-    --permissions="run.services.setIamPolicy" \
+    --description="ClickAndSaveAI Production Firebase deployer: Cloud Run IAM policy and existing Cloud Scheduler job updates only." \
+    --permissions="$CUSTOM_DEPLOY_ROLE_PERMISSIONS" \
     --stage=GA \
     --quiet >/dev/null
-  CUSTOM_ROLE_JSON="$(gcloud iam roles describe "$CUSTOM_DEPLOY_ROLE_ID" --project="$PROJECT_ID" --format=json 2>/dev/null || true)"
+else
+  if ! verify_custom_deploy_role "$CUSTOM_ROLE_JSON"; then
+    gcloud iam roles update "$CUSTOM_DEPLOY_ROLE_ID" \
+      --project="$PROJECT_ID" \
+      --title="$CUSTOM_DEPLOY_ROLE_TITLE" \
+      --description="ClickAndSaveAI Production Firebase deployer: Cloud Run IAM policy and existing Cloud Scheduler job updates only." \
+      --permissions="$CUSTOM_DEPLOY_ROLE_PERMISSIONS" \
+      --stage=GA \
+      --quiet >/dev/null
+  fi
 fi
+CUSTOM_ROLE_JSON="$(gcloud iam roles describe "$CUSTOM_DEPLOY_ROLE_ID" --project="$PROJECT_ID" --format=json 2>/dev/null || true)"
 [[ -n "$CUSTOM_ROLE_JSON" ]] || fail "Custom Production deploy role is missing after bootstrap."
 verify_custom_deploy_role "$CUSTOM_ROLE_JSON" || fail "Custom Production deploy role is not exactly least-privilege; refusing IAM mutation."
 
@@ -253,6 +265,6 @@ configure_artifact_cleanup europe-west1
 configure_artifact_cleanup us-central1
 
 printf 'Production deploy IAM foundation configured for %s.\n' "$EXPECTED_DEPLOY_SA"
-printf 'Custom deploy role permission exact: %s.\n' "$CUSTOM_DEPLOY_ROLE_PERMISSION"
+printf 'Custom deploy role permissions exact: %s.\n' "$CUSTOM_DEPLOY_ROLE_PERMISSIONS"
 printf 'Artifact cleanup retention configured: %s days where gcf-artifacts exists in europe-west1 and us-central1.\n' "$EXPECTED_ARTIFACT_CLEANUP_DAYS"
 printf 'Block 3B.3 runtime/build service-account actAs relationships remain intentionally NOT configured.\n'

--- a/scripts/verify-production-deploy-iam.sh
+++ b/scripts/verify-production-deploy-iam.sh
@@ -17,7 +17,7 @@ EXPECTED_MAPPING="google.subject=assertion.sub,attribute.repository_id=assertion
 EXPECTED_CONDITION="attribute.repository_id=='${GITHUB_REPOSITORY_ID}' && attribute.repository_owner_id=='${GITHUB_REPOSITORY_OWNER_ID}' && attribute.environment=='${GITHUB_ENVIRONMENT}' && attribute.ref=='${GITHUB_REF}' && attribute.workflow_ref=='${GITHUB_WORKFLOW_REF}'"
 EXPECTED_WIF_MEMBER="principalSet://iam.googleapis.com/projects/${EXPECTED_PROJECT_NUMBER}/locations/global/workloadIdentityPools/${EXPECTED_POOL_ID}/attribute.repository_id/${GITHUB_REPOSITORY_ID}"
 CUSTOM_DEPLOY_ROLE_ID="clickandsaveaiFirebaseDeployIamPolicy"
-CUSTOM_DEPLOY_ROLE_PERMISSION="run.services.setIamPolicy"
+CUSTOM_DEPLOY_ROLE_PERMISSIONS="run.services.setIamPolicy,cloudscheduler.jobs.update"
 PROJECT_ID="${PROJECT_ID:-$EXPECTED_PROJECT_ID}"
 CUSTOM_DEPLOY_ROLE_NAME="projects/${EXPECTED_PROJECT_ID}/roles/${CUSTOM_DEPLOY_ROLE_ID}"
 
@@ -44,6 +44,7 @@ FORBIDDEN_ROLES=(
   roles/secretmanager.admin
   roles/storage.admin
   roles/artifactregistry.admin
+  roles/cloudscheduler.admin
   roles/iam.serviceAccountUser
 )
 
@@ -121,18 +122,19 @@ mapfile -t WIF_MEMBERS < <(gcloud iam service-accounts get-iam-policy "$EXPECTED
 [[ "${#WIF_MEMBERS[@]}" -eq 1 && "${WIF_MEMBERS[0]}" == "$EXPECTED_WIF_MEMBER" ]] && pass "Production WIF impersonation boundary exact" || fail "Production WIF impersonation boundary mismatch"
 
 CUSTOM_ROLE_JSON="$(gcloud iam roles describe "$CUSTOM_DEPLOY_ROLE_ID" --project="$PROJECT_ID" --format=json 2>/dev/null || true)"
-if [[ -n "$CUSTOM_ROLE_JSON" ]] && CUSTOM_ROLE_JSON_INPUT="$CUSTOM_ROLE_JSON" python3 - "$CUSTOM_DEPLOY_ROLE_NAME" "$CUSTOM_DEPLOY_ROLE_PERMISSION" <<'PY'
+if [[ -n "$CUSTOM_ROLE_JSON" ]] && CUSTOM_ROLE_JSON_INPUT="$CUSTOM_ROLE_JSON" python3 - "$CUSTOM_DEPLOY_ROLE_NAME" "$CUSTOM_DEPLOY_ROLE_PERMISSIONS" <<'PY'
 import json, os, sys
-expected_name, expected_permission = sys.argv[1:]
+expected_name, expected_permissions_csv = sys.argv[1:]
+expected_permissions = sorted(expected_permissions_csv.split(','))
 role = json.loads(os.environ['CUSTOM_ROLE_JSON_INPUT'])
 assert role.get('name') == expected_name
 assert role.get('deleted', False) is not True
-assert sorted(role.get('includedPermissions', [])) == [expected_permission]
+assert sorted(role.get('includedPermissions', [])) == expected_permissions
 PY
 then
-  pass "custom deploy role contains exactly run.services.setIamPolicy"
+  pass "custom deploy role contains exactly run.services.setIamPolicy and cloudscheduler.jobs.update"
 else
-  fail "custom deploy role missing or broader than run.services.setIamPolicy"
+  fail "custom deploy role missing or not exact least privilege for Cloud Run IAM and Scheduler updates"
 fi
 
 mapfile -t PROJECT_ROLES < <(gcloud projects get-iam-policy "$PROJECT_ID" \
@@ -190,5 +192,5 @@ fi
 printf '\nProduction deploy IAM verification PASSED.\n'
 printf 'productionDeployIamConfigured=true\n'
 printf 'productionDeployEndToEndReady=false\n'
-printf 'customDeployRolePermission=%s\n' "$CUSTOM_DEPLOY_ROLE_PERMISSION"
+printf 'customDeployRolePermissions=%s\n' "$CUSTOM_DEPLOY_ROLE_PERMISSIONS"
 printf 'Block 3B.3 runtime/build service-account actAs relationships remain intentionally NOT configured.\n'


### PR DESCRIPTION
Production Firebase deploy reached real Production and updated the non-scheduled Functions successfully, but the three existing scheduled Functions failed when Firebase attempted to update their Cloud Scheduler jobs. The authoritative error was `cloudscheduler.jobs.update` permission denied.

This PR keeps the deploy service account least-privilege by extending the existing project custom role with exactly one additional supported permission: `cloudscheduler.jobs.update`. It does not grant `roles/cloudscheduler.admin`, does not grant create/delete/run scheduler permissions, and does not broaden any long-lived predefined role.

The bootstrap path now upgrades the existing custom role to the exact two-permission set when necessary, and the verifier/test contract enforces that exact set.

No Production deployment is performed by this PR.