### PR TITLE
Google Sign-In diagnosis — surface exact Credential Manager failure

### DIFF
--- a/.github/workflows/production-enablement-ci.yml
+++ b/.github/workflows/production-enablement-ci.yml
@@ -104,11 +104,21 @@ jobs:
         shell: bash
         run: find . -path "*/schemas/*.json" -empty -delete 2>/dev/null || true
 
-      - name: Android regression, lint, debug and unsigned release audit builds
+      - name: Android regression, lint and debug audit build
         shell: bash
         run: |
           set -euo pipefail
-          gradle --no-daemon testDebugUnitTest lintDebug assembleDebug assembleRelease bundleRelease --stacktrace
+          gradle --no-daemon testDebugUnitTest lintDebug assembleDebug --stacktrace
+
+      - name: Clean up Room schema files before release audit
+        shell: bash
+        run: find . -path "*/schemas/*.json" -empty -delete 2>/dev/null || true
+
+      - name: Android unsigned release audit builds
+        shell: bash
+        run: |
+          set -euo pipefail
+          gradle --no-daemon assembleRelease bundleRelease --stacktrace
 
       - name: Confirm normal CI release audit is not a signed production candidate
         shell: bash

--- a/.github/workflows/production-enablement-ci.yml
+++ b/.github/workflows/production-enablement-ci.yml
@@ -100,6 +100,10 @@ jobs:
           }
           echo 'Production signing configuration fails closed when secure signing material is absent.'
 
+      - name: Clean up stale empty Room schema files
+        shell: bash
+        run: find . -path "*/schemas/*.json" -empty -delete 2>/dev/null || true
+
       - name: Android regression, lint, debug and unsigned release audit builds
         shell: bash
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     applicationId = "com.aistudio.clickandsaveai.app"
     minSdk = 24
     targetSdk = 36
-    versionCode = 3
+    versionCode = 4
     versionName = "1.0"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/app/src/main/java/com/example/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/data/repository/AuthRepository.kt
@@ -127,7 +127,17 @@ class AuthRepository(private val applicationContext: Context) {
             Result.success(session)
         } catch (e: GetCredentialException) {
             Log.e("AuthRepository", "Google Sign-In failed", e)
-            val message = "Google Sign-In was cancelled or failed."
+            val exceptionType = e::class.java.simpleName.ifBlank { "GetCredentialException" }
+            val exceptionDetail = e.localizedMessage?.trim().takeUnless { it.isNullOrBlank() }
+            val message = buildString {
+                append("Google Sign-In failed [")
+                append(exceptionType)
+                append("]")
+                if (exceptionDetail != null) {
+                    append(": ")
+                    append(exceptionDetail.take(240))
+                }
+            }
             _authState.value = AuthState.Error(message)
             Result.failure(e)
         } catch (e: CancellationException) {

--- a/app/src/test/java/com/example/V3ProductionBoundaryGuardTest.kt
+++ b/app/src/test/java/com/example/V3ProductionBoundaryGuardTest.kt
@@ -21,8 +21,16 @@ class V3ProductionBoundaryGuardTest {
     fun releaseIdentityRemainsUnchanged() {
         val gradle = File("build.gradle.kts").readText()
         assertTrue(gradle.contains("applicationId = \"com.aistudio.clickandsaveai.app\""))
-        assertTrue(gradle.contains("versionCode = 3"))
+        assertTrue(gradle.contains("versionCode = 4"))
         assertTrue(gradle.contains("versionName = \"1.0\""))
+    }
+
+    @Test
+    fun googleSignInFailureSurfacesCredentialExceptionTypeForInternalDiagnosis() {
+        val auth = File("src/main/java/com/example/data/repository/AuthRepository.kt").readText()
+        assertTrue(auth.contains("e::class.java.simpleName"))
+        assertTrue(auth.contains("Google Sign-In failed ["))
+        assertFalse(auth.contains("Google Sign-In was cancelled or failed."))
     }
 
     @Test


### PR DESCRIPTION
Internal-testing diagnostic remediation after versionCode 3 confirmed that Google Sign-In reaches Credential Manager but fails before Firebase authentication. This PR surfaces the concrete GetCredentialException type/message in the existing onboarding error card, bumps Play versionCode to 4, and adds guards that prevent regression to the generic hidden failure. No Firebase deploy and no Google Play publish action.