### PR TITLE
Reconcile Production Play signing identities with OAuth guard

### DIFF
--- a/functions/test/productionEnablementContract.test.js
+++ b/functions/test/productionEnablementContract.test.js
@@ -123,3 +123,10 @@ test("production readiness guard rejects environment leakage", () => {
   assert.match(guard, /Production Firebase project must be explicit and distinct from staging/);
   assert.match(guard, /Staging OAuth client leaked into production google-services configuration/);
 });
+
+test("production readiness guard recognizes current Play signing OAuth identity", () => {
+  const guard = read("scripts/production-readiness-guard.mjs");
+  assert.match(guard, /23F46B7A8332A17B7541B483A3685AD5BA17D37F/);
+  assert.match(guard, /44D5E1A00B2893370BA12CAD7025DF44531B55527287EB6BD5B3123336801FD3/);
+  assert.match(guard, /Production Android OAuth client for a known Play signing identity is missing/);
+});

--- a/functions/test/productionRealUserIdentityGuard.test.js
+++ b/functions/test/productionRealUserIdentityGuard.test.js
@@ -13,7 +13,7 @@ const APP_ID = "com.aistudio.clickandsaveai.app";
 const PROJECT_ID = "clickandsaveai-production";
 const WEB_CLIENT_ID = "123456789012-production-web.apps.googleusercontent.com";
 const ANDROID_CLIENT_ID = "123456789012-production-android.apps.googleusercontent.com";
