### PR TITLE
Play release — bump versionCode to 3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     applicationId = "com.aistudio.clickandsaveai.app"
     minSdk = 24
     targetSdk = 36
-    versionCode = 2
+    versionCode = 3
     versionName = "1.0"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/app/src/test/java/com/example/V3ProductionBoundaryGuardTest.kt
+++ b/app/src/test/java/com/example/V3ProductionBoundaryGuardTest.kt
@@ -21,7 +21,7 @@ class V3ProductionBoundaryGuardTest {
     fun releaseIdentityRemainsUnchanged() {
         val gradle = File("build.gradle.kts").readText()
         assertTrue(gradle.contains("applicationId = \"com.aistudio.clickandsaveai.app\""))
-        assertTrue(gradle.contains("versionCode = 2"))
+        assertTrue(gradle.contains("versionCode = 3"))
         assertTrue(gradle.contains("versionName = \"1.0\""))
     }
 


### PR DESCRIPTION
Minimal Play Internal Testing release identity update after versionCode 2 was already consumed. Changes only the Android versionCode from 2 to 3 and updates the production boundary guard expectation. No Firebase deploy, no OAuth config change, no Google Play publish action.