### PR TITLE
Google Sign-In diagnostics — surface onboarding auth failure

### DIFF
--- a/app/src/main/java/com/example/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/example/ui/screens/DashboardScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.example.data.repository.AuthState
 import com.example.data.repository.FinancialHomeResult
 import com.example.data.repository.FinancialRefreshReason
 import com.example.data.repository.FinancialSyncState
@@ -74,6 +75,7 @@ fun DashboardScreen(
     val financialHome by viewModel.authoritativeFinancialHome.collectAsState()
     val latestScan = financialSyncState.latestScanOrNull
     val session by viewModel.userSession.collectAsState()
+    val authState by viewModel.authState.collectAsState()
     val isSyncing by viewModel.isSyncingGmail.collectAsState()
     val gmailSyncStep by viewModel.gmailSyncStep.collectAsState()
     val onboardingStep by viewModel.onboardingStep.collectAsState()
@@ -119,14 +121,25 @@ fun DashboardScreen(
         }
 
         when (val state = financialSyncState) {
-            FinancialSyncState.Unauthenticated -> item {
-                V3OnboardingContent(
-                    step = onboardingStep,
-                    authenticated = false,
-                    onNext = viewModel::nextOnboardingStep,
-                    onGoogleSignIn = onGoogleSignIn,
-                    onConnectGmail = { showGmailConsent = true }
-                )
+            FinancialSyncState.Unauthenticated -> {
+                item {
+                    V3OnboardingContent(
+                        step = onboardingStep,
+                        authenticated = false,
+                        onNext = viewModel::nextOnboardingStep,
+                        onGoogleSignIn = onGoogleSignIn,
+                        onConnectGmail = { showGmailConsent = true }
+                    )
+                }
+                if (authState is AuthState.Error) {
+                    item {
+                        V3SoftStatusCard(
+                            "לא הצלחנו להתחבר עם Google",
+                            (authState as AuthState.Error).message,
+                            modifier = Modifier.testTag("v3_google_signin_error")
+                        )
+                    }
+                }
             }
             FinancialSyncState.CheckingConnection -> {
                 item {

--- a/app/src/test/java/com/example/Issue8UxAcceptanceGuardTest.kt
+++ b/app/src/test/java/com/example/Issue8UxAcceptanceGuardTest.kt
@@ -91,7 +91,7 @@ class Issue8UxAcceptanceGuardTest {
     fun gmailFirstConnectionUiIsNotRepeatedForConnectedOrUnknownState() {
         val dashboard = source("src/main/java/com/example/ui/screens/DashboardScreen.kt")
         val profile = source("src/main/java/com/example/ui/screens/ProfileScreen.kt")
-        assertTrue(dashboard.contains("FinancialSyncState.Unauthenticated -> item"))
+        assertTrue(dashboard.contains("FinancialSyncState.Unauthenticated ->"))
         assertTrue(dashboard.contains("FinancialSyncState.Disconnected -> item"))
         assertTrue(Regex("V3OnboardingContent\\(").findAll(dashboard).count() == 2)
         assertFalse(dashboard.contains("InitialGmailOnboardingCard("))

--- a/app/src/test/java/com/example/V3OnboardingContractTest.kt
+++ b/app/src/test/java/com/example/V3OnboardingContractTest.kt
@@ -36,6 +36,14 @@ class V3OnboardingContractTest {
     }
 
     @Test
+    fun googleSignInFailureIsVisibleOnOnboardingInsteadOfFailingSilently() {
+        val dashboard = File("src/main/java/com/example/ui/screens/DashboardScreen.kt").readText()
+        assertTrue(dashboard.contains("viewModel.authState.collectAsState()"))
+        assertTrue(dashboard.contains("AuthState.Error"))
+        assertTrue(dashboard.contains("v3_google_signin_error"))
+    }
+
+    @Test
     fun firstSyncCopyStaysConservativeAndStateDriven() {
         val dashboard = File("src/main/java/com/example/ui/screens/DashboardScreen.kt").readText()
         assertTrue(dashboard.contains("FinancialSyncState.CheckingConnection"))


### PR DESCRIPTION
Diagnostic-only remediation for the Internal Testing Google Sign-In failure. TDD starts with a RED contract requiring AuthState.Error to be visible on the onboarding surface instead of failing silently. No Firebase/GCP mutation, no OAuth scope change, no Production deploy, no Play action.