-const PLAY_SHA1 = "11223344556677889900AABBCCDDEEFF00112233";
+const PLAY_SHA1 = "1D127D3BB3DB8E7319DDA55F437485F455B44D8D";
 
 function writeGoogleServices({ includeAndroidOAuth = true, includeWebOAuth = true, certificateHash = PLAY_SHA1 } = {}) {
   const dir = mkdtempSync(path.join(os.tmpdir(), "clickandsave-prod-identity-"));

--- a/scripts/production-readiness-guard.mjs
+++ b/scripts/production-readiness-guard.mjs
@@ -5,6 +5,22 @@ const APP_ID = "com.aistudio.clickandsaveai.app";
 const STAGING_PROJECT = "clickandsaveai-staging";
 const STAGING_WEB_CLIENT = "716864421960-hnt5709tqk9qp79si8ggplf5jif1ulfu.apps.googleusercontent.com";
 
+// Public certificate fingerprints observed from the protected production surfaces.
+// Keep legacy identities during signing transitions; Google Play can legitimately
+// serve different app-signing identities across Android generations/key upgrades.
+const KNOWN_PLAY_SIGNING_IDENTITIES = [
+  {
+    name: "legacy-production",
+    sha1: "1D127D3BB3DB8E7319DDA55F437485F455B44D8D",
+    sha256: "42BF0D29B4C1C15D055F0FA89B078CF55D5C0FFBABB95DBCE9581EC03BF939D3",
+  },
+  {
+    name: "play-classic-current",
+    sha1: "23F46B7A8332A17B7541B483A3685AD5BA17D37F",
+    sha256: "44D5E1A00B2893370BA12CAD7025DF44531B55527287EB6BD5B3123336801FD3",
+  },
+];
+
 function requireCondition(condition, message) {
   if (!condition) throw new Error(message);
 }
@@ -39,6 +55,12 @@ function repositoryChecks() {
   requireCondition(rules.includes("allow read, write: if false;"), "Firestore deny-by-default rule was weakened");
   requireCondition(!workflow.includes(STAGING_WEB_CLIENT), "Staging OAuth client leaked into production workflow");
   requireCondition(!workflow.includes(`--project ${STAGING_PROJECT}`), "Production workflow targets staging");
+
+  for (const identity of KNOWN_PLAY_SIGNING_IDENTITIES) {
+    requireCondition(/^[0-9A-F]{40}$/.test(identity.sha1), `Invalid known Play SHA-1 for ${identity.name}`);
+    requireCondition(/^[0-9A-F]{64}$/.test(identity.sha256), `Invalid known Play SHA-256 for ${identity.name}`);
+  }
+
   console.log("Repository production-isolation guard PASS");
 }
 
@@ -46,13 +68,13 @@ function materializedChecks() {
   repositoryChecks();
   const projectId = String(process.env.PRODUCTION_FIREBASE_PROJECT_ID || "").trim();
   const webClientId = String(process.env.PRODUCTION_GOOGLE_WEB_CLIENT_ID || "").trim();
-  const playSigningSha1 = normalizeFingerprint(process.env.PRODUCTION_APP_SIGNING_CERT_SHA1);
+  const configuredPlaySigningSha1 = normalizeFingerprint(process.env.PRODUCTION_APP_SIGNING_CERT_SHA1);
   const configPath = String(process.env.PRODUCTION_GOOGLE_SERVICES_JSON_PATH || "").trim();
 
   requireCondition(projectId && projectId !== STAGING_PROJECT, "Production Firebase project must be explicit and distinct from staging");
   requireCondition(webClientId && webClientId !== STAGING_WEB_CLIENT, "Production Web OAuth client must be explicit and distinct from staging");
   requireCondition(/^[0-9]+-[A-Za-z0-9_-]+\.apps\.googleusercontent\.com$/.test(webClientId), "Production Web OAuth client ID format is invalid");
-  requireCondition(/^[0-9A-F]{40}$/.test(playSigningSha1), "PRODUCTION_APP_SIGNING_CERT_SHA1 must be a SHA-1 certificate fingerprint");
+  requireCondition(/^[0-9A-F]{40}$/.test(configuredPlaySigningSha1), "PRODUCTION_APP_SIGNING_CERT_SHA1 must be a SHA-1 certificate fingerprint");
   requireCondition(configPath && fs.existsSync(configPath), "Production google-services configuration is missing");
 
   const configText = read(configPath);
@@ -63,14 +85,23 @@ function materializedChecks() {
   requireCondition(Boolean(firebaseAndroidClient), `Production google-services configuration does not contain ${APP_ID}`);
 
   const oauthClients = clients.flatMap((client) => Array.isArray(client?.oauth_client) ? client.oauth_client : []);
-  const androidOauthClient = oauthClients.find((client) =>
+  const configuredAndroidOauthClient = oauthClients.find((client) =>
     Number(client?.client_type) === 1 &&
     client?.android_info?.package_name === APP_ID &&
-    normalizeFingerprint(client?.android_info?.certificate_hash) === playSigningSha1
+    normalizeFingerprint(client?.android_info?.certificate_hash) === configuredPlaySigningSha1
+  );
+  requireCondition(Boolean(configuredAndroidOauthClient), `Production Android OAuth client for configured ${APP_ID} signing SHA-1 is missing`);
+
+  const knownPlayOauthClients = KNOWN_PLAY_SIGNING_IDENTITIES.filter((identity) =>
+    oauthClients.some((client) =>
+      Number(client?.client_type) === 1 &&
+      client?.android_info?.package_name === APP_ID &&
+      normalizeFingerprint(client?.android_info?.certificate_hash) === identity.sha1
+    )
   );
   requireCondition(
-    Boolean(androidOauthClient),
-    `Production Android OAuth client for ${APP_ID} and the Play app-signing SHA-1 is missing`
+    knownPlayOauthClients.length > 0,
+    "Production Android OAuth client for a known Play signing identity is missing"
   );
 
   const webOauthClient = oauthClients.find((client) =>
@@ -80,7 +111,7 @@ function materializedChecks() {
 
   requireCondition(!configText.includes(STAGING_PROJECT), "Staging project identifier leaked into production google-services configuration");
   requireCondition(!configText.includes(STAGING_WEB_CLIENT), "Staging OAuth client leaked into production google-services configuration");
-  console.log("Materialized production configuration guard PASS");
+  console.log(`Materialized production configuration guard PASS; recognized Play OAuth identities: ${knownPlayOauthClients.map((identity) => identity.name).join(", ")}`);
 }
 
 if (mode === "repository") repositoryChecks();


### PR DESCRIPTION
Production auth incident follow-up after Internal Testing versionCode 5 surfaced `[16] Account reauth failed`. Verified locally that the signed v5 AAB uses SHA-1 `23:F4:6B:7A:83:32:A1:7B:75:41:B4:83:A3:68:5A:D5:BA:17:D3:7F` and SHA-256 `44:D5:E1:A0:0B:28:93:37:0B:A1:2C:AD:70:25:DF:44:53:1B:55:52:72:87:EB:6B:D5:B3:12:33:36:80:1F:D3`, matching the current Google Play classic signing identity that was added to Firebase Production. This PR makes the Production readiness guard aware of both legacy and current Play signing identities and adds a contract test so future production google-services materialization must contain an Android OAuth client matching a known Play signing identity. No Firebase deploy, no Play publish, no secret material.